### PR TITLE
LPS-19829 FileName added to images at Image Gallery Display

### DIFF
--- a/portal-web/docroot/html/portlet/image_gallery_display/view_images.jspf
+++ b/portal-web/docroot/html/portlet/image_gallery_display/view_images.jspf
@@ -71,7 +71,7 @@
 				Image largeImage = ImageLocalServiceUtil.getImage(fileVersion.getLargeImageId());
 
 				if (largeImage != null) {
-					href = themeDisplay.getPathImage() + "/image_gallery?img_id=" + largeImage.getImageId() + "&t=" + WebServerServletTokenUtil.getToken(largeImage.getImageId());
+					href = themeDisplay.getPathImage() + "/image_gallery?img_id=" + largeImage.getImageId() + "&t=" + WebServerServletTokenUtil.getToken(largeImage.getImageId()) + "&fileName=" + HttpUtil.encodeURL(fileEntry.getTitle());
 					src = themeDisplay.getPathImage() + "/image_gallery?img_id=" + smallImageId + "&fileEntryId=" + fileEntry.getFileEntryId() + "&dlSmallImage=1&t=" + WebServerServletTokenUtil.getToken(smallImageId);
 					style = "height: " + smallImageHeight + "; margin: " + topMargin + "px " + sideMargin + "px 0px " + sideMargin + "px; width: " + smallImageWidth + ";";
 				}


### PR DESCRIPTION
Please checked it: it solves problem downloading images, because they have no extension.

Thanks!
