### PR TITLE
LPS-37409 Move BackgroundTaskStatusRegistryImpl to com.liferay.portal.backgroundtask in order to resolve portal startup error

### DIFF
--- a/portal-impl/src/com/liferay/portal/backgroundtask/BackgroundTaskStatusRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/backgroundtask/BackgroundTaskStatusRegistryImpl.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.backgroundtask.status;
+package com.liferay.portal.backgroundtask;
 
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatus;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusRegistry;


### PR DESCRIPTION
Hi Julio,

Current trunk didn't startup this morning and after some investigation I stumbled upon this commit: https://github.com/juliocamarero/liferay-portal/commit/e993c800aab61c176de07cef995595b99595aedd.

Brian might have wanted to move BTSR\* from "com.liferay.portal.backgroundtask.status" to "com.liferay.portal.backgroundtask", but BTSRI remained in its old place.

Thanks,
Laszlo
