### PR TITLE
Lps 18661 extra column asset publisher

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/html/portlet/asset_publisher/init.jsp" %>
 
 <%
-boolean showIconLabel = ((Boolean)request.getAttribute("view.jsp-showIconLabel")).booleanValue();
+boolean showIconLabel = ((Boolean)request.getAttribute("view.jsp-showIconLabel") ).booleanValue();
 
 AssetRenderer assetRenderer = (AssetRenderer)request.getAttribute("view.jsp-assetRenderer");
 

--- a/portal-web/docroot/html/portlet/asset_publisher/display/table.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/display/table.jsp
@@ -27,6 +27,8 @@ AssetRenderer assetRenderer = (AssetRenderer)request.getAttribute("view.jsp-asse
 
 String title = (String)request.getAttribute("view.jsp-title");
 
+request.setAttribute("view.jsp-showIconLabel", false);
+
 if (Validator.isNull(title)) {
 	title = assetRenderer.getTitle(locale);
 }
@@ -54,6 +56,9 @@ viewFullContentURLString = HttpUtil.setParameter(viewFullContentURLString, "redi
 String viewURL = viewInContext ? assetRenderer.getURLViewInContext(liferayPortletRequest, liferayPortletResponse, viewFullContentURLString) : viewFullContentURL.toString();
 
 viewURL = _checkViewURL(viewURL, currentURL, themeDisplay);
+
+boolean hasStagingGroup = themeDisplay.getScopeGroup().isLayout() ? layout.getGroup().hasStagingGroup() : themeDisplay.getScopeGroup().hasStagingGroup();
+
 %>
 
 <c:if test="<%= assetEntryIndex == 0 %>">
@@ -72,6 +77,9 @@ viewURL = _checkViewURL(viewURL, currentURL, themeDisplay);
 		<%
 		}
 		%>
+		<c:if test="<%= assetRenderer.hasEditPermission(permissionChecker) && !(hasStagingGroup) %>">
+		<th></th>
+		</c:if>
 	</tr>
 </c:if>
 
@@ -172,6 +180,11 @@ viewURL = _checkViewURL(viewURL, currentURL, themeDisplay);
 			}
 		}
 		%>
+		<c:if test="<%= assetRenderer.hasEditPermission(permissionChecker) && !(hasStagingGroup) %>">
+		<td>
+			<liferay-util:include page="/html/portlet/asset_publisher/asset_actions.jsp" />
+		</td>
+		</c:if>
 	</tr>
 </c:if>
 


### PR DESCRIPTION
Hello, the issue has been solved in two commits:

1) the extra column in table display has ben removed, because it was always empty
2) the column has benn re-added with the functionality of editing the asset, whenever the user has permissions.

Manuel.
