### PR TITLE
LPS-38440 Use the proper groupId when getting the site locales

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
@@ -663,7 +663,7 @@ public class PortletImporter {
 	}
 
 	protected Map<Locale, String> getAssetVocabularyTitleMap(
-			AssetVocabulary assetVocabulary, String name)
+			long groupId, AssetVocabulary assetVocabulary, String name)
 		throws PortalException, SystemException {
 
 		Map<Locale, String> titleMap = assetVocabulary.getTitleMap();
@@ -672,9 +672,7 @@ public class PortletImporter {
 			titleMap = new HashMap<Locale, String>();
 		}
 
-		titleMap.put(
-			PortalUtil.getSiteDefaultLocale(assetVocabulary.getGroupId()),
-			name);
+		titleMap.put(PortalUtil.getSiteDefaultLocale(groupId), name);
 
 		return titleMap;
 	}
@@ -936,7 +934,7 @@ public class PortletImporter {
 			importedAssetVocabulary =
 				AssetVocabularyLocalServiceUtil.addVocabulary(
 					userId, StringPool.BLANK,
-					getAssetVocabularyTitleMap(assetVocabulary, name),
+					getAssetVocabularyTitleMap(groupId, assetVocabulary, name),
 					assetVocabulary.getDescriptionMap(),
 					assetVocabulary.getSettings(), serviceContext);
 		}
@@ -953,7 +951,7 @@ public class PortletImporter {
 			importedAssetVocabulary =
 				AssetVocabularyLocalServiceUtil.updateVocabulary(
 					existingAssetVocabulary.getVocabularyId(), StringPool.BLANK,
-					getAssetVocabularyTitleMap(assetVocabulary, name),
+					getAssetVocabularyTitleMap(groupId, assetVocabulary, name),
 					assetVocabulary.getDescriptionMap(),
 					assetVocabulary.getSettings(), serviceContext);
 		}


### PR DESCRIPTION
Hey Julio,

this is a really small and straightforward fix, so I thought a test might be not necessary in this case. The problem is when the vocabulary comes from a lar and this lar is not from the same server the entity's group can't be found via the group local service, so we should use the current scope group instead of the actual entity's group.

thanks,
Daniel
