### PR TITLE
[TECHNICAL-SUPPORT] LPS-38432 ADD_ARTICLE permission is not enough to add new Web Content from Structure with Default Values 

### DIFF
--- a/portal-web/docroot/html/portlet/journal/edit_article.jsp
+++ b/portal-web/docroot/html/portlet/journal/edit_article.jsp
@@ -244,7 +244,7 @@ request.setAttribute("edit_article.jsp-toLanguageId", toLanguageId);
 					<%
 					boolean hasSavePermission = false;
 
-					if (article != null && !article.isNew()) {
+					if ((article != null) && !article.isNew()) {
 						hasSavePermission = JournalArticlePermission.contains(permissionChecker, article, ActionKeys.UPDATE);
 					}
 					else {


### PR DESCRIPTION
Hi Julio,

Tibi has asked me, to forward his list of the possible use cases, which can be helpful, so I'm copying it here:

=== Cases for edit_article.jsp
1. Edit Structure Default Values - 1st time
2. article == null >>> article.isNew() never reached
3. articleId == ""
4. classPK > 0
5. classNameId > 0
6. structureId > 0

> > > Should require ADD_ARTICLE permission
1. Edit Structure Default Values - 2nd time
2. article != null >>> article.isNew() == false
3. articleId > 0
4. classPK > 0
5. classNameId > 0
6. structureId > 0

> > > Should require UPDATE permission
1. Add new Web Content using a Structure WITH Default Values
2. article != null && article.isNew() == true
3. articleId == null
4. classPK == 0
5. classNameId == 0
6. structureId > 0

> > > Should require ADD_ARTICLE permission
1. Add new Web Content using a Structure WITHOUT Default Values
2. article == null
3. articleId == null
4. classPK == 0
5. classNameId == 0
6. structureId > 0

> > > Should require ADD_ARTICLE permission
1. Add new Web Content from Basic Web Content
2. article == null
3. articleId == null
4. classPK == 0
5. classNameId == 0
6. structureId == 0
   
   > > > Should require ADD_ARTICLE permission
7. Edit existing Web Content

> > > Should require UPDATE permission

Tamás
