### PR TITLE
[TECHNICAL-SUPPORT] LPS-44153 LayoutTypePortletImpl#setLayoutTemplateId should call getLayou...

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -1094,26 +1094,9 @@ public class LayoutTypePortletImpl
 			return;
 		}
 
-		String oldLayoutTemplateId = getLayoutTemplateId();
-
-		if (Validator.isNull(oldLayoutTemplateId)) {
-			oldLayoutTemplateId = PropsValues.DEFAULT_LAYOUT_TEMPLATE_ID;
-		}
+		LayoutTemplate oldLayoutTemplate = getLayoutTemplate();
 
 		String themeId = getThemeId();
-
-		LayoutTemplate oldLayoutTemplate =
-			LayoutTemplateLocalServiceUtil.getLayoutTemplate(
-				oldLayoutTemplateId, false, themeId);
-
-		if (oldLayoutTemplate == null) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Unable to find layout template " + oldLayoutTemplateId);
-			}
-
-			return;
-		}
 
 		LayoutTemplate newLayoutTemplate =
 			LayoutTemplateLocalServiceUtil.getLayoutTemplate(


### PR DESCRIPTION
...tTemplate() on the instance instead of a service to get the oldLayoutTemplate

The current logic cannot handle that situation, when there is a "layout-template-id" set in "typeSettings", but the requested template does not exist.

This way users will be able to change template association for a given layout, even if the current template is missing for any reasons

Signed-off-by: Tibor Lipusz tibor.lipusz@liferay.com
