### PR TITLE
LPS-38385 Cannot publish remote staging & remote staging is not showed for a group when on the UI

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -49,9 +49,11 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -281,7 +283,17 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			friendlyURL);
 
 		if (staging) {
-			name = name.concat(" (Staging)");
+			StringBundler sb = new StringBundler();
+
+			sb.append(name);
+			sb.append(StringPool.SPACE);
+			sb.append(StringPool.OPEN_PARENTHESIS);
+			sb.append(
+				LanguageUtil.get(LocaleThreadLocal.getDefaultLocale(),
+				"staging"));
+			sb.append(StringPool.CLOSE_PARENTHESIS);
+
+			name = sb.toString();
 			friendlyURL = friendlyURL.concat("-staging");
 		}
 

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -437,6 +437,8 @@ action.VIEW_USER=View User
 ## Messages
 ##
 
+remote-staging=Remote Staging
+
 1-day=1 Day
 1-minute=1 Minute
 1-month=1 Month

--- a/portal-web/docroot/html/portlet/staging_bar/css/main.css
+++ b/portal-web/docroot/html/portlet/staging_bar/css/main.css
@@ -216,6 +216,12 @@
 			}
 		}
 	}
+
+	.navbar {
+		position: absolute;
+		z-index: 100;
+	}
+
 }
 
 .js .controls-hidden .staging-bar {


### PR DESCRIPTION
Hey Julio,

This is the temporary UI fix for the problem that we cannot click on the publish button for remote staging. It's just some CSS hacking, the UI guys will make it proper later

The other problem mentioned in the ticket is that the group's name is not being changed when turning on the remote staging - however for local staging we do change.

I've applied the same to the remote staging as well - with cleaning up part.

Also added testing, in some cases I ran into the limitations of the mocking framework of the PowerMockito I had to apply some workarounds.

Thanks,

Máté
