### PR TITLE
LPS-32143 Fix non compatible SQL query

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeWikiAttachments.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeWikiAttachments.java
@@ -16,6 +16,7 @@ package com.liferay.portal.upgrade.v6_2_0;
 
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.v6_2_0.BaseUpgradeAttachments;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.util.PortletKeys;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.wiki.model.WikiPage;
@@ -80,9 +81,14 @@ public class UpgradeWikiAttachments extends BaseUpgradeAttachments {
 		try {
 			con = DataAccess.getUpgradeOptimizedConnection();
 
-			ps = con.prepareStatement(
-				"select resourcePrimKey, groupId, companyId, userId, " +
-					"userName, nodeId from WikiPage group by resourcePrimKey");
+			StringBundler sb = new StringBundler(4);
+
+			sb.append("select resourcePrimKey, groupId, companyId, ");
+			sb.append("MIN(userId) as userId, MIN(userName) as userName, ");
+			sb.append("nodeId from WikiPage group by resourcePrimKey, ");
+			sb.append("groupId, companyId, nodeId");
+
+			ps = con.prepareStatement(sb.toString());
 
 			rs = ps.executeQuery();
 


### PR DESCRIPTION
All the fields named in the select list must be named in the group by clause. For fields which may have multiple values in the same group, a single value criteria must be forced. Thus for userId and userName  (which may have multiple values for the same resourcePrimKey, groupId, companyId, nodeId group) the MIN function is used to select a single value.
