### PR TITLE
LPS-32343 DLFolders are not reindexed when updated.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -576,6 +576,7 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 		return dlFolder;
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	public DLFolder updateFolder(
 			long userId, long folderId, long parentFolderId, String name,
 			String description, long defaultFileEntryTypeId,


### PR DESCRIPTION
The addFolder method invokes resourceLocalService.addResources or resourceLocalService.addModelResources, which internally index the folder. Thus the Indexable annotation is not required. However, for the updateFolder method the Indexable annotation must be added to reindex the folder.

@caorongjin
