### PR TITLE
[QUICK WIN] LPS-29234

### DIFF
--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -373,15 +373,14 @@ public class StagingImpl implements Staging {
 			portalPreferences, layoutSetBranchId, plid);
 	}
 
-	public void disableStaging(
-			Group scopeGroup, Group liveGroup, ServiceContext serviceContext)
+	public void disableStaging(Group liveGroup, ServiceContext serviceContext)
 		throws Exception {
 
-		disableStaging(null, scopeGroup, liveGroup, serviceContext);
+		disableStaging((PortletRequest)null, liveGroup, serviceContext);
 	}
 
 	public void disableStaging(
-			PortletRequest portletRequest, Group scopeGroup, Group liveGroup,
+			PortletRequest portletRequest, Group liveGroup,
 			ServiceContext serviceContext)
 		throws Exception {
 
@@ -434,6 +433,23 @@ public class StagingImpl implements Staging {
 			liveGroup.getGroupId(), typeSettingsProperties.toString());
 	}
 
+	@Deprecated
+	public void disableStaging(
+			Group scopeGroup, Group liveGroup, ServiceContext serviceContext)
+		throws Exception {
+
+		disableStaging((PortletRequest)null, liveGroup, serviceContext);
+	}
+
+	@Deprecated
+	public void disableStaging(
+			PortletRequest portletRequest, Group scopeGroup, Group liveGroup,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		disableStaging(portletRequest, liveGroup, serviceContext);
+	}
+
 	public void enableLocalStaging(
 			long userId, Group scopeGroup, Group liveGroup,
 			boolean branchingPublic, boolean branchingPrivate,
@@ -441,7 +457,7 @@ public class StagingImpl implements Staging {
 		throws Exception {
 
 		if (liveGroup.isStagedRemotely()) {
-			disableStaging(scopeGroup, liveGroup, serviceContext);
+			disableStaging(liveGroup, serviceContext);
 		}
 
 		UnicodeProperties typeSettingsProperties =
@@ -525,7 +541,7 @@ public class StagingImpl implements Staging {
 			remoteGroupId);
 
 		if (liveGroup.hasStagingGroup()) {
-			disableStaging(scopeGroup, liveGroup, serviceContext);
+			disableStaging(liveGroup, serviceContext);
 		}
 
 		UnicodeProperties typeSettingsProperties =
@@ -1333,8 +1349,7 @@ public class StagingImpl implements Staging {
 
 		if (stagingType == StagingConstants.TYPE_NOT_STAGED) {
 			if (liveGroup.hasStagingGroup() || liveGroup.isStagedRemotely()) {
-				disableStaging(
-					portletRequest, scopeGroup, liveGroup, serviceContext);
+				disableStaging(portletRequest, liveGroup, serviceContext);
 			}
 		}
 		else if (stagingType == StagingConstants.TYPE_LOCAL_STAGING) {

--- a/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
@@ -73,10 +73,20 @@ public interface Staging {
 			User user, long layoutSetBranchId, long plid)
 		throws SystemException;
 
+	public void disableStaging(Group liveGroup, ServiceContext serviceContext)
+		throws Exception;
+
+	public void disableStaging(
+			PortletRequest portletRequest, Group liveGroup,
+			ServiceContext serviceContext)
+		throws Exception;
+
+	@Deprecated
 	public void disableStaging(
 			Group scopeGroup, Group liveGroup, ServiceContext serviceContext)
 		throws Exception;
 
+	@Deprecated
 	public void disableStaging(
 			PortletRequest portletRequest, Group scopeGroup, Group liveGroup,
 			ServiceContext serviceContext)

--- a/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
@@ -111,12 +111,29 @@ public class StagingUtil {
 	}
 
 	public static void disableStaging(
+			Group liveGroup, ServiceContext serviceContext)
+		throws Exception {
+
+		getStaging().disableStaging(liveGroup, serviceContext);
+	}
+
+	public static void disableStaging(
+			PortletRequest portletRequest, Group liveGroup,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		getStaging().disableStaging(portletRequest, liveGroup, serviceContext);
+	}
+
+	@Deprecated
+	public static void disableStaging(
 			Group scopeGroup, Group liveGroup, ServiceContext serviceContext)
 		throws Exception {
 
 		getStaging().disableStaging(scopeGroup, liveGroup, serviceContext);
 	}
 
+	@Deprecated
 	public static void disableStaging(
 			PortletRequest portletRequest, Group scopeGroup, Group liveGroup,
 			ServiceContext serviceContext)


### PR DESCRIPTION
Hey Julio, this is a quick win related to the StagingImpl class. During a review I found out that there is an unused parameter in the disableStaging method, so I was thinking we can make that deprecated and create a new disableStaging method without the unnecessary parameter. I ran the source formatter on the code, but it throws sort errors. The thing is that I wanted to keep the original parameter lists just without the unused parameter but in this way the source formatter will always throw sort errors because it's not sorted properly according to it. Anyway I thought the consistency between the method is more important than this. Thanks, Mate
