### PR TITLE
LPS-29201 ClassCastException Webcontent folders

### DIFF
--- a/portal-web/docroot/html/portlet/journal/view_folders.jsp
+++ b/portal-web/docroot/html/portlet/journal/view_folders.jsp
@@ -308,7 +308,7 @@ else {
 					%>
 
 					<liferay-ui:app-view-navigation-entry
-						actionJsp="/html/portlet/document_library/folder_action.jsp"
+						actionJsp="/html/portlet/journal/folder_action.jsp"
 						dataExpand="<%= dataExpand %>"
 						dataView="<%= dataView %>"
 						entryTitle="<%= curFolder.getName() %>"


### PR DESCRIPTION
Wrong include (maybe due to code-reusing from original document-library function)
