### PR TITLE
LPS-42399 MailEngine send exception handling

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7067,6 +7067,12 @@
     #
     mail.hook.shell.script=/usr/sbin/mailadmin.ksh
 
+    #
+    # Set this to true to throw an exception when the
+    #com.liferay.util.mail.MailEngine send method fails
+    #
+    mail.throw.exception.when.fails=false
+
 ##
 ## Microsoft Translator
 ##

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1599,6 +1599,8 @@ public interface PropsKeys {
 
 	public static final String MAIL_SESSION_MAIL_TRANSPORT_PROTOCOL = "mail.session.mail.transport.protocol";
 
+	public static final String MAIL_THROW_EXCEPTION_WHEN_FAILS = "mail.throw.exception.when.fails";
+
 	public static final String MEMBERSHIP_POLICY_AUTO_VERIFY = "membership.policy.auto.verify";
 
 	public static final String MEMBERSHIP_POLICY_ORGANIZATIONS = "membership.policy.organizations";


### PR DESCRIPTION
Hi Julio.

This pr is done in order to fix LPS-42399.

The origin of this ticket was discussed in https://in.liferay.com/web/global.engineering/forums/-/message_boards/message/1886462?p_p_auth=W6rUSt7H

With this fix, if you don't change the added preference, the behavior is the same as before. When the property is set to true, if the send mail method fails, an exception will be thrown.

I sent this pr to Neil Griffin before, but he didn't answer me.
