### PR TITLE
LPS-31513 Fix NPE when importing article version older then the latest

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -2066,10 +2066,14 @@ public class JournalArticleLocalServiceImpl
 
 		if (imported) {
 			if (latestVersion > version) {
-				article = journalArticlePersistence.fetchByG_A_V(
-					groupId, articleId, version);
+				JournalArticle existingArticle =
+					journalArticlePersistence.fetchByG_A_V(
+						groupId, articleId, version);
 
-				if (article == null) {
+				if (existingArticle != null) {
+					article = existingArticle;
+				}
+				else {
 					addNewVersion = true;
 				}
 			}


### PR DESCRIPTION
Hey Julio,

In  this case the approach how we modified that single article was wrong. If there was no existing article, the service method set the article variable to null which ended up in an NPE.

Dániel's change goes the other way around: check if there is an existing one and if there is one then set the article variable keeping it's consistency later.

Thanks,

Máté
