### PR TITLE
LPS-30918 Cannot close Site Settings dialog after clicking save twice or more

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/action/EditGroupAction.java
+++ b/portal-impl/src/com/liferay/portlet/sites/action/EditGroupAction.java
@@ -117,14 +117,16 @@ public class EditGroupAction extends PortletAction {
 				String oldStagingFriendlyURL = (String)returnValue[2];
 				long newRefererPlid = (Long)returnValue[3];
 
+				closeRedirect = updateCloseRedirect(
+					closeRedirect, group, themeDisplay, oldFriendlyURL,
+					oldStagingFriendlyURL);
+
+				redirect = HttpUtil.setParameter(
+					redirect, "closeRedirect", closeRedirect);
 				redirect = HttpUtil.setParameter(
 					redirect, "doAsGroupId", group.getGroupId());
 				redirect = HttpUtil.setParameter(
 					redirect, "refererPlid", newRefererPlid);
-
-				closeRedirect = updateCloseRedirect(
-					closeRedirect, group, themeDisplay, oldFriendlyURL,
-					oldStagingFriendlyURL);
 			}
 			else if (cmd.equals(Constants.DEACTIVATE) ||
 					 cmd.equals(Constants.RESTORE)) {


### PR DESCRIPTION
The "closeRedirect" param was missing in the redirect request, so the hidden field "closeRedirect" in the edit_site.jsp was never filled after redirection.

The code involved to set the closeRedirect param is different in EditGroupAction, EditLayoutsAction and EditLayoutSetAction. My solution is the simpliest and fasted, but maybe we should invest some time in refactor and homogenize these classes.
