### PR TITLE
LPS-31038

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/asset/JournalArticleAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/journal/asset/JournalArticleAssetRenderer.java
@@ -16,7 +16,6 @@ package com.liferay.portlet.journal.asset;
 
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
@@ -167,7 +166,7 @@ public class JournalArticleAssetRenderer extends BaseAssetRenderer {
 
 			return groupFriendlyURL.concat(
 				JournalArticleConstants.CANONICAL_URL_SEPARATOR).concat(
-					HtmlUtil.escape(_article.getUrlTitle()));
+					_article.getUrlTitle());
 		}
 
 		Layout layout = themeDisplay.getLayout();


### PR DESCRIPTION
Hey Julio, it seems that we don't need that escape (it was added by Juan in LPS-22659 but I don't even see why) because when we first set URLTitle we normalize it using FriendlyURLNormalizerImpl, so there is no XSS risk there. After the discussion in http://in.liferay.com/web/global.engineering/fo
rums/-/message_boards/view_message/894544#_19_message_880081 it seems that solving the problem of early escaping cannot be done within the scope of this LPS.
