### PR TITLE
LPS-32362 Declare supported classNames in FolderSearcher.

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/search/FolderSearcher.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/FolderSearcher.java
@@ -14,6 +14,10 @@
 
 package com.liferay.portal.kernel.search;
 
+import com.liferay.portlet.bookmarks.model.BookmarksFolder;
+import com.liferay.portlet.documentlibrary.model.DLFolder;
+import com.liferay.portlet.journal.model.JournalFolder;
+
 import java.util.Locale;
 
 import javax.portlet.PortletURL;
@@ -22,6 +26,10 @@ import javax.portlet.PortletURL;
  * @author Eduardo Garcia
  */
 public class FolderSearcher extends BaseIndexer {
+
+	public static final String[] CLASS_NAMES = {
+		BookmarksFolder.class.getName(), DLFolder.class.getName(),
+		JournalFolder.class.getName()};
 
 	public static Indexer getInstance() {
 		return new FolderSearcher();
@@ -33,7 +41,7 @@ public class FolderSearcher extends BaseIndexer {
 	}
 
 	public String[] getClassNames() {
-		return null;
+		return CLASS_NAMES;
 	}
 
 	@Override


### PR DESCRIPTION
https://github.com/liferay/liferay-portal/commit/bd55d0343e6493ccb52654b07443e6ba15636c24

While the FacetSearcher fully overrides the BaseIndexer.createFullQuery method, the FolderSearcher simply extends it. Thus, if FolderSearcher.getClassNames returns null, a NullPointerException will be thrown by the BaseIndexer.createFullQuery method. It is assumed that currently only folders of the declared classNames will be supported, since for them the classPK is unique (they use the same counter). This means this feature is not yet supported for folder entities created in plugins.
