### PR TITLE
LPS-29199 Webcontent not found when editting

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/action/EditArticleAction.java
+++ b/portal-impl/src/com/liferay/portlet/journal/action/EditArticleAction.java
@@ -475,6 +475,12 @@ public class EditArticleAction extends PortletAction {
 		long classPK = ParamUtil.getLong(uploadPortletRequest, "classPK");
 		String articleId = ParamUtil.getString(
 			uploadPortletRequest, "articleId");
+		int pos = articleId.lastIndexOf(VERSION_SEPARATOR);
+
+		if (pos != -1) {
+			articleId = articleId.substring(0, pos);
+		}
+
 		boolean autoArticleId = ParamUtil.getBoolean(
 			uploadPortletRequest, "autoArticleId");
 		double version = ParamUtil.getDouble(uploadPortletRequest, "version");


### PR DESCRIPTION
UpdateArticle method at EditArticleAction adapted to current articleId input format: <articleId>_version_<articleversion>
