### PR TITLE
LPS-34903 make portal script textarea wider, higher and resizable

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -1390,6 +1390,7 @@
 		<private-request-attributes>false</private-request-attributes>
 		<private-session-attributes>false</private-session-attributes>
 		<render-weight>50</render-weight>
+		<header-portlet-css>/html/portlet/admin/css/main.css</header-portlet-css>
 		<footer-portlet-javascript>/html/portlet/admin/js/main.js</footer-portlet-javascript>
 		<css-class-wrapper>portlet-admin</css-class-wrapper>
 	</portlet>

--- a/portal-web/docroot/html/portlet/admin/css/main.css
+++ b/portal-web/docroot/html/portlet/admin/css/main.css
@@ -1,0 +1,5 @@
+.aui-form .aui-fieldset .aui-field.lfr-textarea-container.portal-script textarea {
+    height: 200px;
+    max-width: 2500px;
+    width: 750px;
+}

--- a/portal-web/docroot/html/portlet/admin/server.jspf
+++ b/portal-web/docroot/html/portlet/admin/server.jspf
@@ -711,7 +711,7 @@ serverURL.setParameter("tabs3", tabs3);
 
 					</aui:select>
 
-					<aui:input cssClass="lfr-textarea-container" name="script" type="textarea" value="<%= script %>" />
+					<aui:input cssClass="lfr-textarea-container portal-script" name="script" type="textarea" value="<%= script %>" />
 				</aui:fieldset>
 
 				<c:if test="<%= Validator.isNotNull(scriptOutput) %>">


### PR DESCRIPTION
Hi Julio,

the main advantage I see in this pull is removing the restriction of max-width for the script's textarea. I've also made the default dimensions bigger:

was: 500px wide, 100px high
now: 750px wide, 200px high

Hope you find this usefull,
Josef
