### PR TITLE
LPS-38618 Handle Don't set cookie domain explicitly if  SESSION_COOKIE_USE_FULL_HOSTNAME is enabled

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -1191,7 +1191,11 @@ public class HttpImpl implements Http {
 		Cookie cookie = new Cookie(
 			commonsCookie.getName(), commonsCookie.getValue());
 
-		String domain = commonsCookie.getDomain();
+		String domain = StringPool.BLANK;
+
+		if (!PropsValues.SESSION_COOKIE_USE_FULL_HOSTNAME) {
+			domain = commonsCookie.getDomain();
+		}
 
 		if (Validator.isNotNull(domain)) {
 			cookie.setDomain(domain);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1632,6 +1632,8 @@ public class PropsValues {
 
 	public static final String SESSION_COOKIE_DOMAIN = PropsUtil.get(PropsKeys.SESSION_COOKIE_DOMAIN);
 
+	public static final boolean SESSION_COOKIE_USE_FULL_HOSTNAME = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SESSION_COOKIE_USE_FULL_HOSTNAME));
+
 	public static final boolean SESSION_DISABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SESSION_DISABLED));
 
 	public static final boolean SESSION_ENABLE_PERSISTENT_COOKIES = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SESSION_ENABLE_PERSISTENT_COOKIES));

--- a/portal-service/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -154,7 +154,7 @@ public class CookieKeys {
 		String host = request.getServerName();
 
 		if (_SESSION_COOKIE_USE_FULL_HOSTNAME) {
-			return host;
+			return StringPool.BLANK;
 		}
 
 		return getDomain(host);


### PR DESCRIPTION
Hi Julio,

I really don't know to whom I should send this to. Minhchau is in the CookieKeys class as an author, however, he's not on our review chain.

I chose you as you're familiar with this issue already, but please, feel free to pass or let me know who else I should send to.

Edit: one thing which I forgot to mention. Shouldn't we check the PropsValues.SESSION_COOKIE_DOMAIN property in the HttpImpl class also before the check of PropsValues.SESSION_COOKIE_USE_FULL_HOSTNAME?

Thank you,
Zsigmond
