### PR TITLE
LPS-32236 Journal doesn't handle trash for folders yet

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/journal/trash/JournalArticleTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/trash/JournalArticleTrashHandlerTest.java
@@ -61,6 +61,11 @@ public class JournalArticleTrashHandlerTest extends BaseTrashHandlerTestCase {
 	}
 
 	@Override
+	public void testTrashParentAndDeleteTrashEntries() throws Exception {
+		Assert.assertTrue("This test does not apply yet", true);
+	}
+
+	@Override
 	public void testTrashParentAndRestoreModel() throws Exception {
 		Assert.assertTrue("This test does not apply yet", true);
 	}


### PR DESCRIPTION
Hey Julio,

Journal doesn't handle folders yet, so Sergio skipped this test in JournalArticleTrashHandlerTest.

Test are still unstable, probably because we need an even longer delay for indexing and search operations with Journal entities.  I send Sergio's commit as it is. In case tests fails again, you should get a message.
