### PR TITLE
[TECHNICAL-SUPPORT] LPS-39178 Asset Link Behaviour is not working for portlets on pages in User Groups' Site Template

### DIFF
--- a/portal-impl/src/com/liferay/portal/struts/FindAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/FindAction.java
@@ -80,9 +80,9 @@ public abstract class FindAction extends Action {
 
 			plid = (Long)plidAndPortletId[0];
 
-			String portletId = (String)plidAndPortletId[1];
-
 			setSourceGroup(request, plid, primaryKey);
+
+			String portletId = (String)plidAndPortletId[1];
 
 			PortletURL portletURL = PortletURLFactoryUtil.create(
 				request, portletId, plid, PortletRequest.RENDER_PHASE);
@@ -281,25 +281,25 @@ public abstract class FindAction extends Action {
 			HttpServletRequest request, long plid, long primaryKey)
 		throws Exception {
 
-		Layout layout = LayoutLocalServiceUtil.getLayout(plid);
-
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		PermissionChecker permissionChecker =
 			themeDisplay.getPermissionChecker();
 
-		long sourceGroupId = getGroupId(primaryKey);
+		long entityGroupId = getGroupId(primaryKey);
 
-		if ((sourceGroupId == layout.getGroupId()) ||
-			(layout.getPrivateLayout() &&
-			 !SitesUtil.isUserGroupLayoutSetViewable(
-				permissionChecker, layout.getGroup()))) {
+		Layout layout = LayoutLocalServiceUtil.getLayout(plid);
+
+		if ((entityGroupId == layout.getGroupId()) ||
+			(layout.isPrivateLayout() &&
+				!SitesUtil.isUserGroupLayoutSetViewable(
+					permissionChecker, layout.getGroup()))) {
 
 			return;
 		}
 
-		Group sourceGroup = GroupLocalServiceUtil.getGroup(sourceGroupId);
+		Group sourceGroup = GroupLocalServiceUtil.getGroup(entityGroupId);
 
 		layout = new VirtualLayout(layout, sourceGroup);
 


### PR DESCRIPTION
Hi Julio,

I thought of some more general solution to change the logic in the PortalImpl class' getPlidFromPortletId method, as the problem is that, the direct layouts are taken into account, however it seems it's an Asset Publisher related problem only, so this place seemed to be the best place to fix.

Regards,
Zsigmond
