### PR TITLE
LPS-37944 Structure can be in the company group as well

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/action/EditArticleAction.java
+++ b/portal-impl/src/com/liferay/portlet/journal/action/EditArticleAction.java
@@ -760,11 +760,26 @@ public class EditArticleAction extends PortletAction {
 			}
 			else {
 				if (curArticle.isTemplateDriven()) {
-					DDMStructure ddmStructure =
-						DDMStructureLocalServiceUtil.getStructure(
-							groupId,
-							PortalUtil.getClassNameId(JournalArticle.class),
-							structureId);
+					DDMStructure ddmStructure = null;
+
+					try {
+						ddmStructure =
+							DDMStructureLocalServiceUtil.getStructure(
+								groupId,
+								PortalUtil.getClassNameId(JournalArticle.class),
+								structureId);
+					}
+					catch (NoSuchStructureException nsse) {
+						ThemeDisplay themeDisplay =
+							(ThemeDisplay)actionRequest.getAttribute(
+								WebKeys.THEME_DISPLAY);
+
+						ddmStructure =
+							DDMStructureLocalServiceUtil.getStructure(
+								themeDisplay.getCompanyGroupId(),
+								PortalUtil.getClassNameId(JournalArticle.class),
+								structureId);
+					}
 
 					Fields newFields = DDMUtil.getFields(
 						ddmStructure.getStructureId(), serviceContext);


### PR DESCRIPTION
Hey Julio,

this is a small issue I found during global scope tests. If you have an article has a global scope structure and you click on edit then you can't save the article. I stole the solution from the edit_article.jsp:)

thanks,
Daniel
