### PR TITLE
LPS-31497 Fix Test

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/lar/LayoutExportImportTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/LayoutExportImportTest.java
@@ -24,8 +24,8 @@ import com.liferay.portal.model.LayoutSetPrototype;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.service.ServiceTestUtil;
-import com.liferay.portal.test.EnvironmentExecutionTestListener;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.MainServletExecutionTestListener;
 import com.liferay.portal.test.TransactionalCallbackAwareExecutionTestListener;
 import com.liferay.portlet.sites.util.SitesUtil;
 
@@ -42,7 +42,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
  */
 @ExecutionTestListeners(
 	listeners = {
-		EnvironmentExecutionTestListener.class,
+		MainServletExecutionTestListener.class,
 		TransactionalCallbackAwareExecutionTestListener.class
 	})
 @PrepareForTest({PortletLocalServiceUtil.class})
@@ -200,6 +200,9 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 						layoutSetPrototypeGroup.getGroupId(),
 						ServiceTestUtil.randomString(), true, layoutPrototype,
 						layoutLinkEnabled);
+
+					layoutSetPrototypeLayout = propagateChanges(
+						layoutSetPrototypeLayout);
 
 					propagateChanges(group);
 


### PR DESCRIPTION
1) Use MainServletExecutionTestListener to load portal custom layout templates.
2) After creating a layout based on a layout prototype, changes must be propagated so that the type settings from the prototype are copied to the layout.
