### PR TITLE
The breadcrumb and the page title now displays until the descriptiveName 

### DIFF
--- a/portal-web/docroot/html/taglib/ui/breadcrumb/display_style_horizontal.jsp
+++ b/portal-web/docroot/html/taglib/ui/breadcrumb/display_style_horizontal.jsp
@@ -28,7 +28,9 @@ if (showParentGroups) {
 }
 
 if (showLayout) {
-	_buildLayoutBreadcrumb(selLayout, selLayoutParam, true, portletURL, themeDisplay, sb);
+	if(!selLayout.getLayoutSet().getGroup().isLayoutPrototype()){
+		_buildLayoutBreadcrumb(selLayout, selLayoutParam, true, portletURL, themeDisplay, sb);
+	}
 }
 
 if (showPortletBreadcrumb) {

--- a/portal-web/docroot/html/themes/_unstyled/templates/init.vm
+++ b/portal-web/docroot/html/themes/_unstyled/templates/init.vm
@@ -247,6 +247,10 @@
 	#set ($the_title = $languageUtil.get($locale, $tilesTitle))
 #end
 
+#if($layout.getGroup().isLayoutPrototype())
+	#set ($the_title = $layout.getGroup().getDescriptiveName())
+#end
+
 #set ($the_title = $htmlUtil.escape($the_title))
 
 #if ($layouts)


### PR DESCRIPTION
The breadcrumb and the page title now displays until the descriptiveName of the group. Two files were modified to accomplish this requirement, including if statements to decide if that group was a LayoutPrototype
