### PR TITLE
LPS-18306 Removing link at root breadcrum entry when it is organization

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/init_attributes.jspf
+++ b/portal-web/docroot/html/portlet/layouts_admin/init_attributes.jspf
@@ -197,10 +197,7 @@ request.setAttribute(WebKeys.LAYOUT_LISTER_LIST, layoutList);
 
 <%
 if ((renderResponse != null) && !portletName.equals(PortletKeys.GROUP_PAGES) && !portletName.equals(PortletKeys.MY_PAGES)) {
-	if (organization != null) {
-		UsersAdminUtil.addPortletBreadcrumbEntries(organization, request, renderResponse);
-	}
-	else if (group.isLayoutPrototype()) {
+	if (group.isLayoutPrototype()) {
 		PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(pageContext, "page-template"), null);
 
 		PortalUtil.addPortletBreadcrumbEntry(request, group.getDescriptiveName(), redirectURL.toString());


### PR DESCRIPTION
The breadcrum was showing a link at root breadcrum entry when it represents an organization. The code has been changed in order not to do that.
