### PR TITLE
LPS-33583 Fix for LayoutSetPersistenceTest

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceStagingAdvice.java
@@ -349,7 +349,11 @@ public class LayoutSetLocalServiceStagingAdvice
 			returnValue = wrapLayoutSet((LayoutSet)returnValue);
 		}
 		else if (returnValue instanceof List<?>) {
-			returnValue = wrapLayoutSets((List<LayoutSet>)returnValue);
+			List list = (List)returnValue;
+
+			if (!list.isEmpty() && (list.get(0) instanceof LayoutSet)) {
+				returnValue = wrapLayoutSets((List<LayoutSet>)returnValue);
+			}
 		}
 
 		return returnValue;


### PR DESCRIPTION
Hey Julio,

I've figured out the solution for this one as well. The actionable dynamic query was calling the service's dynamicQuery method which returned with a list of Long objects. The call was executed through the staging advice which was not prepared for such lists.

Thanks,

Máté
