### PR TITLE
LPS-30858 Fix JSP compile error

### DIFF
--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/select_structure.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/select_structure.jsp
@@ -16,6 +16,10 @@
 
 <%@ include file="/html/portlet/dynamic_data_mapping/init.jsp" %>
 
+<%
+long groupId = ParamUtil.getLong(request, "groupId", scopeGroupId);
+%>
+
 <c:if test="<%= showToolbar %>">
 	<liferay-util:include page="/html/portlet/dynamic_data_mapping/structure_toolbar.jsp">
 		<liferay-util:param name="toolbarItem" value="view-all" />


### PR DESCRIPTION
Hey Julio,

This is just a quick fix, because one JSP did not compile on trunk this morning. This has been caused by the LPS-30858 I think.

I've also sent an email about it to engineering.

Thanks,

Máté
