### PR TITLE
LPS-30387 Portlet preferences staging fix for not unique per layout and group owner

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
@@ -839,7 +839,7 @@ public class PortletExporter {
 
 		if (exportPortletSetup) {
 			if (!portlet.isPreferencesUniquePerLayout() &&
-					portlet.isPreferencesOwnedByGroup()) {
+				portlet.isPreferencesOwnedByGroup()) {
 
 				exportPortletPreferences(
 					portletDataContext, portletDataContext.getScopeGroupId(),
@@ -1147,12 +1147,12 @@ public class PortletExporter {
 		String path = getPortletPreferencesPath(
 			portletDataContext, portletId, ownerId, ownerType, plid);
 
+		Element portletPreferencesElement = parentElement.addElement(
+			"portlet-preferences");
+
+		portletPreferencesElement.addAttribute("path", path);
+
 		if (portletDataContext.isPathNotProcessed(path)) {
-			Element portletPreferencesElement = parentElement.addElement(
-				"portlet-preferences");
-
-			portletPreferencesElement.addAttribute("path", path);
-
 			portletDataContext.addZipEntry(
 				path, document.formattedString(StringPool.TAB, false, false));
 		}


### PR DESCRIPTION
Hey Julio,

This bug happens on a specific setup (also described in the LPS ticket). Basically when the portlet preferences is owned by the group and the preference is _not_ unique per layout the preferences are not being propagated correctly to the staging environment.

The root cause of the problem is that the preferences is being saved with the root portlet id, and not the portlet instances and this was not exported. This change allows this option as well.

We have considered and tested staging and single portlet export/import.

I'll be on vacation next week, if you have any question regarding this can you please contact w/ @KocsisDaniel, he know about this change and we discussed everything about it.

Thanks,

Máté
