### PR TITLE
[TECH SUPPORT] LPS-28786

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -409,7 +409,8 @@ public class JournalArticleLocalServiceImpl
 
 		List<JournalArticle> articles =
 			journalArticleFinder.findByExpirationDate(
-				0, WorkflowConstants.STATUS_APPROVED, now);
+				0, WorkflowConstants.STATUS_APPROVED,
+				new Date(now.getTime() + _JOURNAL_ARTICLE_CHECK_INTERVAL));
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Expiring " + articles.size() + " articles");


### PR DESCRIPTION
Hey Julio, Would you mind reviewing this change, I saw your comments on the related DDD thread. This solution is based on what Ray have suggested, but I must say I'm not convinced about it. Basically due to the periodic checking there will be always a gap when the web content is being expired and this fix is just placing that gap to the other side, and that's it. Although I do understand that there is a limitation on this area. So if we want a web content to be expired at 12:00 instead of expiring at 12:15 it will now expire at 11:45. The only advantage of this change is that now the web content display will always show something content, because previously it didn't showed anything during that gap. Thanks, Mate
