### PR TITLE
LPS-37797

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4533,13 +4533,6 @@ public class JournalArticleLocalServiceImpl
 				JournalArticle.class.getName(), article.getId(), article,
 				serviceContext);
 		}
-		else if (article.getVersion() ==
-					JournalArticleConstants.VERSION_DEFAULT) {
-
-			// Indexer
-
-			reindex(article);
-		}
 
 		return article;
 	}


### PR DESCRIPTION
[TECHNICAL-SUPPORT] Currently, WC search is through DB by default because enabling journal.articles.search.with.index=true causes that expired content is not retrieved, this will be implemented as New Feature through LPS-27261. This code should be removed because causes a different bug. Normally DEFAULT_VERSION (1.0) is indexed in the method updateStatus invoked by com.liferay.portlet.journal.service.impl.JournalArticleLocalServiceImpl.addArticle()
