### PR TITLE
LPS-19709 Validation bug

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1933,11 +1933,6 @@ public class JournalArticleLocalServiceImpl
 		catch (IOException ioe) {
 		}
 
-		validate(
-			user.getCompanyId(), groupId, 0, titleMap, content, type,
-			structureId, templateId, smallImage, smallImageURL, smallImageFile,
-			smallImageBytes);
-
 		JournalArticle oldArticle = null;
 		double oldVersion = 0;
 
@@ -1973,6 +1968,11 @@ public class JournalArticleLocalServiceImpl
 				incrementVersion = true;
 			}
 		}
+
+		validate(
+			user.getCompanyId(), groupId, oldArticle.getClassNameId(), titleMap,
+			content, type, structureId, templateId, smallImage, smallImageURL,
+			smallImageFile, smallImageBytes);
 
 		JournalArticle article = null;
 


### PR DESCRIPTION
After a conflict between LPS-19709 and LPS-23858, here's the code that solves both problems... and solves  the underlying problem: the validation on WCM articles update was being done without having the original classNameId into account. 

The classNameId allow us to differentiate between normal articles and the structures default values, so if we don't respect this in the update method in JALSI, we won't be able to check different conditions on article's updates. 
