### PR TITLE
[TECH SUPPORT] LPS-34960 Status changing when importing article is being imported

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -440,26 +440,26 @@ public class JournalArticleLocalServiceImpl
 
 		// Workflow
 
-		if (!ExportImportThreadLocal.isImportInProcess()) {
-			if (classNameId == JournalArticleConstants.CLASSNAME_ID_DEFAULT) {
+		if (classNameId == JournalArticleConstants.CLASSNAME_ID_DEFAULT) {
+			if (!ExportImportThreadLocal.isImportInProcess()) {
 				WorkflowHandlerRegistryUtil.startWorkflowInstance(
 					user.getCompanyId(), groupId, userId,
 					JournalArticle.class.getName(), article.getId(), article,
 					serviceContext);
-
-				if (serviceContext.getWorkflowAction() !=
-						WorkflowConstants.ACTION_PUBLISH) {
-
-					// Indexer
-
-					reindex(article);
-				}
 			}
-			else {
-				updateStatus(
-					userId, article, WorkflowConstants.STATUS_APPROVED, null,
-					new HashMap<String, Serializable>(), serviceContext);
+
+			if (serviceContext.getWorkflowAction() !=
+					WorkflowConstants.ACTION_PUBLISH) {
+
+				// Indexer
+
+				reindex(article);
 			}
+		}
+		else {
+			updateStatus(
+				userId, article, WorkflowConstants.STATUS_APPROVED, null,
+				new HashMap<String, Serializable>(), serviceContext);
 		}
 
 		return getArticle(article.getPrimaryKey());

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -440,24 +440,26 @@ public class JournalArticleLocalServiceImpl
 
 		// Workflow
 
-		if (classNameId == JournalArticleConstants.CLASSNAME_ID_DEFAULT) {
-			WorkflowHandlerRegistryUtil.startWorkflowInstance(
-				user.getCompanyId(), groupId, userId,
-				JournalArticle.class.getName(), article.getId(), article,
-				serviceContext);
+		if (!ExportImportThreadLocal.isImportInProcess()) {
+			if (classNameId == JournalArticleConstants.CLASSNAME_ID_DEFAULT) {
+				WorkflowHandlerRegistryUtil.startWorkflowInstance(
+					user.getCompanyId(), groupId, userId,
+					JournalArticle.class.getName(), article.getId(), article,
+					serviceContext);
 
-			if (serviceContext.getWorkflowAction() !=
-					WorkflowConstants.ACTION_PUBLISH) {
+				if (serviceContext.getWorkflowAction() !=
+						WorkflowConstants.ACTION_PUBLISH) {
 
-				// Indexer
+					// Indexer
 
-				reindex(article);
+					reindex(article);
+				}
 			}
-		}
-		else {
-			updateStatus(
-				userId, article, WorkflowConstants.STATUS_APPROVED, null,
-				new HashMap<String, Serializable>(), serviceContext);
+			else {
+				updateStatus(
+					userId, article, WorkflowConstants.STATUS_APPROVED, null,
+					new HashMap<String, Serializable>(), serviceContext);
+			}
 		}
 
 		return getArticle(article.getPrimaryKey());


### PR DESCRIPTION
Hey Julio,

This is a bug fix from the support. It seems valid for me, but I'd like to ask your opinion about it. We are exporting expired articles as well (if the article is auto-expiring we will need it on the target system) and during import a workflow process is being started for the expired content. It will change the status of it, or at least this is not necessary.

Zsolt Balogh created a fix for this, but I've refactored because I think this would be a regression bug for the structure default values, I think on import it should be updated as originally.

Thanks,

Máté
