### PR TITLE
LPS-30833 Cannot add subpages to a site page that is linked to a site template

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -37,6 +37,7 @@ import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.comparator.LayoutPriorityComparator;
+import com.liferay.portlet.sites.util.SitesUtil;
 
 import java.util.List;
 
@@ -320,6 +321,14 @@ public class LayoutLocalServiceHelper implements IdentifiableBean {
 			if (PortalUtil.isLayoutDescendant(layout, parentLayoutId)) {
 				throw new LayoutParentLayoutIdException(
 					LayoutParentLayoutIdException.SELF_DESCENDANT);
+			}
+
+			// Layout cannot become a child of a layout which is not sortable
+			// because it is linked to a layout set prototype
+
+			if (!SitesUtil.isLayoutSortable(parentLayout)) {
+				throw new LayoutParentLayoutIdException(
+					LayoutParentLayoutIdException.NOT_SORTABLE);
 			}
 
 			// If layout is moved, the new first layout must be valid

--- a/portal-service/src/com/liferay/portal/LayoutParentLayoutIdException.java
+++ b/portal-service/src/com/liferay/portal/LayoutParentLayoutIdException.java
@@ -30,6 +30,8 @@ public class LayoutParentLayoutIdException extends PortalException {
 
 	public static final int NOT_PARENTABLE = 1;
 
+	public static final int NOT_SORTABLE = 5;
+
 	public static final int SELF_DESCENDANT = 2;
 
 	public LayoutParentLayoutIdException(int type) {


### PR DESCRIPTION
Deleting the page in the site template would cause the deletion of any custom subpages of the page in the site when changes are propagated. To prevent this issue, the operation is possible only if the link between the site and the site template is not enabled.
