### PR TITLE
LPS-29962 Fix tests

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinderTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.test.EnvironmentExecutionTestListener;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
 import com.liferay.portal.test.TransactionalExecutionTestListener;
 import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
@@ -45,11 +46,10 @@ import com.liferay.portlet.documentlibrary.util.DLAppTestUtil;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.testng.Assert;
 
 /**
  * @author Zsolt Berentey
@@ -251,6 +251,11 @@ public class DLFileEntryFinderTest {
 	public void testFindByNoAssets() throws Exception {
 		AssetEntryLocalServiceUtil.deleteEntry(
 			DLFileEntry.class.getName(), _dlFileVersion.getFileEntryId());
+
+		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+			DLFileEntry.class.getName(), _dlFileVersion.getFileEntryId());
+
+		Assert.assertNull(assetEntry);
 
 		List<DLFileEntry> dlFileEntries =
 			DLFileEntryFinderUtil.findByNoAssets();

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/DLFolderFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/DLFolderFinderTest.java
@@ -39,11 +39,10 @@ import com.liferay.portlet.documentlibrary.util.DLAppTestUtil;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.testng.Assert;
 
 /**
  * @author Zsolt Berentey


### PR DESCRIPTION
It shouldn't be necessary to add the line to retrieve the assetEntries, but after debugging with @migue for a few hours with hibernate and spring sources we are not able to determine why is needed.

So, for now we commit this that fixes the test until we can find a better final solution.
