### PR TITLE
LPS-37901 Correct test fix

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/lar/BasePrototypePropagationTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/BasePrototypePropagationTestCase.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.lar;
 
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
@@ -197,6 +198,8 @@ public abstract class BasePrototypePropagationTestCase extends PowerMockito {
 			LayoutTestUtil.getPortletPreferences(
 				prototypeLayout, journalContentPortletId);
 
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
 		layoutSetPrototypePortletPreferences.setValue(
 			"articleId", StringPool.BLANK);
 
@@ -246,6 +249,8 @@ public abstract class BasePrototypePropagationTestCase extends PowerMockito {
 	}
 
 	protected Layout propagateChanges(Layout layout) throws Exception {
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
 		return LayoutLocalServiceUtil.getLayout(layout.getPlid());
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.lar;
 
+import com.liferay.portal.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -278,6 +279,8 @@ public class LayoutSetPrototypePropagationTest
 			boolean layoutSetLayoutLinkEnabled)
 		throws Exception {
 
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
 		Layout layoutSetPrototypeLayout = LayoutTestUtil.addLayout(
 			_layoutSetPrototypeGroup.getGroupId(),
 			ServiceTestUtil.randomString(), true, layoutPrototype,
@@ -347,6 +350,8 @@ public class LayoutSetPrototypePropagationTest
 	}
 
 	protected void propagateChanges(Group group) throws Exception {
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
 		LayoutLocalServiceUtil.getLayouts(
 			group.getGroupId(), false,
 			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);

--- a/portal-service/src/com/liferay/portal/kernel/staging/MergeLayoutPrototypesThreadLocal.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/MergeLayoutPrototypesThreadLocal.java
@@ -25,6 +25,10 @@ import java.util.Set;
  */
 public class MergeLayoutPrototypesThreadLocal {
 
+	public static void clearMergeComplete() {
+		_mergeComplete.remove();
+	}
+
 	public static boolean isInProgress() {
 		return _inProgress.get();
 	}


### PR DESCRIPTION
Hey Julio,

As you seen my email about clearing the thread locals in tests, I'm going to send a PR to Miguel with the test framework addition later, but in the meantime I've fixed the Layout and LayoutSetPrototypePropagation tests, so I'm submitting this to you, and later on I'll submit the changes to Miguel.

Although, I've described the problem in the ticket, I'm adding the root cause here as well just for the record; the original problem was we record the information if a layout prototype has been propagated in a thread local variable. Due to the nature of the tests we are propagating the prototypes multiple times but any subsequent propagation after the first one won't run because it has been already completed, so the test will fail. So after all the problem is not the test logic, and I haven't touched it.

Once I'm clearing the thread local the tests are running correctly.

This situation should never happen when using the portal normally according to the request/response style of the operation and the fact that the new requests will be executed in new threads.

Thanks,

Máté

cc: @epgarcia
