### PR TITLE
LPS-46622 See docs metadata from workflow task

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/context/DLFileEntryActionsDisplayContext.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/context/DLFileEntryActionsDisplayContext.java
@@ -122,6 +122,8 @@ public class DLFileEntryActionsDisplayContext {
 			portletId.equals(PortletKeys.DOCUMENT_LIBRARY_ADMIN) ||
 			portletId.equals(PortletKeys.MEDIA_GALLERY_DISPLAY) ||
 			portletId.equals(PortletKeys.DOCUMENT_LIBRARY_DISPLAY) ||
+			portletId.equals(PortletKeys.MY_WORKFLOW_INSTANCES) ||
+			portletId.equals(PortletKeys.MY_WORKFLOW_TASKS) ||
 			portletId.equals(PortletKeys.TRASH)) {
 
 			return true;


### PR DESCRIPTION
It is needed because, when a reviewer is validating a document, he/she needs to
be able to see its medata and the download button.

This problem happens from My workflow tasks and My workflowInstances

Before:
![before](https://cloud.githubusercontent.com/assets/2162403/2902860/c52ec7bc-d5ea-11e3-9df1-a598e1581bd3.png)

After:
![after](https://cloud.githubusercontent.com/assets/2162403/2902859/c52b76a2-d5ea-11e3-821f-b1c4cda39945.png)
