### PR TITLE
[TECH_SUPPORT] LPS-28132

### DIFF
--- a/portal-web/docroot/html/portlet/polls/view_question.jsp
+++ b/portal-web/docroot/html/portlet/polls/view_question.jsp
@@ -52,13 +52,13 @@ if (viewResults && !PollsQuestionPermission.contains(permissionChecker, question
 	<aui:fieldset>
  		<liferay-ui:header
 			backURL="<%= redirect %>"
-			escapeXml="<%= false %>"
+			escapeXml="<%= true %>"
 			localizeTitle="<%= false %>"
 			title="<%= question.getTitle(locale) %>"
 		/>
 
 		<span style="font-size: x-small;">
-			<%= StringUtil.replace(question.getDescription(locale), StringPool.NEW_LINE, "<br />") %>
+			<%= StringUtil.replace(HtmlUtil.escape(question.getDescription(locale)), StringPool.NEW_LINE, "<br />") %>
 		</span>
 
 		<br /><br />

--- a/portal-web/docroot/html/portlet/polls/view_question_results.jspf
+++ b/portal-web/docroot/html/portlet/polls/view_question_results.jspf
@@ -183,6 +183,8 @@ for (int i = 0; i < choices.size(); i++) {
 
 			PollsChoice choice = vote.getChoice();
 
+			choice = choice.toEscapedModel();
+
 			row.addText(choice.getName() + ". " + choice.getDescription(locale));
 
 			// Vote date


### PR DESCRIPTION
Hi Julio,

for this pr you can find more details on the LPS ticket comments and on the LPP as well. 

Briefly we had an initial issue some years ago with XSS and we provided a fix for that but later it was changed because the usage of escapedModel and the HtmlUtil.escape together caused bad results because we double escaped the strings. So these escape methods removed and we became unprotected. Now we tried to find a solution that wont re-produce any of these issues. Because of that on the view_questions.jps it is not allowed to use the escapemodel since the breadcrumb tag will escape it again but on the other jsp we can use escapedModel instead of many HtmlUtil calls just like on the other jsp's of the portlet. My only concers with that is inconsistency but I didn't want to change the taglibrary to remove escape, so please let me know your opinion! 

Thanks,
Daniel
