### PR TITLE
LPS-21450 Cannot define permissions when using DB2 9.7, Oracle, and Sybase

### DIFF
--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -291,7 +291,7 @@
 				(ResourcePermission.scope = ?) AND
 				(ResourceAction.actionId = ?) AND
 				(ResourcePermission.roleId = ?) AND
-				((ResourcePermission.actionIds & ResourceAction.bitwiseValue) != 0)
+				( ((ResourcePermission.actionIds & ResourceAction.bitwiseValue)) != 0)
 		]]>
 	</sql>
 	<sql id="com.liferay.portal.service.persistence.GroupFinder.joinByRoleResourceTypePermissions">
@@ -305,7 +305,7 @@
 				ResourceAction ON
 					(ResourceAction.name = ResourceTypePermission.name) AND
 					(ResourceAction.actionId = ?) AND
-					((ResourceTypePermission.actionIds & ResourceAction.bitwiseValue) != 0)
+					( ((ResourceTypePermission.actionIds & ResourceAction.bitwiseValue)) != 0)
 			WHERE
 				(Group_.liveGroupId = 0)
 		]]>
@@ -1048,7 +1048,7 @@
 				(ResourcePermission.scope = ?) AND
 				(ResourcePermission.primKey = ?) AND
 				(ResourcePermission.roleId = ?) AND
-				((ResourcePermission.actionIds & ?) = ?)
+				( ((ResourcePermission.actionIds & ?)) = ?)
 		]]>
 	</sql>
 	<sql id="com.liferay.portal.service.persistence.ResourcePermissionFinder.findByResource">


### PR DESCRIPTION
Modify the query in order to allow the SQL transformer get its job done when replacing bitwise operators
