### PR TITLE
LPS-39405 Wrong permission checking in add panel

### DIFF
--- a/portal-web/docroot/html/portlet/dockbar/add_panel.jsp
+++ b/portal-web/docroot/html/portlet/dockbar/add_panel.jsp
@@ -23,18 +23,14 @@
 			<%
 			Group group = layout.getGroup();
 
-			boolean hasLayoutCustomizePermission = LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE);
-
-			boolean hasLayoutUpdatePermission = LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE);
-
 			boolean stateMaximized = ParamUtil.getBoolean(request, "stateMaximized");
 
-			boolean hasAddContentAndApplicationsPermission = !stateMaximized && layout.isTypePortlet() && !layout.isLayoutPrototypeLinkActive() && (hasLayoutUpdatePermission || (layoutTypePortlet.isCustomizable() && layoutTypePortlet.isCustomizedView() && hasLayoutCustomizePermission));
+			boolean hasAddContentAndApplicationsPermission = !stateMaximized && layout.isTypePortlet() && !layout.isLayoutPrototypeLinkActive() && (LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE) || (layoutTypePortlet.isCustomizable() && layoutTypePortlet.isCustomizedView() && LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE)));
 
 			boolean hasAddPagePermission = !group.isLayoutPrototype() && GroupPermissionUtil.contains(permissionChecker, scopeGroupId, ActionKeys.ADD_LAYOUT);
 			%>
 
-			<c:if test="<%= !group.isControlPanel() && (!group.hasStagingGroup() || group.isStagingGroup()) && (GroupPermissionUtil.contains(permissionChecker, group.getGroupId(), ActionKeys.ADD_LAYOUT) || hasLayoutUpdatePermission || (layoutTypePortlet.isCustomizable() && layoutTypePortlet.isCustomizedView() && hasLayoutCustomizePermission)) %>">
+			<c:if test="<%= !group.isControlPanel() && (!group.hasStagingGroup() || group.isStagingGroup()) && (hasAddContentAndApplicationsPermission || hasAddPagePermission) %>">
 				<div class="add-content-menu" id="<portlet:namespace />addPanelContainer">
 					<aui:button cssClass="close pull-right" name="closePanelAdd" value="&times;" />
 


### PR DESCRIPTION
Hey Julio,

Initial conditions to display the Add Content and Add Application tabs are the same. In both cases the user adds an application to a page. Specific conditions (e.g. view permissions, add to page permissions, create content permissions) are checked within the panel logic. These initial conditions are:
- Current state is not maximized
- Layout type is portlet
- Page hasn't a link enabled to a page template
- User has permission to update pages or this page is customizable and user has permission to customize

Conditions to add a new page are:
- User is not editing a Page Template
- User has permission to add pages

Besides, the whole add panel won't be displayed in control panel nor in live environment, if staging is enabled.

These changes solve LPS-39405 and LPS-38040.

Thanks!

@JorgeFerrer
