### PR TITLE
[TECH SUPPORT] LPS-33802 AssetTags are not being deleted when group is deleted

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -843,7 +843,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 					Group.class.getName(), group.getGroupId());
 			}
 
-		assetTagLocalService.deleteGroupTags(group.getGroupId());
+			assetTagLocalService.deleteTags(group.getGroupId());
 
 			assetVocabularyLocalService.deleteVocabularies(group.getGroupId());
 

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -843,6 +843,8 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 					Group.class.getName(), group.getGroupId());
 			}
 
+		assetTagLocalService.deleteGroupTags(group.getGroupId());
+
 			assetVocabularyLocalService.deleteVocabularies(group.getGroupId());
 
 			// Expando

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -201,17 +201,6 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 	}
 
 	@Override
-	public void deleteGroupTags(long groupId)
-		throws PortalException, SystemException {
-
-		List<AssetTag> groupTags = getGroupTags(groupId);
-
-		for (AssetTag tag : groupTags) {
-			deleteTag(tag);
-		}
-	}
-
-	@Override
 	public void deleteTag(AssetTag tag)
 		throws PortalException, SystemException {
 
@@ -244,6 +233,17 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		AssetTag tag = assetTagPersistence.findByPrimaryKey(tagId);
 
 		deleteTag(tag);
+	}
+
+	@Override
+	public void deleteTags(long groupId)
+		throws PortalException, SystemException {
+
+		List<AssetTag> tags = getGroupTags(groupId);
+
+		for (AssetTag tag : tags) {
+			deleteTag(tag);
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -201,6 +201,17 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 	}
 
 	@Override
+	public void deleteGroupTags(long groupId)
+		throws PortalException, SystemException {
+
+		List<AssetTag> groupTags = getGroupTags(groupId);
+
+		for (AssetTag tag : groupTags) {
+			deleteTag(tag);
+		}
+	}
+
+	@Override
 	public void deleteTag(AssetTag tag)
 		throws PortalException, SystemException {
 

--- a/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
@@ -43,6 +43,8 @@ import com.liferay.portal.util.GroupTestUtil;
 import com.liferay.portal.util.LayoutTestUtil;
 import com.liferay.portal.util.TestPropsValues;
 import com.liferay.portal.util.UserTestUtil;
+import com.liferay.portlet.asset.model.AssetTag;
+import com.liferay.portlet.asset.service.AssetTagLocalServiceUtil;
 import com.liferay.portlet.blogs.model.BlogsEntry;
 import com.liferay.portlet.blogs.service.BlogsEntryLocalServiceUtil;
 import com.liferay.portlet.blogs.util.BlogsTestUtil;
@@ -160,6 +162,29 @@ public class GroupServiceTest {
 		Assert.assertNull(
 			BlogsEntryLocalServiceUtil.fetchBlogsEntry(
 				blogsEntry.getEntryId()));
+	}
+
+	@Test
+	public void testDeleteSiteWithTags() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext(
+			group.getGroupId());
+
+		AssetTagLocalServiceUtil.addTag(
+			TestPropsValues.getUserId(), ServiceTestUtil.randomString(), null,
+			serviceContext);
+
+		List<AssetTag> tags = AssetTagLocalServiceUtil.getGroupTags(
+			group.getGroupId());
+
+		Assert.assertEquals(1, tags.size());
+
+		GroupLocalServiceUtil.deleteGroup(group.getGroupId());
+
+		tags = AssetTagLocalServiceUtil.getGroupTags(group.getGroupId());
+
+		Assert.assertEquals(0, tags.size());
 	}
 
 	@Test

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/AssetTagServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/AssetTagServiceTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.asset.service;
+
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.test.EnvironmentExecutionTestListener;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.TransactionalExecutionTestListener;
+import com.liferay.portal.util.GroupTestUtil;
+import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portlet.asset.model.AssetTag;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mate Thurzo
+ */
+@ExecutionTestListeners(
+	listeners = {
+		EnvironmentExecutionTestListener.class,
+		TransactionalExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public class AssetTagServiceTest {
+
+	@Test
+	public void testDeleteTags() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext(
+			group.getGroupId());
+
+		AssetTagLocalServiceUtil.addTag(
+			TestPropsValues.getUserId(), ServiceTestUtil.randomString(), null,
+			serviceContext);
+
+		AssetTagLocalServiceUtil.addTag(
+			TestPropsValues.getUserId(), ServiceTestUtil.randomString(), null,
+			serviceContext);
+
+		List<AssetTag> tags = AssetTagLocalServiceUtil.getGroupTags(
+			group.getGroupId());
+
+		Assert.assertEquals(2, tags.size());
+
+		AssetTagLocalServiceUtil.deleteTags(group.getGroupId());
+
+		tags = AssetTagLocalServiceUtil.getGroupTags(group.getGroupId());
+
+		Assert.assertEquals(0, tags.size());
+	}
+
+}

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetTagLocalService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetTagLocalService.java
@@ -382,6 +382,10 @@ public interface AssetTagLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
+	public void deleteTags(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.asset.model.AssetTag> getEntryTags(
 		long entryId)

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetTagLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetTagLocalServiceUtil.java
@@ -456,6 +456,12 @@ public class AssetTagLocalServiceUtil {
 		getService().deleteTag(tagId);
 	}
 
+	public static void deleteTags(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		getService().deleteTags(groupId);
+	}
+
 	public static java.util.List<com.liferay.portlet.asset.model.AssetTag> getEntryTags(
 		long entryId)
 		throws com.liferay.portal.kernel.exception.SystemException {

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetTagLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetTagLocalServiceWrapper.java
@@ -485,6 +485,13 @@ public class AssetTagLocalServiceWrapper implements AssetTagLocalService,
 	}
 
 	@Override
+	public void deleteTags(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		_assetTagLocalService.deleteTags(groupId);
+	}
+
+	@Override
 	public java.util.List<com.liferay.portlet.asset.model.AssetTag> getEntryTags(
 		long entryId)
 		throws com.liferay.portal.kernel.exception.SystemException {


### PR DESCRIPTION
Hey Julio,

The problem and fix as well is simple and easy, the asset tags associated with a group are not being deleted when the group is deleted.

For me the solution seems fine, I've only applied source formatting, but I wanted someone to double check it as well.

I also wrote some test cases, those are simple too.

Thanks,

Máté
