### PR TITLE
LPS-38191 Fix markup in order to be valid

### DIFF
--- a/portal-web/docroot/html/portlet/site_map/view.jsp
+++ b/portal-web/docroot/html/portlet/site_map/view.jsp
@@ -84,9 +84,9 @@ private void _buildSiteMap(Layout layout, List<Layout> layouts, Layout rootLayou
 
 		_buildLayoutView(rootLayout, cssClass, useHtmlTitle, themeDisplay, sb);
 
-		sb.append("</li>");
-
 		_buildSiteMap(layout, layouts, rootLayout, includeRootInTree, displayDepth, showCurrentPage, useHtmlTitle, showHiddenPages, curDepth +1, themeDisplay, sb);
+
+		sb.append("</li>");
 	}
 	else {
 		for (Layout curLayout : layouts) {


### PR DESCRIPTION
UL elements are not allowed insied UL elements, so the change is based on include the nested ul inside the root li element
