### PR TITLE
LPS-28904 Support title and description translation for multi-portlet plugins

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -68,6 +68,7 @@ import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringComparator;
@@ -3160,8 +3161,21 @@ public class PortalImpl implements Portal {
 
 		ResourceBundle resourceBundle = portletConfig.getResourceBundle(locale);
 
-		return resourceBundle.getString(
-			JavaConstants.JAVAX_PORTLET_DESCRIPTION);
+		String portletId = portlet.getRootPortletId();
+
+		String portletDescription =
+			ResourceBundleUtil.getString(
+				resourceBundle,
+				JavaConstants.JAVAX_PORTLET_DESCRIPTION.concat(
+					StringPool.PERIOD).concat(portletId));
+
+		if (Validator.isNull(portletDescription)) {
+			portletDescription =
+				ResourceBundleUtil.getString(
+					resourceBundle, JavaConstants.JAVAX_PORTLET_DESCRIPTION);
+		}
+
+		return portletDescription;
 	}
 
 	public String getPortletDescription(Portlet portlet, User user) {
@@ -3433,7 +3447,21 @@ public class PortalImpl implements Portal {
 
 		ResourceBundle resourceBundle = portletConfig.getResourceBundle(locale);
 
-		return resourceBundle.getString(JavaConstants.JAVAX_PORTLET_TITLE);
+		String portletId = portlet.getRootPortletId();
+
+		String portletTitle =
+			ResourceBundleUtil.getString(
+				resourceBundle,
+				JavaConstants.JAVAX_PORTLET_TITLE.concat(StringPool.PERIOD)
+					.concat(portletId));
+
+		if (Validator.isNull(portletTitle)) {
+			portletTitle =
+				ResourceBundleUtil.getString(
+					resourceBundle, JavaConstants.JAVAX_PORTLET_TITLE);
+		}
+
+		return portletTitle;
 	}
 
 	public String getPortletTitle(Portlet portlet, String languageId) {

--- a/portal-web/docroot/html/common/themes/portlet.jsp
+++ b/portal-web/docroot/html/common/themes/portlet.jsp
@@ -54,24 +54,14 @@ if (portletDecorateObj != null) {
 String portletTitle = PortletConfigurationUtil.getPortletTitle(portletSetup, themeDisplay.getLanguageId());
 
 if (portletDisplay.isAccess() && portletDisplay.isActive() && (portletTitle == null)) {
-	portletTitle = HtmlUtil.extractText(renderResponseImpl.getTitle());
-}
-
-ResourceBundle resourceBundle = portletConfig.getResourceBundle(locale);
-
-if (portletTitle == null) {
-	portletTitle = ResourceBundleUtil.getString(resourceBundle, JavaConstants.JAVAX_PORTLET_TITLE);
+	portletTitle = PortalUtil.getPortletTitle(portlet, pageContext.getServletContext(), locale);
 }
 
 portletDisplay.setTitle(portletTitle);
 
 // Portlet description
 
-String portletDescription = ResourceBundleUtil.getString(resourceBundle, JavaConstants.JAVAX_PORTLET_DESCRIPTION);
-
-if (Validator.isNull(portletDescription)) {
-	portletDescription = PortalUtil.getPortletDescription(portlet.getPortletId(), locale);
-}
+String portletDescription = PortalUtil.getPortletDescription(portlet, pageContext.getServletContext(), locale);
 
 portletDisplay.setDescription(portletDescription);
 


### PR DESCRIPTION
At liferay-portal we use the same resource bundle Language for all portlets. Titles and descriptions can be defined for each portlet by using the following non-standard key scheme:

javax.portlet.title.<portletId>
javax.portlet.description.<portletId>

For liferay-plugins containing more than one portlet, we should add one resource bundle Language for each in order to provide specific title and description translations (standard procedure), since the above described non-standard solution was not supported in this case. Currently, Liferay plugins use only one resource bundle Language and their titles and descriptions are not translatable. 

Through this commit, the same non-standard key scheme can be used for plugin portlets. Example:

javax.portlet.title.1_WAR_tasksportlet=Tasks
javax.portlet.title.2_WAR_tasksportlet=Upcoming Tasks
