### PR TITLE
LPS-38958

### DIFF
--- a/portal-service/src/com/liferay/portlet/documentlibrary/util/DLPreviewableProcessor.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/util/DLPreviewableProcessor.java
@@ -529,6 +529,12 @@ public abstract class DLPreviewableProcessor implements DLProcessor {
 		FileVersion fileVersion = fileEntry.getFileVersion();
 
 		if (!hasPreview(fileVersion, previewType)) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"No preview found for file entry " +
+						fileEntry.getFileEntryId());
+			}
+
 			return;
 		}
 
@@ -583,6 +589,12 @@ public abstract class DLPreviewableProcessor implements DLProcessor {
 		FileVersion fileVersion = fileEntry.getFileVersion();
 
 		if (!hasThumbnail(fileVersion, index)) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"No thumbnail found for file entry " +
+						fileEntry.getFileEntryId());
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
Hey Julio,

small fix again from the support, they are reusing the logic we have in case of thumbnails, which means to return when it doesn't exist for the actual file entry. I added some logging as well, since we have logs when the binary export fails, so I think it makes sense to have logging if the process fails in a previous point.

thanks,
Daniel
