### PR TITLE
[WAITING] Revert "LPS-37233 only show trace in debug mode"

### DIFF
--- a/portal-impl/src/com/liferay/portal/backgroundtask/messaging/BackgroundTaskMessageListener.java
+++ b/portal-impl/src/com/liferay/portal/backgroundtask/messaging/BackgroundTaskMessageListener.java
@@ -130,9 +130,7 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 				}
 			}
 
-			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to execute background task", e);
-			}
+			_log.error("Unable to execute background task", e);
 		}
 		finally {
 			BackgroundTaskLocalServiceUtil.amendBackgroundTask(


### PR DESCRIPTION
Hi Julio,

I would like to revert the following commit because if we do not log the full stacktrace by default it will be a pain to ask customers to reproduce issues when debug is enabled (as far as I know the log level won't be set to debug for this class in 6.2).

https://github.com/liferay/liferay-portal/commit/7731d28e30d2d043a63505f4efa737dd1256bb4a

Thanks,
Ákos
