### PR TITLE
LPS-34920 Fix wrong SQL

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyResourcePermissions.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyResourcePermissions.java
@@ -103,7 +103,7 @@ public class VerifyResourcePermissions extends VerifyProcess {
 			ps = con.prepareStatement(
 				"update ResourcePermission set actionIds = ? where name = ? " +
 					"and roleId in (select roleId from Role_ where name = ?) " +
-						"and primKey != 0");
+						"and primKey != '0'");
 
 			ps.setLong(1, GetterUtil.getLong(actionId));
 			ps.setString(2, portlet);


### PR DESCRIPTION
Hi Julio,

I'm not sure if this was the idea behind the condition primKey != 0 but that condition is definitely wrong, since primKey is a varchar column...
