### PR TITLE
LPS-41219 Retrieve structure with local service.

### DIFF
--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/select_template.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/select_template.jsp
@@ -28,7 +28,7 @@ DDMStructure structure = null;
 long structureClassNameId = PortalUtil.getClassNameId(DDMStructure.class);
 
 if ((classPK > 0) && (structureClassNameId == classNameId)) {
-	structure = DDMStructureServiceUtil.getStructure(classPK);
+	structure = DDMStructureLocalServiceUtil.getStructure(classPK);
 }
 
 String title = ddmDisplay.getViewTemplatesTitle(structure, locale);


### PR DESCRIPTION
Structure is used here just to obtain the name of the template list. Thus, there isn't any security issue with using local service in this case.
