### PR TITLE
LPS-29198 NullPointer open webcontent control panel

### DIFF
--- a/portal-web/docroot/html/portlet/journal/init.jsp
+++ b/portal-web/docroot/html/portlet/journal/init.jsp
@@ -122,9 +122,9 @@ page import="com.liferay.util.RSSUtil" %>
 <%
 PortalPreferences portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(liferayPortletRequest);
 
-PortletPreferences preferences = renderRequest.getPreferences();
+PortletPreferences preferences = liferayPortletRequest.getPreferences();
 
-String[] displayViews = StringUtil.split(PrefsParamUtil.getString(preferences, renderRequest, "displayViews", StringUtil.merge(PropsValues.JOURNAL_DISPLAY_VIEWS)));
+String[] displayViews = StringUtil.split(PrefsParamUtil.getString(preferences, liferayPortletRequest, "displayViews", StringUtil.merge(PropsValues.JOURNAL_DISPLAY_VIEWS)));
 
 Format dateFormatDate = FastDateFormatFactoryUtil.getDate(locale, timeZone);
 Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);


### PR DESCRIPTION
Bug caused by latest source formatting. It's been changed back and now it works as in document_library/init.jsp using liferayPortletRequest to get portlet preferences.
