### PR TITLE
[TECH SUPPORT] LPS-28999

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -127,8 +127,6 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 			long groupId, boolean privateLayout, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		Group group = groupPersistence.findByPrimaryKey(groupId);
-
 		LayoutSet layoutSet = layoutSetPersistence.findByG_P(
 			groupId, privateLayout);
 


### PR DESCRIPTION
Hi Julio,

I spent a quite lot of time with this one because I would like to find a better solution than the original I got from the support. The problem is when you delete an organization site it tries to delete the group, but of course we don't let it do so we introduced "workarounds" in grouplocalservice and layoutlocalservice to prevent the deletion in case of organization sites. It leads to some consistency problems because we don't re-init the layout sets only keeps them and we don't do anything with active staging. In this fix we have to resolve these issues. The staging part is easy but the re-init of layout set is not. I tried to minimize the number of "workarounds" so I cleaned the layoutsetlocalservice.delete from the old logic and I forced the grouplocalservice to re-create the attached layoutsets when we remove the belonging sites. Another solution could be to not remove but re-initialize these objects, but after a while I rejected that because the necessary code is not a clean or easily maintainable solution. 

Please let me know your opinion!

Thanks,
Daniel 
