### PR TITLE
LPS-33307 Source formatting other lar tests

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/lar/AssetPublisherExportImportTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/AssetPublisherExportImportTest.java
@@ -67,7 +67,7 @@ public class AssetPublisherExportImportTest
 		Map<String, String[]> preferenceMap = new HashMap<String, String[]>();
 
 		Group childGroup = GroupTestUtil.addGroup(
-			_group.getGroupId(), ServiceTestUtil.randomString());
+			group.getGroupId(), ServiceTestUtil.randomString());
 
 		preferenceMap.put(
 			"scopeIds",
@@ -77,7 +77,7 @@ public class AssetPublisherExportImportTest
 			});
 
 		PortletPreferences portletPreferences = getImportedPortletPreferences(
-			_layout, preferenceMap);
+			layout, preferenceMap);
 
 		Assert.assertEquals(null, portletPreferences.getValue("scopeId", null));
 		Assert.assertTrue(
@@ -90,7 +90,7 @@ public class AssetPublisherExportImportTest
 		Map<String, String[]> preferenceMap = new HashMap<String, String[]>();
 
 		Company company = CompanyLocalServiceUtil.getCompany(
-			_layout.getCompanyId());
+			layout.getCompanyId());
 
 		Group companyGroup = company.getGroup();
 
@@ -101,7 +101,7 @@ public class AssetPublisherExportImportTest
 			});
 
 		PortletPreferences portletPreferences = getImportedPortletPreferences(
-			_layout, preferenceMap);
+			layout, preferenceMap);
 
 		Assert.assertEquals(
 			AssetPublisher.SCOPE_ID_GROUP_PREFIX + companyGroup.getGroupId(),
@@ -113,20 +113,20 @@ public class AssetPublisherExportImportTest
 	public void testLayoutScopeId() throws Exception {
 		Map<String, String[]> preferenceMap = new HashMap<String, String[]>();
 
-		GroupTestUtil.addGroup(TestPropsValues.getUserId(), _layout);
+		GroupTestUtil.addGroup(TestPropsValues.getUserId(), layout);
 
 		preferenceMap.put(
 			"scopeIds",
 			new String[] {
-				AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX + _layout.getUuid()
+				AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX + layout.getUuid()
 			});
 
 		PortletPreferences portletPreferences = getImportedPortletPreferences(
-			_layout, preferenceMap);
+			layout, preferenceMap);
 
 		Assert.assertEquals(
 			AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX +
-			_importedLayout.getUuid(),
+			importedLayout.getUuid(),
 			portletPreferences.getValue("scopeIds", null));
 		Assert.assertEquals(null, portletPreferences.getValue("scopeId", null));
 	}
@@ -135,19 +135,19 @@ public class AssetPublisherExportImportTest
 	public void testLegacyLayoutScopeId() throws Exception {
 		Map<String, String[]> preferenceMap = new HashMap<String, String[]>();
 
-		GroupTestUtil.addGroup(TestPropsValues.getUserId(), _layout);
+		GroupTestUtil.addGroup(TestPropsValues.getUserId(), layout);
 
 		preferenceMap.put(
 			"scopeIds", new String[] {
-				AssetPublisher.SCOPE_ID_LAYOUT_PREFIX + _layout.getLayoutId()
+				AssetPublisher.SCOPE_ID_LAYOUT_PREFIX + layout.getLayoutId()
 			});
 
 		PortletPreferences portletPreferences = getImportedPortletPreferences(
-			_layout, preferenceMap);
+			layout, preferenceMap);
 
 		Assert.assertEquals(
 			AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX +
-				_importedLayout.getUuid(),
+				importedLayout.getUuid(),
 			portletPreferences.getValue("scopeIds", null));
 		Assert.assertEquals(null, portletPreferences.getValue("scopeId", null));
 	}
@@ -155,16 +155,16 @@ public class AssetPublisherExportImportTest
 	@Test
 	public void testSeveralLayoutScopeIds() throws Exception {
 		Company company = CompanyLocalServiceUtil.getCompany(
-			_layout.getCompanyId());
+			layout.getCompanyId());
 
 		Layout secondLayout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), ServiceTestUtil.randomString());
+			group.getGroupId(), ServiceTestUtil.randomString());
 
 		GroupTestUtil.addGroup(TestPropsValues.getUserId(), secondLayout);
 
 		Map<String, String[]> preferenceMap = new HashMap<String, String[]>();
 
-		GroupTestUtil.addGroup(TestPropsValues.getUserId(), _layout);
+		GroupTestUtil.addGroup(TestPropsValues.getUserId(), layout);
 
 		Group companyGroup = company.getGroup();
 
@@ -173,18 +173,18 @@ public class AssetPublisherExportImportTest
 			new String[] {
 				AssetPublisher.SCOPE_ID_GROUP_PREFIX +
 					companyGroup.getGroupId(),
-				AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX + _layout.getUuid(),
+				AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX + layout.getUuid(),
 				AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX +
 					secondLayout.getUuid()
 			});
 
 		PortletPreferences portletPreferences = getImportedPortletPreferences(
-			_layout, preferenceMap);
+			layout, preferenceMap);
 
 		Layout importedSecondLayout =
 			LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
-				secondLayout.getUuid(), _importedGroup.getGroupId(),
-				_importedLayout.isPrivateLayout());
+				secondLayout.getUuid(), importedGroup.getGroupId(),
+				importedLayout.isPrivateLayout());
 
 		Assert.assertEquals(null, portletPreferences.getValue("scopeId", null));
 
@@ -194,7 +194,7 @@ public class AssetPublisherExportImportTest
 		sb.append(companyGroup.getGroupId());
 		sb.append(StringPool.COMMA);
 		sb.append(AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX);
-		sb.append(_importedLayout.getUuid());
+		sb.append(importedLayout.getUuid());
 		sb.append(StringPool.COMMA);
 		sb.append(AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX);
 		sb.append(importedSecondLayout.getUuid());
@@ -207,36 +207,36 @@ public class AssetPublisherExportImportTest
 	@Test
 	public void testSeveralLegacyLayoutScopeIds() throws Exception {
 		Layout secondLayout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), ServiceTestUtil.randomString());
+			group.getGroupId(), ServiceTestUtil.randomString());
 
 		GroupTestUtil.addGroup(TestPropsValues.getUserId(), secondLayout);
 
 		Map<String, String[]> preferenceMap = new HashMap<String, String[]>();
 
-		GroupTestUtil.addGroup(TestPropsValues.getUserId(), _layout);
+		GroupTestUtil.addGroup(TestPropsValues.getUserId(), layout);
 
 		preferenceMap.put(
 			"scopeIds",
 			new String[] {
-				AssetPublisher.SCOPE_ID_LAYOUT_PREFIX + _layout.getLayoutId(),
+				AssetPublisher.SCOPE_ID_LAYOUT_PREFIX + layout.getLayoutId(),
 				AssetPublisher.SCOPE_ID_LAYOUT_PREFIX +
 					secondLayout.getLayoutId()
 			});
 
 		PortletPreferences portletPreferences = getImportedPortletPreferences(
-			_layout, preferenceMap);
+			layout, preferenceMap);
 
 		Layout importedSecondLayout =
 			LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
-				secondLayout.getUuid(), _importedGroup.getGroupId(),
-				_importedLayout.isPrivateLayout());
+				secondLayout.getUuid(), importedGroup.getGroupId(),
+				importedLayout.isPrivateLayout());
 
 		Assert.assertEquals(null, portletPreferences.getValue("scopeId", null));
 
 		StringBundler sb = new StringBundler(5);
 
 		sb.append(AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX);
-		sb.append(_importedLayout.getUuid());
+		sb.append(importedLayout.getUuid());
 		sb.append(StringPool.COMMA);
 		sb.append(AssetPublisher.SCOPE_ID_LAYOUT_UUID_PREFIX);
 		sb.append(importedSecondLayout.getUuid());
@@ -253,8 +253,8 @@ public class AssetPublisherExportImportTest
 		// Export site LAR
 
 		String assetPublisherPortletId = LayoutTestUtil.addPortletToLayout(
-			TestPropsValues.getUserId(), _layout, PortletKeys.ASSET_PUBLISHER,
-			"column-1", preferenceMap);
+			TestPropsValues.getUserId(), this.layout,
+			PortletKeys.ASSET_PUBLISHER, "column-1", preferenceMap);
 
 		Map<String, String[]> parameterMap =  new HashMap<String, String[]>();
 
@@ -262,26 +262,26 @@ public class AssetPublisherExportImportTest
 			PortletDataHandlerKeys.PORTLET_SETUP,
 			new String[] {Boolean.TRUE.toString()});
 
-		_larFile = LayoutLocalServiceUtil.exportLayoutsAsFile(
+		larFile = LayoutLocalServiceUtil.exportLayoutsAsFile(
 			layout.getGroupId(), layout.isPrivateLayout(), null, parameterMap,
 			null, null);
 
-		_importedGroup = GroupTestUtil.addGroup();
+		importedGroup = GroupTestUtil.addGroup();
 
 		// Import site LAR
 
 		LayoutLocalServiceUtil.importLayouts(
-			TestPropsValues.getUserId(), _importedGroup.getGroupId(),
-			layout.isPrivateLayout(), parameterMap, _larFile);
+			TestPropsValues.getUserId(), importedGroup.getGroupId(),
+			layout.isPrivateLayout(), parameterMap, larFile);
 
-		_importedLayout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
-			layout.getUuid(), _importedGroup.getGroupId(),
+		importedLayout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
+			layout.getUuid(), importedGroup.getGroupId(),
 			layout.isPrivateLayout());
 
-		Assert.assertNotNull(_importedLayout);
+		Assert.assertNotNull(importedLayout);
 
 		return LayoutTestUtil.getPortletPreferences(
-			_importedLayout.getCompanyId(), _importedLayout.getPlid(),
+			importedLayout.getCompanyId(), importedLayout.getPlid(),
 			assetPublisherPortletId);
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/lar/BasePortletExportImportTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/BasePortletExportImportTestCase.java
@@ -39,42 +39,41 @@ public class BasePortletExportImportTestCase extends PowerMockito {
 
 	@Before
 	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+		group = GroupTestUtil.addGroup();
 
-		_layout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), ServiceTestUtil.randomString());
+		layout = LayoutTestUtil.addLayout(
+			group.getGroupId(), ServiceTestUtil.randomString());
 
 		// Delete and readd to ensure a different layout ID (not ID or UUID).
 		// See LPS-32132.
 
-		LayoutLocalServiceUtil.deleteLayout(
-			_layout, true, new ServiceContext());
+		LayoutLocalServiceUtil.deleteLayout(layout, true, new ServiceContext());
 
-		_layout = LayoutTestUtil.addLayout(
-			_group.getGroupId(), ServiceTestUtil.randomString());
+		layout = LayoutTestUtil.addLayout(
+			group.getGroupId(), ServiceTestUtil.randomString());
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		try {
-			GroupLocalServiceUtil.deleteGroup(_group);
-			GroupLocalServiceUtil.deleteGroup(_importedGroup);
+			GroupLocalServiceUtil.deleteGroup(group);
+			GroupLocalServiceUtil.deleteGroup(importedGroup);
 		}
 		catch (RequiredGroupException rge) {
 		}
 
-		LayoutLocalServiceUtil.deleteLayout(_layout);
-		LayoutLocalServiceUtil.deleteLayout(_importedLayout);
+		LayoutLocalServiceUtil.deleteLayout(layout);
+		LayoutLocalServiceUtil.deleteLayout(importedLayout);
 
-		if ((_larFile != null) && _larFile.exists()) {
-			FileUtil.delete(_larFile);
+		if ((larFile != null) && larFile.exists()) {
+			FileUtil.delete(larFile);
 		}
 	}
 
-	public Group _group;
-	public Group _importedGroup;
-	public Layout _importedLayout;
-	public File _larFile;
-	public Layout _layout;
+	protected Group group;
+	protected Group importedGroup;
+	protected Layout importedLayout;
+	protected File larFile;
+	protected Layout layout;
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/journal/lar/JournalExportImportTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/lar/JournalExportImportTest.java
@@ -83,72 +83,72 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 
 		if (structuredContent) {
 			ddmStructure = DDMStructureTestUtil.addStructure(
-				_group.getGroupId(), JournalArticle.class.getName());
+				group.getGroupId(), JournalArticle.class.getName());
 
 			ddmTemplate = DDMTemplateTestUtil.addTemplate(
-				_group.getGroupId(), ddmStructure.getStructureId());
+				group.getGroupId(), ddmStructure.getStructureId());
 
 			String content = DDMStructureTestUtil.getSampleStructuredContent();
 
 			article = JournalTestUtil.addArticleWithXMLContent(
-				_group.getGroupId(), content, ddmStructure.getStructureKey(),
+				group.getGroupId(), content, ddmStructure.getStructureKey(),
 				ddmTemplate.getTemplateKey());
 		}
 		else {
 			article = JournalTestUtil.addArticle(
-				_group.getGroupId(), ServiceTestUtil.randomString(),
+				group.getGroupId(), ServiceTestUtil.randomString(),
 				ServiceTestUtil.randomString());
 		}
 
 		String exportedResourceUuid = article.getArticleResourceUuid();
 
 		Map<String, String[]> parameterMap = getExportParameterMap(
-			_group.getGroupId(), _layout.getPlid());
+			group.getGroupId(), layout.getPlid());
 
 		_larFile = LayoutLocalServiceUtil.exportPortletInfoAsFile(
-			_layout.getPlid(), _group.getGroupId(), PortletKeys.JOURNAL,
+			layout.getPlid(), group.getGroupId(), PortletKeys.JOURNAL,
 			parameterMap, null, null);
 
-		_importedGroup = GroupTestUtil.addGroup();
+		importedGroup = GroupTestUtil.addGroup();
 
-		_importedLayout = LayoutTestUtil.addLayout(
-			_importedGroup.getGroupId(), ServiceTestUtil.randomString());
+		importedLayout = LayoutTestUtil.addLayout(
+			importedGroup.getGroupId(), ServiceTestUtil.randomString());
 
 		int initialArticlesCount =
 			JournalArticleLocalServiceUtil.getArticlesCount(
-				_importedGroup.getGroupId());
+				importedGroup.getGroupId());
 
 		PortletImporter portletImporter = new PortletImporter();
 
 		parameterMap = getImportParameterMap(
-			_importedGroup.getGroupId(), _importedLayout.getPlid());
+			importedGroup.getGroupId(), importedLayout.getPlid());
 
 		portletImporter.importPortletInfo(
-			TestPropsValues.getUserId(), _importedLayout.getPlid(),
-			_importedGroup.getGroupId(), PortletKeys.JOURNAL, parameterMap,
+			TestPropsValues.getUserId(), importedLayout.getPlid(),
+			importedGroup.getGroupId(), PortletKeys.JOURNAL, parameterMap,
 			_larFile);
 
 		int articlesCount = JournalArticleLocalServiceUtil.getArticlesCount(
-			_importedGroup.getGroupId());
+			importedGroup.getGroupId());
 
 		Assert.assertEquals(initialArticlesCount + 1, articlesCount);
 
 		JournalArticleResource importedJournalArticleResource =
 			JournalArticleResourceLocalServiceUtil.fetchArticleResource(
-				exportedResourceUuid, _importedGroup.getGroupId());
+				exportedResourceUuid, importedGroup.getGroupId());
 
 		Assert.assertNotNull(importedJournalArticleResource);
 
 		if (structuredContent) {
 			DDMStructure importedDDMStructure =
 				DDMStructureLocalServiceUtil.fetchStructure(
-					ddmStructure.getUuid(), _importedGroup.getGroupId());
+					ddmStructure.getUuid(), importedGroup.getGroupId());
 
 			Assert.assertNotNull(importedDDMStructure);
 
 			DDMTemplate importedDDMTemplate =
 				DDMTemplateLocalServiceUtil.fetchTemplate(
-					ddmTemplate.getUuid(), _importedGroup.getGroupId());
+					ddmTemplate.getUuid(), importedGroup.getGroupId());
 
 			Assert.assertNotNull(importedDDMTemplate);
 			Assert.assertEquals(


### PR DESCRIPTION
1) Use '_' prefix only to name private members.
2) Use protected instead of public if only member visibility in subclasses is required.

I performed automatic replace, except for AssetPublisherExportImportTest#getImportedPortletPreferences where "layout" is a parameter, so I used this.layout to replace _layout.
