### PR TITLE
LPS-39477

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutExportBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutExportBackgroundTaskExecutor.java
@@ -16,6 +16,8 @@ package com.liferay.portal.lar.backgroundtask;
 
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
 import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.model.BackgroundTask;
@@ -69,6 +71,14 @@ public class LayoutExportBackgroundTaskExecutor
 			userId, backgroundTask.getBackgroundTaskId(), fileName, larFile);
 
 		return BackgroundTaskResult.SUCCESS;
+	}
+
+	@Override
+	public String handleException(BackgroundTask backgroundTask, Exception e) {
+		JSONObject jsonObject = StagingUtil.getExceptionMessagesJSONObject(
+			getLocale(backgroundTask), e, backgroundTask.getTaskContextMap());
+
+		return jsonObject.toString();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/PortletExportBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/PortletExportBackgroundTaskExecutor.java
@@ -16,6 +16,8 @@ package com.liferay.portal.lar.backgroundtask;
 
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
 import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.model.BackgroundTask;
 import com.liferay.portal.service.BackgroundTaskLocalServiceUtil;
@@ -65,6 +67,14 @@ public class PortletExportBackgroundTaskExecutor
 			userId, backgroundTask.getBackgroundTaskId(), fileName, larFile);
 
 		return BackgroundTaskResult.SUCCESS;
+	}
+
+	@Override
+	public String handleException(BackgroundTask backgroundTask, Exception e) {
+		JSONObject jsonObject = StagingUtil.getExceptionMessagesJSONObject(
+			getLocale(backgroundTask), e, backgroundTask.getTaskContextMap());
+
+		return jsonObject.toString();
 	}
 
 }

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -6161,6 +6161,7 @@ ukrainian=Ukrainian
 unable-to-activate-user-because-that-would-exceed-the-maximum-number-of-users-allowed=Unable to activate user because that would exceed the maximum number of users allowed.
 unable-to-completely-empty-trash-you-do-not-have-permission-to-delete-one-or-more-items=Unable to completely empty trash. You do not have permission to delete one or more items.
 unable-to-create-user-account-because-the-maximum-number-of-users-has-been-reached=Unable to create user account because the maximum number of users has been reached.
+unable-to-execute-background-task=Unable to excute background task.
 unable-to-load-content=Unable to load content.
 unable-to-login-because-the-maximum-number-of-users-has-been-reached=Unable to login because the maximum number of users has been reached.
 unable-to-move-this-item-to-the-selected-destination=Unable to move this item to the selected destination. There is an entry with the same name.

--- a/portal-web/docroot/html/portlet/layouts_admin/export_layouts_processes.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/export_layouts_processes.jsp
@@ -125,7 +125,7 @@ OrderByComparator orderByComparator = BackgroundTaskComparatorFactoryUtil.getBac
 					<liferay-ui:icon
 						image="download"
 						label="<%= true %>"
-						message='<%= MapUtil.getString(taskContextMap, "fileName") %>'
+						message='<%= HtmlUtil.escape(MapUtil.getString(taskContextMap, "fileName")) %>'
 					/>
 				</c:otherwise>
 			</c:choose>

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_process_message.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_process_message.jsp
@@ -48,10 +48,10 @@ BackgroundTask backgroundTask = (BackgroundTask)row.getObject();
 		<div class="progress progress-striped active">
 			<div class="bar" style="width: <%= percentage %>%;">
 
-			  <c:if test="<%= allModelAdditionCountersTotal > 0 %>">
-				  <%= currentModelAdditionCountersTotal %> / <%= allModelAdditionCountersTotal %>
-			  </c:if>
-		  </div>
+				<c:if test="<%= allModelAdditionCountersTotal > 0 %>">
+					<%= currentModelAdditionCountersTotal %> / <%= allModelAdditionCountersTotal %>
+				</c:if>
+			</div>
 		</div>
 
 		<%
@@ -106,7 +106,7 @@ BackgroundTask backgroundTask = (BackgroundTask)row.getObject();
 		<c:choose>
 			<c:when test="<%= jsonObject == null %>">
 				<div class="alert <%= backgroundTask.getStatus() == BackgroundTaskConstants.STATUS_FAILED ? "alert-error" : StringPool.BLANK %> publish-error">
-					<%= backgroundTask.getStatusMessage() %>
+					<%= LanguageUtil.get(locale, "unable-to-execute-background-task") %>
 				</div>
 			</c:when>
 			<c:otherwise>

--- a/portal-web/docroot/html/portlet/portlet_configuration/export_portlet_processes.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/export_portlet_processes.jsp
@@ -123,7 +123,7 @@ OrderByComparator orderByComparator = BackgroundTaskComparatorFactoryUtil.getBac
 					<liferay-ui:icon
 						image="download"
 						label="<%= true %>"
-						message='<%= MapUtil.getString(taskContextMap, "fileName") %>'
+						message='<%= HtmlUtil.escape(MapUtil.getString(taskContextMap, "fileName")) %>'
 					/>
 				</c:otherwise>
 			</c:choose>


### PR DESCRIPTION
Basic change: 
1 Change the error message to be localizable
2 Removed the task name from the error message when the error msg is a string, because publish_process_message.jsp is only referenced by liferay-ui:search-container-column-jsp within the item there's other column displays task name/file name
3 Overwrite the handleException in LayoutExportBackgroundTaskEcecutor & PortletEcportBackgroundTaskExecutor returns json string instead err mag directly the same method as BaseStagingBackgroundTaskExecutor does.
