### PR TITLE
LPS-38525

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
@@ -574,6 +574,17 @@ public class GroupImpl extends GroupBaseImpl {
 	}
 
 	@Override
+	public boolean isCompanyStaging() {
+		Group liveGroup = getLiveGroup();
+
+		if (liveGroup == null) {
+			return false;
+		}
+
+		return liveGroup.isCompany();
+	}
+
+	@Override
 	public boolean isControlPanel() {
 		String name = getName();
 

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -263,7 +263,9 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 		long groupClassNameId = PortalUtil.getClassNameId(Group.class);
 
-		if ((classNameId <= 0) || className.equals(Group.class.getName())) {
+		if (((classNameId <= 0) || className.equals(Group.class.getName())) ||
+			(className.equals(Company.class.getName()) && staging)) {
+
 			className = Group.class.getName();
 			classNameId = groupClassNameId;
 			classPK = groupId;

--- a/portal-impl/src/com/liferay/portlet/grouppages/GroupPagesControlPanelEntry.java
+++ b/portal-impl/src/com/liferay/portlet/grouppages/GroupPagesControlPanelEntry.java
@@ -32,7 +32,7 @@ public class GroupPagesControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
 
-		return group.isCompany();
+		return group.isCompany() || group.isCompanyStaging();
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/sitesadmin/SiteMembershipsControlPanelEntry.java
+++ b/portal-impl/src/com/liferay/portlet/sitesadmin/SiteMembershipsControlPanelEntry.java
@@ -32,8 +32,9 @@ public class SiteMembershipsControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
 
-		if (group.isCompany() || group.isLayoutSetPrototype() ||
-			!group.isManualMembership() || group.isUser()) {
+		if (group.isCompany() || group.isCompanyStaging() ||
+			group.isLayoutSetPrototype() || !group.isManualMembership() ||
+			group.isUser()) {
 
 			return true;
 		}

--- a/portal-impl/src/com/liferay/portlet/sitesadmin/SiteTeamsControlPanelEntry.java
+++ b/portal-impl/src/com/liferay/portlet/sitesadmin/SiteTeamsControlPanelEntry.java
@@ -31,8 +31,9 @@ public class SiteTeamsControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
 
-		if (group.isCompany() || group.isLayoutSetPrototype() ||
-			!group.isManualMembership() || group.isUser()) {
+		if (group.isCompany() || group.isCompanyStaging() ||
+			group.isLayoutSetPrototype() || !group.isManualMembership() ||
+			group.isUser()) {
 
 			return true;
 		}

--- a/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
@@ -84,6 +84,31 @@ public class GroupServiceTest {
 	}
 
 	@Test
+	public void testAddGroupWithGlobalLive() throws Exception {
+		Group companyGroup = GroupLocalServiceUtil.getCompanyGroup(
+			TestPropsValues.getCompanyId());
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAttribute("staging", String.valueOf(true));
+
+		Group stagingGroup = GroupLocalServiceUtil.addGroup(
+			TestPropsValues.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			companyGroup.getClassName(), companyGroup.getClassPK(),
+			companyGroup.getGroupId(), companyGroup.getDescriptiveName(),
+			companyGroup.getDescription(), companyGroup.getType(),
+			companyGroup.isManualMembership(),
+			companyGroup.getMembershipRestriction(),
+			companyGroup.getFriendlyURL(), false, companyGroup.isActive(),
+			serviceContext);
+
+		Assert.assertTrue(stagingGroup.isCompanyStaging());
+
+		Assert.assertEquals(
+			companyGroup.getGroupId(), stagingGroup.getLiveGroupId());
+	}
+
+	@Test
 	public void testAddPermissionsCustomRole() throws Exception {
 		Group group = GroupTestUtil.addGroup();
 

--- a/portal-service/src/com/liferay/portal/model/Group.java
+++ b/portal-service/src/com/liferay/portal/model/Group.java
@@ -123,6 +123,8 @@ public interface Group extends GroupModel, PersistedModel {
 
 	public boolean isCompany();
 
+	public boolean isCompanyStaging();
+
 	public boolean isControlPanel();
 
 	public boolean isGuest();

--- a/portal-service/src/com/liferay/portal/model/GroupWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/GroupWrapper.java
@@ -957,6 +957,11 @@ public class GroupWrapper implements Group, ModelWrapper<Group> {
 	}
 
 	@Override
+	public boolean isCompanyStaging() {
+		return _group.isCompanyStaging();
+	}
+
+	@Override
 	public boolean isControlPanel() {
 		return _group.isControlPanel();
 	}

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
@@ -34,11 +34,7 @@ Group stagingGroup = null;
 
 int pagesCount = 0;
 
-if (selGroup.isCompany()) {
-	stagingGroup = selGroup;
-	liveGroup = selGroup;
-}
-else if (selGroup.isStagingGroup()) {
+if (selGroup.isStagingGroup()) {
 	liveGroup = selGroup.getLiveGroup();
 	stagingGroup = selGroup;
 }
@@ -77,7 +73,7 @@ if (liveGroup.isStaged()) {
 		localPublishing = false;
 	}
 }
-else if (cmd.equals("publish_to_remote") || selGroup.isCompany()) {
+else if (cmd.equals("publish_to_remote")) {
 	localPublishing = false;
 }
 
@@ -99,7 +95,7 @@ String publishActionKey = "copy";
 if (liveGroup.isStaged()) {
 	publishActionKey = "publish";
 }
-else if (cmd.equals("publish_to_remote") || selGroup.isCompany()) {
+else if (cmd.equals("publish_to_remote")) {
 	publishActionKey = "publish";
 }
 

--- a/portal-web/docroot/html/portlet/sites_admin/edit_site.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site.jsp
@@ -103,7 +103,7 @@ if (!trashEnabled && ArrayUtil.contains(advancedSections, "recycle-bin")) {
 	advancedSections = ArrayUtil.remove(advancedSections, "recycle-bin");
 }
 
-if ((group != null) && group.isCompany()) {
+if ((group != null) && (group.isCompany() || group.isCompanyStaging())) {
 	mainSections = ArrayUtil.remove(mainSections, "categorization");
 	mainSections = ArrayUtil.remove(mainSections, "site-url");
 	mainSections = ArrayUtil.remove(mainSections, "site-template");
@@ -233,7 +233,7 @@ String[][] categorySections = {mainSections, seoSections, advancedSections, misc
 		</c:if>
 
 		if (ok) {
-			<c:if test="<%= (group != null) && !group.isCompany() %>">
+			<c:if test="<%= (group != null) && !group.isCompany() && !group.isCompanyStaging() %>">
 				<portlet:namespace />saveLocales();
 			</c:if>
 

--- a/portal-web/docroot/html/portlet/sites_admin/site/staging.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/staging.jsp
@@ -67,9 +67,7 @@ LayoutSet publicLayoutSet = LayoutSetLocalServiceUtil.getLayoutSet(liveGroup.get
 			<aui:field-wrapper label="staging-type">
 				<aui:input checked="<%= !liveGroup.isStaged() %>" id="none" label="none" name="stagingType" type="radio" value="<%= StagingConstants.TYPE_NOT_STAGED %>" />
 
-				<c:if test="<%= !liveGroup.isCompany() %>">
-					<aui:input checked="<%= liveGroup.isStaged() && !liveGroup.isStagedRemotely() %>" helpMessage="staging-type-local" id="local" label="local-live" name="stagingType" type="radio" value="<%= StagingConstants.TYPE_LOCAL_STAGING %>" />
-				</c:if>
+				<aui:input checked="<%= liveGroup.isStaged() && !liveGroup.isStagedRemotely() %>" helpMessage="staging-type-local" id="local" label="local-live" name="stagingType" type="radio" value="<%= StagingConstants.TYPE_LOCAL_STAGING %>" />
 
 				<aui:input checked="<%= liveGroup.isStaged() && liveGroup.isStagedRemotely() %>" helpMessage="staging-type-remote" id="remote" label="remote-live" name="stagingType" type="radio" value="<%= StagingConstants.TYPE_REMOTE_STAGING %>" />
 			</aui:field-wrapper>

--- a/portal-web/docroot/html/taglib/ui/staging/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/staging/page.jsp
@@ -51,10 +51,7 @@ else {
 Group liveGroup = null;
 Group stagingGroup = null;
 
-if (group.isCompany()) {
-	stagingGroup = group;
-}
-else if (group.isStagingGroup()) {
+if (group.isStagingGroup()) {
 	liveGroup = group.getLiveGroup();
 	stagingGroup = group;
 }
@@ -75,27 +72,24 @@ if (groupId <= 0) {
 
 String publishDialogTitle = null;
 
-if (group.isCompany()) {
-	publishDialogTitle = "publish-to-remote-live";
-}
-else {
+if (!group.isCompany()) {
 	layoutSetBranches = LayoutSetBranchLocalServiceUtil.getLayoutSetBranches(stagingGroup.getGroupId(), privateLayout);
+}
 
-	if (group.isStaged() && group.isStagedRemotely()) {
-		if ((layoutSetBranchId > 0) && (layoutSetBranches.size() > 1)) {
-			publishDialogTitle = "publish-x-to-remote-live";
-		}
-		else {
-			publishDialogTitle = "publish-to-remote-live";
-		}
+if (group.isStaged() && group.isStagedRemotely()) {
+	if ((layoutSetBranchId > 0) && (layoutSetBranches.size() > 1)) {
+		publishDialogTitle = "publish-x-to-remote-live";
 	}
 	else {
-		if ((layoutSetBranchId > 0) && (layoutSetBranches.size() > 1)) {
-			publishDialogTitle = "publish-x-to-live";
-		}
-		else {
-			publishDialogTitle = "publish-to-live";
-		}
+		publishDialogTitle = "publish-to-remote-live";
+	}
+}
+else {
+	if ((layoutSetBranchId > 0) && (layoutSetBranches.size() > 1)) {
+		publishDialogTitle = "publish-x-to-live";
+	}
+	else {
+		publishDialogTitle = "publish-to-live";
 	}
 }
 
@@ -104,7 +98,7 @@ String publishMessage = LanguageUtil.get(pageContext, publishDialogTitle);
 
 <liferay-portlet:renderURL plid="<%= plid %>" portletMode="<%= PortletMode.VIEW.toString() %>" portletName="<%= PortletKeys.LAYOUTS_ADMIN %>" varImpl="publishRenderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 	<liferay-portlet:param name="struts_action" value="/layouts_admin/publish_layouts" />
-	<liferay-portlet:param name="<%= Constants.CMD %>" value='<%= (group.isCompany()) ? "publish_to_remote" : "publish_to_live" %>' />
+	<liferay-portlet:param name="<%= Constants.CMD %>" value="publish_to_live" />
 	<liferay-portlet:param name="tabs1" value='<%= (privateLayout) ? "private-pages" : "public-pages" %>' />
 	<liferay-portlet:param name="closeRedirect" value="<%= currentURL %>" />
 	<liferay-portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" />


### PR DESCRIPTION
Hey Julio,

These are Eduardo's changes for the UI parts, but also my bugfix for the global scope to be able to turn on.

For my part the problem was if we tried to turn on the staging for global scope there was an error being thrown because the companyId, className, classPK fields are unique in the table. The global scope's values are for the className/classPK pair is the Company.class.getName, and the companyId itself. Now that's no good for the staging group. So the logic is now, if we are trying to add a staging group for the global scope we add it the same way we add a staging group. They will be linked together with the liveGroupId.

So I'm not sure if this is the best solution. It's probably one of the more easy ones, this logic seems to work properly, I was able to turn on and off the global scope staging with the staging group getting deleted after switching off the staging. This seemed easy enough to implement without breaking any other major functionality in the portal. Let me know what you think.

cc: @KocsisDaniel, @epgarcia
