### PR TITLE
LPS-36194 Use proper class name when getting summary count

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandler.java
@@ -71,7 +71,7 @@ public class DLPortletDataHandler extends BasePortletDataHandler {
 		setExportControls(
 			new PortletDataHandlerBoolean(
 				NAMESPACE, "documents", true, false, null,
-				DLFileEntry.class.getName()),
+				FileEntry.class.getName()),
 			new PortletDataHandlerBoolean(
 				NAMESPACE, "shortcuts", true, false, null,
 				DLFileShortcut.class.getName()),


### PR DESCRIPTION
Hey Julio,

this is the huge fix:) for counting document library's file entries (or to display the already fetched number).

thanks,
Daniel
