### PR TITLE
[WAITING FOR ANSWER] [TECHNICAL-SUPPORT] LPS-33282 Page sorting in navigation is an administrative change on a Site. It should require MANAGE_LAYOUTS permision 

### DIFF
--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -16,8 +16,6 @@
 
 <%@ include file="/html/portal/layout/view/portlet_js.jspf" %>
 
-<%@ page import="com.liferay.portlet.sites.util.SitesUtil" %>
-
 <%
 boolean hasAddLayoutPermission = GroupPermissionUtil.contains(permissionChecker, scopeGroupId, ActionKeys.ADD_LAYOUT);
 %>


### PR DESCRIPTION
Hi Julio,

I'm sending another pull request (LPS-31857) which is related to this one.

Tamás
