### PR TITLE
LPS-30961 Portlet preferences have to be updated after updating structures

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
@@ -186,8 +186,6 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		super.doUpgrade();
-
 		try {
 			runSQL(
 				"alter_column_name JournalFeed feedType feedFormat " +
@@ -202,6 +200,8 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 
 		updateStructures();
 		updateTemplates();
+
+		super.doUpgrade();
 	}
 
 	@Override


### PR DESCRIPTION
Once the structures have been updated, the resulting ids are used to update the portlet preferences.
