### PR TITLE
Lps 25044 - validation script doesn't work if contain literals

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -37,6 +37,8 @@ import net.htmlparser.jericho.TextExtractor;
  */
 public class HtmlImpl implements Html {
 
+	public static final char DOUBLE_QUOTE = 0x22;
+
 	public static final int ESCAPE_MODE_ATTRIBUTE = 1;
 
 	public static final int ESCAPE_MODE_CSS = 2;
@@ -46,6 +48,8 @@ public class HtmlImpl implements Html {
 	public static final int ESCAPE_MODE_TEXT = 4;
 
 	public static final int ESCAPE_MODE_URL = 5;
+
+	public static final char SINGLE_QUOTE = 0x27;
 
 	public String escape(String text) {
 		if (text == null) {
@@ -234,8 +238,6 @@ public class HtmlImpl implements Html {
 	public String escapeJSSource(String js) {
 		boolean parsingValue = false;
 
-		char DOUBLE_QUOTE = 0x22;
-		char SINGLE_QUOTE = 0x27;
 		char openedQuote = 0x0;
 
 		StringBundler scriptBundler = new StringBundler(10);

--- a/portal-service/src/com/liferay/portal/kernel/util/Html.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Html.java
@@ -33,7 +33,7 @@ public interface Html {
 	public String escapeHREF(String href);
 
 	public String escapeJS(String js);
-	
+
 	public String escapeJSSource(String js);
 
 	public String escapeURL(String url);

--- a/portal-service/src/com/liferay/portal/kernel/util/HtmlUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/HtmlUtil.java
@@ -45,7 +45,7 @@ public class HtmlUtil {
 	public static String escapeJS(String js) {
 		return getHtml().escapeJS(js);
 	}
-	
+
 	public static String escapeJSSource(String js) {
 		return getHtml().escapeJSSource(js);
 	}


### PR DESCRIPTION
Hi Julio,
please review my work. I've added javascript source escaper which detects literal in js source and escapes them. Please dont forget to pull pr in liferay-plugins which use this escaper to fix issue.

Julio thank you very much!
