### PR TITLE
LPS-42399 MailEngine send exception handling

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7067,6 +7067,12 @@
     #
     mail.hook.shell.script=/usr/sbin/mailadmin.ksh
 
+    #
+    # Set this to true to throw an exception when the
+    #com.liferay.util.mail.MailEngine send method fails
+    #
+    mail.throw.exception.when.fails=false
+
 ##
 ## Microsoft Translator
 ##

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1599,6 +1599,8 @@ public interface PropsKeys {
 
 	public static final String MAIL_SESSION_MAIL_TRANSPORT_PROTOCOL = "mail.session.mail.transport.protocol";
 
+	public static final String MAIL_THROW_EXCEPTION_WHEN_FAILS = "mail.throw.exception.when.fails";
+
 	public static final String MEMBERSHIP_POLICY_AUTO_VERIFY = "membership.policy.auto.verify";
 
 	public static final String MEMBERSHIP_POLICY_ORGANIZATIONS = "membership.policy.organizations";

--- a/util-java/src/com/liferay/util/mail/MailEngine.java
+++ b/util-java/src/com/liferay/util/mail/MailEngine.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.mail.SMTPAccount;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -357,6 +358,10 @@ public class MailEngine {
 		}
 		catch (SendFailedException sfe) {
 			_log.error(sfe);
+
+			if (_isFailOnException()) {
+				throw new MailEngineException(sfe);
+			}
 		}
 		catch (Exception e) {
 			throw new MailEngineException(e);
@@ -513,9 +518,24 @@ public class MailEngine {
 		}
 	}
 
+	private static boolean _isFailOnException() {
+		boolean failOnException = false;
+
+		try {
+			failOnException = PrefsPropsUtil.getBoolean(
+				PropsKeys.MAIL_THROW_EXCEPTION_WHEN_FAILS, false);
+		}
+		catch (SystemException e) {
+			_log.error("Error getting preference: " +
+				PropsKeys.MAIL_THROW_EXCEPTION_WHEN_FAILS);
+		}
+
+		return failOnException;
+	}
+
 	private static void _send(
 		Session session, Message message, InternetAddress[] bulkAddresses,
-		int batchSize) {
+		int batchSize) throws MailEngineException {
 
 		try {
 			boolean smtpAuth = GetterUtil.getBoolean(
@@ -591,6 +611,10 @@ public class MailEngine {
 			}
 			else {
 				LogUtil.log(_log, me);
+			}
+
+			if (_isFailOnException()) {
+				throw new MailEngineException(me);
 			}
 		}
 	}


### PR DESCRIPTION
Hi Julio.

This pr is done in order to fix LPS-42399.  

The origin of this ticket was discussed in https://in.liferay.com/web/global.engineering/forums/-/message_boards/message/1886462?p_p_auth=W6rUSt7H

With this fix, if you don't change the added preference, the behavior is the same as before. When the property is set to true,  if the send mail method fails, an  exception will be thrown.

I sent this pr to Neil Griffin before, but he didn't answer me.
