### PR TITLE
LPS-27214: Search container must exist on the page if user belongs to an...

### DIFF
--- a/portal-web/docroot/html/portlet/users_admin/user/roles.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/user/roles.jsp
@@ -143,7 +143,7 @@ userGroupRoles.addAll(organizationRoles);
 	<liferay-ui:message key="this-user-does-not-belong-to-an-organization-to-which-an-organization-role-can-be-assigned" />
 </c:if>
 
-<c:if test="<%= !organizationRoles.isEmpty() %>">
+<c:if test="<%= !organizations.isEmpty() %>">
 	<liferay-ui:search-container
 		headerNames="title,organization,null"
 		id="organizationRolesSearchContainer"


### PR DESCRIPTION
... organization, regardless of having organization roles
