### PR TITLE
LPS-21149  Usability problem when searching users and organizations.

### DIFF
--- a/portal-web/docroot/html/portlet/users_admin/view_tree.jspf
+++ b/portal-web/docroot/html/portlet/users_admin/view_tree.jspf
@@ -380,7 +380,7 @@ int organizationsCount = OrganizationLocalServiceUtil.searchCount(company.getCom
 
 					<%= usersTitle %>
 
-					<c:if test="<%= organization == null && showOrganizations %>">
+					<c:if test="<%= organization == null %>">
 						<span class="view-all-link">(<a href="<%= viewUsersURL %>" id="<portlet:namespace />allUsersLink"><liferay-ui:message key="view-all-users" /></a>)</span>
 					</c:if>
 				</liferay-util:buffer>


### PR DESCRIPTION
Two fixes:

1- Correct message for user and organization container after searching

2- Show view all user link when it doesn't exist organizations. It's necessary for advanced search and reactivate users.
