### PR TITLE
LPS-38284 - Checks if event and domEvent are available on asset_tags_selector

### DIFF
--- a/portal-web/docroot/html/js/liferay/asset_tags_selector.js
+++ b/portal-web/docroot/html/js/liferay/asset_tags_selector.js
@@ -370,7 +370,11 @@ AUI.add(
 					_onAddEntryClick: function(event) {
 						var instance = this;
 
-						event.domEvent.preventDefault();
+						var domEvent = event ? event.domEvent : null;
+
+						if (domEvent) {
+							domEvent.preventDefault();
+						}
 
 						var text = Liferay.Util.escapeHTML(instance.inputNode.val());
 


### PR DESCRIPTION
Hey, @natecavanaugh, we are pushing this since it's blocking a lot of functionality. Could you please review later today in case you'd rather fix it differently?

Thanks!
