### PR TITLE
LPS-31002 Get strict but not layout based portletpreferences when exporting portlets

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
@@ -806,7 +806,7 @@ public class PortletExporter {
 
 		if (exportPortletData) {
 			javax.portlet.PortletPreferences jxPreferences =
-				PortletPreferencesFactoryUtil.getStrictLayoutPortletSetup(
+				PortletPreferencesFactoryUtil.getStrictPortletSetup(
 					layout, portletId);
 
 			if (!portlet.isPreferencesUniquePerLayout()) {

--- a/portal-service/src/com/liferay/portlet/PortletPreferencesFactory.java
+++ b/portal-service/src/com/liferay/portlet/PortletPreferencesFactory.java
@@ -118,6 +118,10 @@ public interface PortletPreferencesFactory {
 			Layout layout, String portletId)
 		throws SystemException;
 
+	public PortletPreferences getStrictPortletSetup(
+			Layout layout, String portletId)
+		throws SystemException;
+
 	public String toXML(PortalPreferences portalPreferences);
 
 	public String toXML(PortletPreferences portletPreferences);

--- a/portal-service/src/com/liferay/portlet/PortletPreferencesFactoryUtil.java
+++ b/portal-service/src/com/liferay/portlet/PortletPreferencesFactoryUtil.java
@@ -215,6 +215,14 @@ public class PortletPreferencesFactoryUtil {
 			layout, portletId);
 	}
 
+	public static PortletPreferences getStrictPortletSetup(
+			Layout layout, String portletId)
+		throws SystemException {
+
+		return getPortletPreferencesFactory().getStrictPortletSetup(
+			layout, portletId);
+	}
+
 	public static String toXML(PortalPreferences portalPreferences) {
 		return getPortletPreferencesFactory().toXML(portalPreferences);
 	}


### PR DESCRIPTION
Hey Julio,

The problem was that during the staging when the portlet preferences was returned, the code was looking for a preferences tied to a layout in strict mode. Because of the strict mode an empty object is being returned for certain portlets what are being pushed to live, but does not have a layout tied preferences and when the staging process tried to store the preferences it throw an exception because  the prefs object is empty - no portletId is set up there.

This should fix the problem, because we look up the preferences not just for layouts and we also keep the strict mode.

Thanks,

Máté
