### PR TITLE
[TECH SUPPORT] LPS-30253

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
@@ -1090,9 +1090,8 @@ public class PortletExporter {
 		if (rootPotletId.equals(PortletKeys.ASSET_PUBLISHER)) {
 			preferencesXML = updateAssetPublisherPortletPreferences(
 				preferencesXML, plid);
-		} else if (rootPotletId.equals(
-			PortletKeys.TAGS_CATEGORIES_NAVIGATION)) {
-
+		}
+		else if (rootPotletId.equals(PortletKeys.TAGS_CATEGORIES_NAVIGATION)) {
 			preferencesXML = updateCategoryNavigationPortletPreferences(
 				preferencesXML, plid);
 		}
@@ -1438,73 +1437,6 @@ public class PortletExporter {
 		jxPreferences.setValues(key, newValues);
 	}
 
-	protected void updateAssetPublisherClassPKs(
-			javax.portlet.PortletPreferences jxPreferences, String key,
-			String className)
-		throws Exception {
-
-		String[] oldValues = jxPreferences.getValues(key, null);
-
-		if (oldValues == null) {
-			return;
-		}
-
-		String[] newValues = new String[oldValues.length];
-
-		for (int i = 0; i < oldValues.length; i++) {
-			String oldValue = oldValues[i];
-
-			String newValue = oldValue;
-
-			String[] primaryKeys = StringUtil.split(oldValue);
-
-			for (String primaryKey : primaryKeys) {
-				if (!Validator.isNumber(primaryKey)) {
-					break;
-				}
-
-				long primaryKeyLong = GetterUtil.getLong(primaryKey);
-
-				String uuid = null;
-
-				if (className.equals(AssetCategory.class.getName())) {
-					AssetCategory category =
-						AssetCategoryLocalServiceUtil.fetchCategory(
-							primaryKeyLong);
-
-					if (category != null) {
-						uuid = category.getUuid();
-					}
-				}
-				else if (className.equals(JournalStructure.class.getName())) {
-					JournalStructure structure =
-						JournalStructureLocalServiceUtil.fetchJournalStructure(
-							primaryKeyLong);
-
-					if (structure != null) {
-						uuid = structure.getUuid();
-					}
-				}
-
-				if (Validator.isNull(uuid)) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							"Unable to get UUID for class " + className +
-								" with primary key " + primaryKeyLong);
-					}
-
-					continue;
-				}
-
-				newValue = StringUtil.replace(newValue, primaryKey, uuid);
-			}
-
-			newValues[i] = newValue;
-		}
-
-		jxPreferences.setValues(key, newValues);
-	}
-
 	protected void updateAssetPublisherGlobalScopeId(
 			javax.portlet.PortletPreferences jxPreferences, String key,
 			long plid)
@@ -1557,7 +1489,7 @@ public class PortletExporter {
 					"classTypeIdsJournalArticleAssetRendererFactory") ||
 				name.equals("classTypeIds")) {
 
-				updateAssetPublisherClassPKs(
+				updatePreferencesClassPKs(
 					jxPreferences, name, JournalStructure.class.getName());
 			}
 			else if (name.equals("anyAssetType") ||
@@ -1573,7 +1505,7 @@ public class PortletExporter {
 
 				String index = name.substring(9);
 
-				updateAssetPublisherClassPKs(
+				updatePreferencesClassPKs(
 					jxPreferences, "queryValues" + index,
 					AssetCategory.class.getName());
 			}
@@ -1582,7 +1514,28 @@ public class PortletExporter {
 		return PortletPreferencesFactoryUtil.toXML(jxPreferences);
 	}
 
-	protected void updateCategoryNavigationClassPKs(
+	protected String updateCategoryNavigationPortletPreferences(
+			String xml, long plid)
+		throws Exception {
+
+		javax.portlet.PortletPreferences jxPreferences =
+			PortletPreferencesFactoryUtil.fromDefaultXML(xml);
+
+		Enumeration<String> enu = jxPreferences.getNames();
+
+		while (enu.hasMoreElements()) {
+			String name = enu.nextElement();
+
+			if (name.equals("assetVocabularyIds")) {
+				updatePreferencesClassPKs(
+					jxPreferences, name, AssetVocabulary.class.getName());
+			}
+		}
+
+		return PortletPreferencesFactoryUtil.toXML(jxPreferences);
+	}
+
+	protected void updatePreferencesClassPKs(
 			javax.portlet.PortletPreferences jxPreferences, String key,
 			String className)
 		throws Exception {
@@ -1611,7 +1564,25 @@ public class PortletExporter {
 
 				String uuid = null;
 
-				if (className.equals(AssetVocabulary.class.getName())) {
+				if (className.equals(AssetCategory.class.getName())) {
+					AssetCategory category =
+						AssetCategoryLocalServiceUtil.fetchCategory(
+							primaryKeyLong);
+
+					if (category != null) {
+						uuid = category.getUuid();
+					}
+				}
+				else if (className.equals(JournalStructure.class.getName())) {
+					JournalStructure structure =
+						JournalStructureLocalServiceUtil.fetchJournalStructure(
+							primaryKeyLong);
+
+					if (structure != null) {
+						uuid = structure.getUuid();
+					}
+				}
+				else if (className.equals(AssetVocabulary.class.getName())) {
 					AssetVocabulary vocabulary =
 						AssetVocabularyLocalServiceUtil.fetchAssetVocabulary(
 							primaryKeyLong);
@@ -1621,6 +1592,16 @@ public class PortletExporter {
 					}
 				}
 
+				if (Validator.isNull(uuid)) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"Unable to get UUID for class " + className +
+								" with primary key " + primaryKeyLong);
+					}
+
+					continue;
+				}
+
 				newValue = StringUtil.replace(newValue, primaryKey, uuid);
 			}
 
@@ -1628,27 +1609,6 @@ public class PortletExporter {
 		}
 
 		jxPreferences.setValues(key, newValues);
-	}
-
-	protected String updateCategoryNavigationPortletPreferences(
-			String xml, long plid)
-		throws Exception {
-
-		javax.portlet.PortletPreferences jxPreferences =
-			PortletPreferencesFactoryUtil.fromDefaultXML(xml);
-
-		Enumeration<String> enu = jxPreferences.getNames();
-
-		while (enu.hasMoreElements()) {
-			String name = enu.nextElement();
-
-			if (name.equals("assetVocabularyIds")) {
-				updateCategoryNavigationClassPKs(
-					jxPreferences, name, AssetVocabulary.class.getName());
-			}
-		}
-
-		return PortletPreferencesFactoryUtil.toXML(jxPreferences);
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(PortletExporter.class);

--- a/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
@@ -1193,8 +1193,9 @@ public class PortletImporter {
 					xml = updateAssetPublisherPortletPreferences(
 						portletDataContext, companyId, ownerId, ownerType, plid,
 						portletId, xml);
-				} else if ((rootPotletId.equals(
-						PortletKeys.TAGS_CATEGORIES_NAVIGATION))) {
+				}
+				else if (rootPotletId.equals(
+							PortletKeys.TAGS_CATEGORIES_NAVIGATION)) {
 
 					xml = updateCategoryNavigationPortletPreferences(
 						portletDataContext, companyId, ownerId, ownerType, plid,
@@ -1747,103 +1748,6 @@ public class PortletImporter {
 		jxPreferences.setValues(key, newValues);
 	}
 
-	protected void updateAssetPublisherClassPKs(
-			PortletDataContext portletDataContext,
-			javax.portlet.PortletPreferences jxPreferences, String key,
-			Class<?> clazz, long companyGroupId)
-		throws Exception {
-
-		String[] oldValues = jxPreferences.getValues(key, null);
-
-		if (oldValues == null) {
-			return;
-		}
-
-		Map<Long, Long> primaryKeysMap =
-			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(clazz);
-
-		String[] newValues = new String[oldValues.length];
-
-		for (int i = 0; i < oldValues.length; i++) {
-			String oldValue = oldValues[i];
-
-			String newValue = oldValue;
-
-			String[] uuids = StringUtil.split(oldValue);
-
-			for (String uuid : uuids) {
-				Long newPrimaryKey = null;
-
-				if (Validator.isNumber(uuid)) {
-					long oldPrimaryKey = GetterUtil.getLong(uuid);
-
-					newPrimaryKey = MapUtil.getLong(
-						primaryKeysMap, oldPrimaryKey, oldPrimaryKey);
-				}
-				else {
-					String className = clazz.getName();
-
-					if (className.equals(AssetCategory.class.getName())) {
-						AssetCategory category =
-							AssetCategoryUtil.fetchByUUID_G(
-								uuid, portletDataContext.getScopeGroupId());
-
-						if (category == null) {
-							category =
-								AssetCategoryUtil.fetchByUUID_G(
-									uuid, companyGroupId);
-						}
-
-						if (category != null) {
-							newPrimaryKey = category.getCategoryId();
-						}
-					}
-					else if (className.equals(
-								JournalStructure.class.getName())) {
-
-						JournalStructure structure =
-							JournalStructureUtil.fetchByUUID_G(
-								uuid, portletDataContext.getScopeGroupId());
-
-						if (structure == null) {
-							structure = JournalStructureUtil.fetchByUUID_G(
-								uuid, companyGroupId);
-						}
-
-						if (structure != null) {
-							newPrimaryKey = structure.getId();
-						}
-					}
-				}
-
-				if (Validator.isNull(newPrimaryKey)) {
-					if (_log.isWarnEnabled()) {
-						StringBundler sb = new StringBundler(8);
-
-						sb.append("Unable to get primary key for ");
-						sb.append(clazz);
-						sb.append(" with UUID ");
-						sb.append(uuid);
-						sb.append(" in company group ");
-						sb.append(companyGroupId);
-						sb.append(" or in group ");
-						sb.append(portletDataContext.getScopeGroupId());
-
-						_log.warn(sb.toString());
-					}
-				}
-				else {
-					newValue = StringUtil.replace(
-						newValue, uuid, newPrimaryKey.toString());
-				}
-			}
-
-			newValues[i] = newValue;
-		}
-
-		jxPreferences.setValues(key, newValues);
-	}
-
 	protected void updateAssetPublisherGlobalScopeId(
 			javax.portlet.PortletPreferences jxPreferences, String key,
 			long groupId)
@@ -1896,7 +1800,7 @@ public class PortletImporter {
 					"classTypeIdsJournalArticleAssetRendererFactory") ||
 				name.equals("classTypeIds")) {
 
-				updateAssetPublisherClassPKs(
+				updatePreferencesClassPKs(
 					portletDataContext, jxPreferences, name,
 					JournalStructure.class, companyGroup.getGroupId());
 			}
@@ -1914,94 +1818,13 @@ public class PortletImporter {
 
 				String index = name.substring(9, name.length());
 
-				updateAssetPublisherClassPKs(
+				updatePreferencesClassPKs(
 					portletDataContext, jxPreferences, "queryValues" + index,
 					AssetCategory.class, companyGroup.getGroupId());
 			}
 		}
 
 		return PortletPreferencesFactoryUtil.toXML(jxPreferences);
-	}
-
-	protected void updateCategoryNavigationClassPKs(
-			PortletDataContext portletDataContext,
-			javax.portlet.PortletPreferences jxPreferences, String key,
-			Class<?> clazz, long companyGroupId)
-		throws Exception {
-
-		String[] oldValues = jxPreferences.getValues(key, null);
-
-		if (oldValues == null) {
-			return;
-		}
-
-		Map<Long, Long> primaryKeysMap =
-			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(clazz);
-
-		String[] newValues = new String[oldValues.length];
-
-		for (int i = 0; i < oldValues.length; i++) {
-			String oldValue = oldValues[i];
-
-			String newValue = oldValue;
-
-			String[] uuids = StringUtil.split(oldValue);
-
-			for (String uuid : uuids) {
-				Long newPrimaryKey = null;
-
-				if (Validator.isNumber(uuid)) {
-					long oldPrimaryKey = GetterUtil.getLong(uuid);
-
-					newPrimaryKey = MapUtil.getLong(
-						primaryKeysMap, oldPrimaryKey, oldPrimaryKey);
-				}
-				else {
-					String className = clazz.getName();
-
-					if (className.equals(AssetVocabulary.class.getName())) {
-						AssetVocabulary vocabulary =
-							AssetVocabularyUtil.fetchByUUID_G(
-								uuid, portletDataContext.getScopeGroupId());
-
-						if (vocabulary == null) {
-							vocabulary =
-								AssetVocabularyUtil.fetchByUUID_G(
-									uuid, companyGroupId);
-						}
-
-						if (vocabulary != null) {
-							newPrimaryKey = vocabulary.getVocabularyId();
-						}
-					}
-				}
-
-				if (Validator.isNull(newPrimaryKey)) {
-					if (_log.isWarnEnabled()) {
-						StringBundler sb = new StringBundler(8);
-
-						sb.append("Unable to get primary key for ");
-						sb.append(clazz);
-						sb.append(" with UUID ");
-						sb.append(uuid);
-						sb.append(" in company group ");
-						sb.append(companyGroupId);
-						sb.append(" or in group ");
-						sb.append(portletDataContext.getScopeGroupId());
-
-						_log.warn(sb.toString());
-					}
-				}
-				else {
-					newValue = StringUtil.replace(
-						newValue, uuid, newPrimaryKey.toString());
-				}
-			}
-
-			newValues[i] = newValue;
-		}
-
-		jxPreferences.setValues(key, newValues);
 	}
 
 	protected String updateCategoryNavigationPortletPreferences(
@@ -2023,7 +1846,7 @@ public class PortletImporter {
 			String name = enu.nextElement();
 
 			if (name.equals("assetVocabularyIds")) {
-				updateCategoryNavigationClassPKs(
+				updatePreferencesClassPKs(
 					portletDataContext, jxPreferences, name,
 					AssetVocabulary.class, companyGroup.getGroupId());
 			}
@@ -2100,6 +1923,118 @@ public class PortletImporter {
 			PortletPreferencesLocalServiceUtil.updatePreferences(
 				ownerId, ownerType, plid, portletId, portletPreferences);
 		}
+	}
+
+	protected void updatePreferencesClassPKs(
+			PortletDataContext portletDataContext,
+			javax.portlet.PortletPreferences jxPreferences, String key,
+			Class<?> clazz, long companyGroupId)
+		throws Exception {
+
+		String[] oldValues = jxPreferences.getValues(key, null);
+
+		if (oldValues == null) {
+			return;
+		}
+
+		Map<Long, Long> primaryKeysMap =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(clazz);
+
+		String[] newValues = new String[oldValues.length];
+
+		for (int i = 0; i < oldValues.length; i++) {
+			String oldValue = oldValues[i];
+
+			String newValue = oldValue;
+
+			String[] uuids = StringUtil.split(oldValue);
+
+			for (String uuid : uuids) {
+				Long newPrimaryKey = null;
+
+				if (Validator.isNumber(uuid)) {
+					long oldPrimaryKey = GetterUtil.getLong(uuid);
+
+					newPrimaryKey = MapUtil.getLong(
+						primaryKeysMap, oldPrimaryKey, oldPrimaryKey);
+				}
+				else {
+					String className = clazz.getName();
+
+					if (className.equals(AssetCategory.class.getName())) {
+						AssetCategory category =
+							AssetCategoryUtil.fetchByUUID_G(
+								uuid, portletDataContext.getScopeGroupId());
+
+						if (category == null) {
+							category = AssetCategoryUtil.fetchByUUID_G(
+									uuid, companyGroupId);
+						}
+
+						if (category != null) {
+							newPrimaryKey = category.getCategoryId();
+						}
+					}
+					else if (className.equals(
+							JournalStructure.class.getName())) {
+
+						JournalStructure structure =
+							JournalStructureUtil.fetchByUUID_G(
+								uuid, portletDataContext.getScopeGroupId());
+
+						if (structure == null) {
+							structure = JournalStructureUtil.fetchByUUID_G(
+								uuid, companyGroupId);
+						}
+
+						if (structure != null) {
+							newPrimaryKey = structure.getId();
+						}
+					}
+					else if (className.equals(
+								AssetVocabulary.class.getName())) {
+
+						AssetVocabulary vocabulary =
+							AssetVocabularyUtil.fetchByUUID_G(
+								uuid, portletDataContext.getScopeGroupId());
+
+						if (vocabulary == null) {
+							vocabulary = AssetVocabularyUtil.fetchByUUID_G(
+								uuid, companyGroupId);
+						}
+
+						if (vocabulary != null) {
+							newPrimaryKey = vocabulary.getVocabularyId();
+						}
+					}
+				}
+
+				if (Validator.isNull(newPrimaryKey)) {
+					if (_log.isWarnEnabled()) {
+						StringBundler sb = new StringBundler(8);
+
+						sb.append("Unable to get primary key for ");
+						sb.append(clazz);
+						sb.append(" with UUID ");
+						sb.append(uuid);
+						sb.append(" in company group ");
+						sb.append(companyGroupId);
+						sb.append(" or in group ");
+						sb.append(portletDataContext.getScopeGroupId());
+
+						_log.warn(sb.toString());
+					}
+				}
+				else {
+					newValue = StringUtil.replace(
+						newValue, uuid, newPrimaryKey.toString());
+				}
+			}
+
+			newValues[i] = newValue;
+		}
+
+		jxPreferences.setValues(key, newValues);
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(PortletImporter.class);


### PR DESCRIPTION
Hi Julio,

This is a staging related fix. The story here is that previously we had a problem with the asset publisher's portlet preferences: we storing some classnameid and primary keys; and during the and export/import process (staging) the ids will not reflect the new ids in the live system. We have already solved this problem by modifying the PortletExporter/PortletImporter to replace these IDs appropriately.

Now we have the same problem with the categories navigation portlet as well. Zsolt based on my advice followed the same approach like we have for asset publisher and it works properly, I've refactored his code a little.

Although there is more to this story. There can be more portlets suffering from the same problem, and I'd like to explore all those and fix the issue for those as well. That on the other hand would be a bigger set of change and I'd like to test it properly as well. This change I'd like to do as part of the staging rewrite project, and I've already initiated a discussion for the solution for all the portlets with @mhan810.
As soon as I get back from the EU Symposium I'll start to work on discovering what other portlets have the same problem, although this fix is needed for the support to get a backport and then give out as a patch.

Thanks,

Máté

cc-ing @KocsisDaniel
