### PR TITLE
LPS-31740 Fix duplicate id

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
@@ -99,7 +99,7 @@ List<LayoutPrototype> layoutPrototypes = LayoutPrototypeServiceUtil.search(compa
 			<aui:input id="addLayoutHidden" name="hidden" />
 
 			<div class="aui-helper-hidden" id="<portlet:namespace />layoutPrototypeLinkOptions">
-				<aui:input label="automatically-apply-changes-done-to-the-page-template" name="layoutPrototypeLinkEnabled" type="checkbox" value="<%= PropsValues.LAYOUT_PROTOTYPE_LINK_ENABLED_DEFAULT %>" />
+				<aui:input id="addLayoutLayoutPrototypeLinkEnabled" label="automatically-apply-changes-done-to-the-page-template" name="layoutPrototypeLinkEnabled" type="checkbox" value="<%= PropsValues.LAYOUT_PROTOTYPE_LINK_ENABLED_DEFAULT %>" />
 			</div>
 		</aui:fieldset>
 


### PR DESCRIPTION
The aui:input checkbox for "Automatically apply changes done to the page template" has the same name (and thus by default the same id) in the page details view and in the add page dialog. Since the latest is included (though hidden) in the html of the first, in order to prevent JS errors in actions on this checkbox, we have to explicitly assign it a different id in the add_layout.jsp, as done in other inputs of this view.
