### PR TITLE
LPS-37444 - When you creating content, You can't see the content on left panel. 

### DIFF
--- a/portal-web/docroot/html/portlet/dockbar/add_content_redirect.jsp
+++ b/portal-web/docroot/html/portlet/dockbar/add_content_redirect.jsp
@@ -41,17 +41,17 @@ if (Validator.isNotNull(className) && (classPK > 0)) {
 <span <%= AUIUtil.buildData(data) %> class="aui-helper-hidden portlet-item"></span>
 
 <aui:script use="aui-base">
-	<c:if test="<%= Validator.isNotNull(className) && (classPK > 0) %>">
-		var Util = Liferay.Util;
+	var Util = Liferay.Util;
 
+	Util.getOpener().Liferay.fire('AddContent:refreshContentList');
+
+	<c:if test="<%= Validator.isNotNull(className) && (classPK > 0) %>">
 		Util.getOpener().Liferay.fire(
 			'AddContent:addPortlet',
 			{
 				node: A.one('.portlet-item')
 			}
 		);
-
-		Util.getOpener().Liferay.fire('AddContent:refreshContentList');
 	</c:if>
 
 	Liferay.fire(


### PR DESCRIPTION
Hey @juliocamarero,

Attached is an update for http://issues.liferay.com/browse/LPS-37444.

Nate had sent you a pull regarding this before, but it was closed automatically.  His comments were that he is not 100% sure what the cause is and he doesn't think this is quite the right solution. Basically, className and classPK always come back as null. Part of him thought this might be related to Shuyang's change, but this is just a stab in the dark. Since you guys wrote this piece, he wanted to see if one of the guys there could take a look?

Please let me know if you have any questions.  Thanks!
