### PR TITLE
LPS-30283

### DIFF
--- a/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java
+++ b/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java
@@ -234,7 +234,7 @@ public class HookHotDeployListener
 		"portlet.add.default.resource.check.enabled",
 		"portlet.add.default.resource.check.whitelist",
 		"portlet.add.default.resource.check.whitelist.actions",
-		"portal.authentication.verifier.pipeline", "rss.feeds.enabled",
+		"auth.verifier.pipeline", "rss.feeds.enabled",
 		"sanitizer.impl", "servlet.session.create.events",
 		"servlet.session.destroy.events", "servlet.service.events.post",
 		"servlet.service.events.pre", "session.max.allowed",


### PR DESCRIPTION
Hi Julio,

to give you a context - we forgot to rename a property in HookHotDeployListener after refactoring, it should be the value of PropKeys.AUTH_VERIFIER_PIPELINE.

Thank you.

-- tom +
