### PR TITLE
[Regression] LPS-38703 Check EXPIRE permission in EntriesChecker for journal portlet

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/search/EntriesChecker.java
+++ b/portal-impl/src/com/liferay/portlet/journal/search/EntriesChecker.java
@@ -100,7 +100,7 @@ public class EntriesChecker extends RowChecker {
 				if (JournalArticlePermission.contains(
 						_permissionChecker, article, ActionKeys.DELETE) ||
 					JournalArticlePermission.contains(
-						_permissionChecker, article, ActionKeys.UPDATE)) {
+						_permissionChecker, article, ActionKeys.EXPIRE)) {
 
 					showInput = true;
 				}


### PR DESCRIPTION
Hi Julio,

I discovered a regression bug while I was working on to fix http://issues.liferay.com/browse/LPS-38582 in ee-6.1.x.

This one is caused by an improvement:
http://issues.liferay.com/browse/LPS-27600 | liferay@6bcee405665658d3a00abadabcfea6a9679d216b

I guess, accidentally Sergio forgot to change UPDATE to EXPIRE when he re-used the existing logic of com.liferay.portlet.documentlibrary.search.EntriesChecker

Please, review my changes and let me know if you have any concerns.

Regards,
Tibor
