### PR TITLE
LPS-37434 Remote staging in background

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar.backgroundtask;
+
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatus;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusRegistryUtil;
+import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.lar.MissingReference;
+import com.liferay.portal.kernel.lar.MissingReferences;
+import com.liferay.portal.kernel.staging.StagingUtil;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.model.BackgroundTask;
+import com.liferay.portal.service.LayoutLocalServiceUtil;
+
+import java.io.File;
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * @author Julio Camarero
+ */
+public class LayoutRemoteStagingBackgroundTaskExecutor
+	extends BaseBackgroundTaskExecutor {
+
+	public LayoutRemoteStagingBackgroundTaskExecutor() {
+		setBackgroundTaskStatusMessageTranslator(
+			new DefaultExportImportBackgroundTaskStatusMessageTranslator());
+
+		setSerial(true);
+	}
+
+	@Override
+	public BackgroundTaskResult execute(BackgroundTask backgroundTask)
+		throws Exception {
+
+		Map<String, Serializable> taskContextMap =
+			backgroundTask.getTaskContextMap();
+
+		long userId = MapUtil.getLong(taskContextMap, "userId");
+		long targetGroupId = MapUtil.getLong(taskContextMap, "targetGroupId");
+
+		StagingUtil.lockGroup(userId, targetGroupId);
+
+		long sourceGroupId = MapUtil.getLong(taskContextMap, "sourceGroupId");
+		boolean privateLayout = MapUtil.getBoolean(
+			taskContextMap, "privateLayout");
+		long[] layoutIds = GetterUtil.getLongValues(
+			taskContextMap.get("layoutIds"));
+		Map<String, String[]> parameterMap =
+			(Map<String, String[]>)taskContextMap.get("parameterMap");
+		Date startDate = (Date)taskContextMap.get("startDate");
+		Date endDate = (Date)taskContextMap.get("endDate");
+
+		BackgroundTaskStatus backgroundTaskStatus =
+			BackgroundTaskStatusRegistryUtil.getBackgroundTaskStatus(
+				backgroundTask.getBackgroundTaskId());
+
+		backgroundTaskStatus.clearAttributes();
+
+		File file = null;
+		MissingReferences missingReferences = null;
+
+		try {
+			file = LayoutLocalServiceUtil.exportLayoutsAsFile(
+				sourceGroupId, privateLayout, layoutIds, parameterMap,
+				startDate, endDate);
+
+			missingReferences =
+				LayoutLocalServiceUtil.validateImportLayoutsFile(
+					userId, targetGroupId, privateLayout, parameterMap,
+					file);
+
+			LayoutLocalServiceUtil.importLayouts(
+				userId, targetGroupId, privateLayout, parameterMap, file);
+		}
+		finally {
+			FileUtil.delete(file);
+
+			StagingUtil.unlockGroup(targetGroupId);
+		}
+
+		BackgroundTaskResult backgroundTaskResult = new BackgroundTaskResult(
+			BackgroundTaskConstants.STATUS_SUCCESSFUL);
+
+		Map<String, MissingReference> weakMissingReferences =
+			missingReferences.getWeakMissingReferences();
+
+		if ((weakMissingReferences != null) &&
+			!weakMissingReferences.isEmpty()) {
+
+			JSONArray jsonArray = StagingUtil.getWarningMessagesJSONArray(
+				getLocale(backgroundTask), weakMissingReferences,
+				backgroundTask.getTaskContextMap());
+
+			backgroundTaskResult.setStatusMessage(jsonArray.toString());
+		}
+
+		return backgroundTaskResult;
+	}
+
+	@Override
+	public String handleException(BackgroundTask backgroundTask, Exception e) {
+		JSONObject jsonObject = StagingUtil.getExceptionMessagesJSONObject(
+			getLocale(backgroundTask), e, backgroundTask.getTaskContextMap());
+
+		return jsonObject.toString();
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -229,6 +229,18 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 		}
 	}
 
+	protected long[] getLayoutIds(List<Layout> layouts) {
+		long[] layoutIds = new long[layouts.size()];
+
+		for (int i = 0; i < layouts.size(); i++) {
+			Layout layout = layouts.get(i);
+
+			layoutIds[i] = layout.getLayoutId();
+		}
+
+		return layoutIds;
+	}
+
 	/**
 	 * @see #getMissingParentLayouts(Layout, long)
 	 */

--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutStagingBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutStagingBackgroundTaskExecutor.java
@@ -77,24 +77,23 @@ public class LayoutStagingBackgroundTaskExecutor
 
 		backgroundTaskStatus.clearAttributes();
 
-		File larFile = null;
+		File file = null;
 		MissingReferences missingReferences = null;
 
 		try {
-			larFile = LayoutLocalServiceUtil.exportLayoutsAsFile(
+			file = LayoutLocalServiceUtil.exportLayoutsAsFile(
 				sourceGroupId, privateLayout, layoutIds, parameterMap,
 				startDate, endDate);
 
 			missingReferences =
 				LayoutLocalServiceUtil.validateImportLayoutsFile(
-					userId, targetGroupId, privateLayout, parameterMap,
-					larFile);
+					userId, targetGroupId, privateLayout, parameterMap, file);
 
 			LayoutLocalServiceUtil.importLayouts(
-				userId, targetGroupId, privateLayout, parameterMap, larFile);
+				userId, targetGroupId, privateLayout, parameterMap, file);
 		}
 		finally {
-			FileUtil.delete(larFile);
+			FileUtil.delete(file);
 
 			StagingUtil.unlockGroup(targetGroupId);
 		}

--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutStagingBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutStagingBackgroundTaskExecutor.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.lar.MissingReference;
 import com.liferay.portal.kernel.lar.MissingReferences;
 import com.liferay.portal.kernel.staging.StagingUtil;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.model.BackgroundTask;
@@ -70,19 +71,20 @@ public class LayoutStagingBackgroundTaskExecutor
 		Date startDate = (Date)taskContextMap.get("startDate");
 		Date endDate = (Date)taskContextMap.get("endDate");
 
-		File larFile = LayoutLocalServiceUtil.exportLayoutsAsFile(
-			sourceGroupId, privateLayout, layoutIds, parameterMap, startDate,
-			endDate);
-
 		BackgroundTaskStatus backgroundTaskStatus =
 			BackgroundTaskStatusRegistryUtil.getBackgroundTaskStatus(
 				backgroundTask.getBackgroundTaskId());
 
 		backgroundTaskStatus.clearAttributes();
 
+		File larFile = null;
 		MissingReferences missingReferences = null;
 
 		try {
+			larFile = LayoutLocalServiceUtil.exportLayoutsAsFile(
+				sourceGroupId, privateLayout, layoutIds, parameterMap,
+				startDate, endDate);
+
 			missingReferences =
 				LayoutLocalServiceUtil.validateImportLayoutsFile(
 					userId, targetGroupId, privateLayout, parameterMap,
@@ -92,7 +94,7 @@ public class LayoutStagingBackgroundTaskExecutor
 				userId, targetGroupId, privateLayout, parameterMap, larFile);
 		}
 		finally {
-			larFile.delete();
+			FileUtil.delete(larFile);
 
 			StagingUtil.unlockGroup(targetGroupId);
 		}

--- a/portal-impl/src/com/liferay/portal/security/auth/HttpPrincipal.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/HttpPrincipal.java
@@ -26,6 +26,9 @@ import java.io.Serializable;
  */
 public class HttpPrincipal implements Serializable {
 
+	public HttpPrincipal() {
+	}
+
 	public HttpPrincipal(String url) {
 		_url = url;
 	}

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -848,6 +848,16 @@ public class StagingImpl implements Staging {
 				locale, "please-import-a-lar-file-for-the-current-portlet");
 			errorType = ServletResponseConstants.SC_FILE_CUSTOM_EXCEPTION;
 		}
+		else if (e instanceof RemoteExportException) {
+			RemoteExportException ree = (RemoteExportException)e;
+
+			errorType = ServletResponseConstants.SC_FILE_CUSTOM_EXCEPTION;
+
+			if (ree.getType() == RemoteExportException.NO_LAYOUTS) {
+				errorMessage = LanguageUtil.get(
+					locale, "no-pages-are-selected-for-export");
+			}
+		}
 		else {
 			errorType = ServletResponseConstants.SC_FILE_CUSTOM_EXCEPTION;
 		}

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -313,62 +313,6 @@ public class StagingImpl implements Staging {
 
 			throw ree;
 		}
-
-		long stagingRequestId = 0;
-
-		File file = null;
-
-		FileInputStream fileInputStream = null;
-
-		try {
-			file = exportLayoutsAsFile(
-				sourceGroupId, privateLayout, layoutIdMap, parameterMap,
-				remoteGroupId, startDate, endDate, httpPrincipal);
-
-			String checksum = FileUtil.getMD5Checksum(file);
-
-			fileInputStream = new FileInputStream(file);
-
-			stagingRequestId = StagingServiceHttp.createStagingRequest(
-				httpPrincipal, remoteGroupId, checksum);
-
-			byte[] bytes =
-				new byte[PropsValues.STAGING_REMOTE_TRANSFER_BUFFER_SIZE];
-
-			int i = 0;
-
-			while ((i = fileInputStream.read(bytes)) >= 0) {
-				if (i < PropsValues.STAGING_REMOTE_TRANSFER_BUFFER_SIZE) {
-					byte[] tempBytes = new byte[i];
-
-					System.arraycopy(bytes, 0, tempBytes, 0, i);
-
-					StagingServiceHttp.updateStagingRequest(
-						httpPrincipal, stagingRequestId, file.getName(),
-						tempBytes);
-				}
-				else {
-					StagingServiceHttp.updateStagingRequest(
-						httpPrincipal, stagingRequestId, file.getName(), bytes);
-				}
-
-				bytes =
-					new byte[PropsValues.STAGING_REMOTE_TRANSFER_BUFFER_SIZE];
-			}
-
-			StagingServiceHttp.publishStagingRequest(
-				httpPrincipal, stagingRequestId, privateLayout, parameterMap);
-		}
-		finally {
-			StreamUtil.cleanUp(fileInputStream);
-
-			FileUtil.delete(file);
-
-			if (stagingRequestId > 0) {
-				StagingServiceHttp.cleanUpStagingRequest(
-					httpPrincipal, stagingRequestId);
-			}
-		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -2037,62 +2037,6 @@ public class StagingImpl implements Staging {
 		}
 	}
 
-	protected File exportLayoutsAsFile(
-			long sourceGroupId, boolean privateLayout,
-			Map<Long, Boolean> layoutIdMap, Map<String, String[]> parameterMap,
-			long remoteGroupId, Date startDate, Date endDate,
-			HttpPrincipal httpPrincipal)
-		throws Exception {
-
-		if ((layoutIdMap == null) || layoutIdMap.isEmpty()) {
-			return LayoutLocalServiceUtil.exportLayoutsAsFile(
-				sourceGroupId, privateLayout, null, parameterMap, startDate,
-				endDate);
-		}
-		else {
-			List<Layout> layouts = new ArrayList<Layout>();
-
-			for (Map.Entry<Long, Boolean> entry : layoutIdMap.entrySet()) {
-				long plid = GetterUtil.getLong(String.valueOf(entry.getKey()));
-				boolean includeChildren = entry.getValue();
-
-				Layout layout = LayoutLocalServiceUtil.getLayout(plid);
-
-				if (!layouts.contains(layout)) {
-					layouts.add(layout);
-				}
-
-				List<Layout> parentLayouts = getMissingRemoteParentLayouts(
-					httpPrincipal, layout, remoteGroupId);
-
-				for (Layout parentLayout : parentLayouts) {
-					if (!layouts.contains(parentLayout)) {
-						layouts.add(parentLayout);
-					}
-				}
-
-				if (includeChildren) {
-					for (Layout childLayout : layout.getAllChildren()) {
-						if (!layouts.contains(childLayout)) {
-							layouts.add(childLayout);
-						}
-					}
-				}
-			}
-
-			long[] layoutIds = getLayoutIds(layouts);
-
-			if (layoutIds.length <= 0) {
-				throw new RemoteExportException(
-					RemoteExportException.NO_LAYOUTS);
-			}
-
-			return LayoutLocalServiceUtil.exportLayoutsAsFile(
-				sourceGroupId, privateLayout, layoutIds, parameterMap,
-				startDate, endDate);
-		}
-	}
-
 	protected boolean getBoolean(
 		PortletRequest portletRequest, Group group, String param) {
 
@@ -2127,40 +2071,6 @@ public class StagingImpl implements Staging {
 		return ParamUtil.getLong(
 			portletRequest, param,
 			GetterUtil.getLong(group.getTypeSettingsProperty(param)));
-	}
-
-	/**
-	 * @see #getMissingParentLayouts(Layout, long)
-	 */
-	protected List<Layout> getMissingRemoteParentLayouts(
-			HttpPrincipal httpPrincipal, Layout layout, long remoteGroupId)
-		throws Exception {
-
-		List<Layout> missingRemoteParentLayouts = new ArrayList<Layout>();
-
-		long parentLayoutId = layout.getParentLayoutId();
-
-		while (parentLayoutId > 0) {
-			Layout parentLayout = LayoutLocalServiceUtil.getLayout(
-				layout.getGroupId(), layout.isPrivateLayout(), parentLayoutId);
-
-			try {
-				LayoutServiceHttp.getLayoutByUuidAndGroupId(
-					httpPrincipal, parentLayout.getUuid(), remoteGroupId,
-					parentLayout.getPrivateLayout());
-
-				// If one parent is found all others are assumed to exist
-
-				break;
-			}
-			catch (NoSuchLayoutException nsle) {
-				missingRemoteParentLayouts.add(parentLayout);
-
-				parentLayoutId = parentLayout.getParentLayoutId();
-			}
-		}
-
-		return missingRemoteParentLayouts;
 	}
 
 	protected PortalPreferences getPortalPreferences(User user)

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -185,10 +185,6 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 							<%= LanguageUtil.format(pageContext, "remote-group-with-id-x-does-not-exist", ree.getGroupId()) %>
 						</c:if>
 
-						<c:if test="<%= ree.getType() == RemoteExportException.NO_LAYOUTS %>">
-							<liferay-ui:message key="no-pages-are-selected-for-export" />
-						</c:if>
-
 						<c:if test="<%= ree.getType() == RemoteExportException.NO_PERMISSIONS %>">
 							<liferay-ui:message arguments="<%= ree.getGroupId() %>" key="you-do-not-have-permissions-to-edit-the-site-with-id-x-on-the-remote-server" />
 						</c:if>

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
@@ -103,10 +103,6 @@ boolean hasViewPagesPermission = (pagesCount > 0) && (liveGroup.isStaged() || se
 			<%= LanguageUtil.format(pageContext, "remote-group-with-id-x-does-not-exist", ree.getGroupId()) %>
 		</c:if>
 
-		<c:if test="<%= ree.getType() == RemoteExportException.NO_LAYOUTS %>">
-			<liferay-ui:message key="no-pages-are-selected-for-export" />
-		</c:if>
-
 		<c:if test="<%= ree.getType() == RemoteExportException.NO_PERMISSIONS %>">
 			<liferay-ui:message arguments="<%= ree.getGroupId() %>" key="you-do-not-have-permissions-to-edit-the-site-with-id-x-on-the-remote-server" />
 		</c:if>

--- a/portal-web/docroot/html/portlet/layouts_admin/init.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/init.jsp
@@ -62,6 +62,7 @@ page import="com.liferay.portal.kernel.util.MapUtil" %><%@
 page import="com.liferay.portal.lar.LayoutExporter" %><%@
 page import="com.liferay.portal.lar.backgroundtask.LayoutExportBackgroundTaskExecutor" %><%@
 page import="com.liferay.portal.lar.backgroundtask.LayoutImportBackgroundTaskExecutor" %><%@
+page import="com.liferay.portal.lar.backgroundtask.LayoutRemoteStagingBackgroundTaskExecutor" %><%@
 page import="com.liferay.portal.lar.backgroundtask.LayoutStagingBackgroundTaskExecutor" %><%@
 page import="com.liferay.portal.layoutconfiguration.util.RuntimePageUtil" %><%@
 page import="com.liferay.portal.util.LayoutLister" %><%@

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
@@ -439,6 +439,7 @@ response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 			<liferay-util:include page="/html/portlet/layouts_admin/publish_layouts_processes.jsp">
 				<liferay-util:param name="groupId" value="<%= String.valueOf(stagingGroupId) %>" />
 				<liferay-util:param name="closeRedirect" value="<%= closeRedirect %>" />
+				<liferay-util:param name="localPublishing" value="<%= String.valueOf(localPublishing) %>" />
 			</liferay-util:include>
 		</div>
 	</liferay-ui:section>

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
@@ -281,10 +281,6 @@ response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 					<liferay-ui:message arguments="<%= ree.getGroupId() %>" key="no-site-exists-on-the-remote-server-with-site-id-x" />
 				</c:if>
 
-				<c:if test="<%= ree.getType() == RemoteExportException.NO_LAYOUTS %>">
-					<liferay-ui:message key="there-are-no-layouts-in-the-exported-data" />
-				</c:if>
-
 				<c:if test="<%= ree.getType() == RemoteExportException.NO_PERMISSIONS %>">
 					<liferay-ui:message arguments="<%= ree.getGroupId() %>" key="you-do-not-have-permissions-to-edit-the-site-with-id-x-on-the-remote-server" />
 				</c:if>

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts_processes.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts_processes.jsp
@@ -19,6 +19,7 @@
 <%
 String closeRedirect = ParamUtil.getString(request, "closeRedirect");
 long groupId = ParamUtil.getLong(request, "groupId");
+boolean localPublishing = ParamUtil.getBoolean(request, "localPublishing");
 
 PortletURL renderURL = liferayPortletResponse.createRenderURL();
 
@@ -40,6 +41,8 @@ else {
 }
 
 OrderByComparator orderByComparator = BackgroundTaskUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
+
+String backgroundTaskExecutorClassName = localPublishing ? LayoutStagingBackgroundTaskExecutor.class.getName() : LayoutRemoteStagingBackgroundTaskExecutor.class.getName();
 %>
 
 <liferay-ui:search-container
@@ -48,10 +51,10 @@ OrderByComparator orderByComparator = BackgroundTaskUtil.getBackgroundTaskOrderB
 	orderByCol="<%= orderByCol %>"
 	orderByComparator="<%= orderByComparator %>"
 	orderByType="<%= orderByType %>"
-	total="<%= BackgroundTaskLocalServiceUtil.getBackgroundTasksCount(groupId, LayoutStagingBackgroundTaskExecutor.class.getName()) %>"
+	total="<%= BackgroundTaskLocalServiceUtil.getBackgroundTasksCount(groupId, backgroundTaskExecutorClassName) %>"
 >
 	<liferay-ui:search-container-results
-		results="<%= BackgroundTaskLocalServiceUtil.getBackgroundTasks(groupId, LayoutStagingBackgroundTaskExecutor.class.getName(), searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator()) %>"
+		results="<%= BackgroundTaskLocalServiceUtil.getBackgroundTasks(groupId, backgroundTaskExecutorClassName, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator()) %>"
 	/>
 
 	<liferay-ui:search-container-row


### PR DESCRIPTION
Hey Julio,

I've squashed some commits, but nothing big change.

The only thing I've modified the exception handling - the remote exceptions. 3 of them are being thrown in before we kick off the background task. Before we do anything we check the connection status for example. I did not move that to the background task executor since they user should know if the connection has a problem before the background task. If that's ok then kick off the background task.
I did remove the NO_LAYOUTS exception handling from the jsps though because it will be thrown from the background task so it does not make sense to keep it there.

Besides that everything is the same.

Thanks,

Máté
