### PR TITLE
[TECH SUPPORT] LPS-31785 

### DIFF
--- a/portal-web/docroot/html/portlet/users_admin/view_flat_users.jspf
+++ b/portal-web/docroot/html/portlet/users_admin/view_flat_users.jspf
@@ -37,11 +37,16 @@ if (!ParamUtil.getBoolean(renderRequest, "advancedSearch")) {
 	<%
 	UserSearchTerms searchTerms = (UserSearchTerms)searchContainer.getSearchTerms();
 
+	int totalUsers = 0;
 	LinkedHashMap countParams = new LinkedHashMap<String, Object>();
 
-	countParams.put("usersOrgs", searchTerms.getOrganizationId());
-
-	int totalUsers = UserLocalServiceUtil.searchCount(company.getCompanyId(), searchTerms.getKeywords(), searchTerms.getStatus(), countParams);
+	if (searchTerms.isAdvancedSearch()) {
+		totalUsers = UserLocalServiceUtil.searchCount(company.getCompanyId(), searchTerms.getFirstName(), searchTerms.getMiddleName(), searchTerms.getLastName(), searchTerms.getScreenName(), searchTerms.getEmailAddress(), searchTerms.getStatus(), countParams, searchTerms.isAndOperator());
+	}
+	else {
+		countParams.put("usersOrgs", searchTerms.getOrganizationId());
+		totalUsers = UserLocalServiceUtil.searchCount(company.getCompanyId(), searchTerms.getKeywords(), searchTerms.getStatus(), countParams);
+	}
 
 	userSearch.setTotal(totalUsers);
 


### PR DESCRIPTION
- LPS-31785  During user administration, deactivating the last user from a SearchContainer page results in No Users message 
- Resending after adding the handling of advanced search.
