### PR TITLE
LPS-46117 Fixing resource browser when staging environment

### DIFF
--- a/portal-impl/src/com/liferay/portal/editor/fckeditor/receiver/impl/BaseCommandReceiver.java
+++ b/portal-impl/src/com/liferay/portal/editor/fckeditor/receiver/impl/BaseCommandReceiver.java
@@ -357,7 +357,7 @@ public abstract class BaseCommandReceiver implements CommandReceiver {
 
 		ThemeDisplay themeDisplay = commandArgument.getThemeDisplay();
 
-		long scopeGroupId = themeDisplay.getScopeGroupId();
+		long doAsGroupId = themeDisplay.getDoAsGroupId();
 
 		HttpServletRequest request = commandArgument.getHttpServletRequest();
 
@@ -373,7 +373,7 @@ public abstract class BaseCommandReceiver implements CommandReceiver {
 			if (group.hasStagingGroup()) {
 				Group stagingGroup = group.getStagingGroup();
 
-				if ((stagingGroup.getGroupId() == scopeGroupId) &&
+				if ((stagingGroup.getGroupId() == doAsGroupId) &&
 					group.isStagedPortlet(portletId) &&
 					!group.isStagedRemotely() && isStagedData(group)) {
 

--- a/portal-impl/src/com/liferay/portal/editor/fckeditor/receiver/impl/BaseCommandReceiver.java
+++ b/portal-impl/src/com/liferay/portal/editor/fckeditor/receiver/impl/BaseCommandReceiver.java
@@ -368,7 +368,9 @@ public abstract class BaseCommandReceiver implements CommandReceiver {
 
 			foldersElement.appendChild(folderElement);
 
-			boolean setNameAttribute = false;
+			long groupId = group.getGroupId();
+			String descriptiveName = HtmlUtil.escape(
+				group.getDescriptiveName());
 
 			if (group.hasStagingGroup()) {
 				Group stagingGroup = group.getStagingGroup();
@@ -377,21 +379,14 @@ public abstract class BaseCommandReceiver implements CommandReceiver {
 					group.isStagedPortlet(portletId) &&
 					!group.isStagedRemotely() && isStagedData(group)) {
 
-					folderElement.setAttribute(
-						"name",
-						stagingGroup.getGroupId() + " - " +
-							HtmlUtil.escape(stagingGroup.getDescriptiveName()));
-
-					setNameAttribute = true;
+					groupId = stagingGroup.getGroupId();
+					descriptiveName = HtmlUtil.escape(
+						stagingGroup.getDescriptiveName());
 				}
 			}
 
-			if (!setNameAttribute) {
-				folderElement.setAttribute(
-					"name",
-					group.getGroupId() + " - " +
-						HtmlUtil.escape(group.getDescriptiveName()));
-			}
+			folderElement.setAttribute(
+				"name", groupId + " - " + descriptiveName);
 		}
 	}
 


### PR DESCRIPTION
Hey Julio,

This is what I've mentioned during the weekly engineering meeting, the resource browser in the CKEditor was not working properly when staging was turned on. This is fixing the issue. The root cause was that we used the scope group id to find out if we should consider the staging group at all, but better use the doAsGroupId as we are setting that explicitly from where we are coming.

I also did a little refactoring.

Thanks,

Máté
