### PR TITLE
LPS-31892

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/view_resources.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/view_resources.jsp
@@ -22,6 +22,9 @@
 boolean viewTree = ParamUtil.getBoolean(request, "viewTree");
 boolean viewLayout = ParamUtil.getBoolean(request, "viewLayout");
 
+boolean hasLayoutUpdatePermission = (selPlid > 0) && LayoutPermissionUtil.contains(permissionChecker, selPlid, ActionKeys.UPDATE);
+boolean hasGroupUpdatePermission = (liveGroupId > 0) && GroupPermissionUtil.contains(permissionChecker, liveGroupId, ActionKeys.UPDATE);
+
 SitesUtil.addPortletBreadcrumbEntries(group, pagesName, redirectURL, request, renderResponse);
 %>
 
@@ -37,10 +40,14 @@ SitesUtil.addPortletBreadcrumbEntries(group, pagesName, redirectURL, request, re
 	<div id="<portlet:namespace />viewLayout">
 		<c:choose>
 			<c:when test="<%= selPlid > 0 %>">
-				<liferay-util:include page="/html/portlet/layouts_admin/edit_layout.jsp" />
+				<c:if test="<%= hasLayoutUpdatePermission %>">
+					<liferay-util:include page="/html/portlet/layouts_admin/edit_layout.jsp" />
+				</c:if>
 			</c:when>
 			<c:otherwise>
-				<liferay-util:include page="/html/portlet/layouts_admin/edit_layout_set.jsp" />
+				<c:if test="<%= hasGroupUpdatePermission %>">
+					<liferay-util:include page="/html/portlet/layouts_admin/edit_layout_set.jsp" />
+				</c:if>
 			</c:otherwise>
 		</c:choose>
 	</div>


### PR DESCRIPTION
Hi Julio,

core of the issue are missing permission checks when displaying Manage Page => when "cmd" parameter is not defined.

I had to fix this in render phase (EditLayoutsAction) and in resource phase (view_resources.jsp).

To fix this I needed to distinguish display page action (cmd="") from cmd=publish_to_live and refactor the code for that. But this isn't clear refactor and caused change in the permission checking logic. 

Before my change, "publish_to_live" action checked for 
1, Group.PUBLISH_STAGING and Layout.UPDATE actions 
2, UPDATE for group of type Company/LayoutPrototype/LayoutSetPrototype/User. 

I tried to activate staging on the groups (Company/LayoutPrototype/LayoutSetPrototype/User) but there is no UI for this. When I tried to manipulate URL and replace groupIds to enable staging on these groups, it end up with ConstraintViolation DB exception. So it seems that the checks were never executed in real.

So I changed it so that now md=publish_to_live only checks:
1, Group.PUBLISH_STAGING and Layout.UPDATE actions 

I also changed permission checking logic in EditLayoutsAction from allowing to denying. Boolean hasPermission was initially set to "true" and changed to false only in some cases, which is a bad behavior from a security perspective. 

I know it seems complicated, if you need any assistance please call me.

Thank you.
