### PR TITLE
LPS-32654 Support the automatic storage of fields in the Edit Site form as typeSettings.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/action/EditGroupAction.java
+++ b/portal-impl/src/com/liferay/portlet/sites/action/EditGroupAction.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropertiesParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -546,6 +547,12 @@ public class EditGroupAction extends PortletAction {
 		typeSettingsProperties.setProperty(
 			"contentSharingWithChildrenEnabled",
 			String.valueOf(contentSharingWithChildrenEnabled));
+
+		UnicodeProperties formTypeSettingsProperties =
+			PropertiesParamUtil.getProperties(
+				actionRequest, "TypeSettingsProperties--");
+
+		typeSettingsProperties.putAll(formTypeSettingsProperties);
 
 		// Virtual hosts
 


### PR DESCRIPTION
This change is all we need to fulfill LPS-32654. Adding a custom JSP to extend the Edit Site form was already supported, and with this new feature developers are able to store new fields as Group TypeSettings without changing the struts action class.

@sergiogonzalez
