### PR TITLE
LPS-31081

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/S3Store.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/S3Store.java
@@ -595,7 +595,11 @@ public class S3Store extends BaseStore {
 		sb.append(companyId);
 		sb.append(StringPool.SLASH);
 		sb.append(repositoryId);
-		sb.append(StringPool.SLASH);
+
+		if (!fileName.startsWith(StringPool.SLASH)) {
+			sb.append(StringPool.SLASH);
+		}
+
 		sb.append(fileName);
 		sb.append(StringPool.SLASH);
 
@@ -611,7 +615,11 @@ public class S3Store extends BaseStore {
 		sb.append(companyId);
 		sb.append(StringPool.SLASH);
 		sb.append(repositoryId);
-		sb.append(StringPool.SLASH);
+
+		if (!fileName.startsWith(StringPool.SLASH)) {
+			sb.append(StringPool.SLASH);
+		}
+
 		sb.append(fileName);
 		sb.append(StringPool.SLASH);
 		sb.append(versionLabel);


### PR DESCRIPTION
Hey Julio, while this is currently working on trunk because we have changed the way how we store the attachements and S3Store gets a number instead of a full path, I'd still commit this on trunk as well in case  some added feature returns a path again in the future..
