### PR TITLE
LPS-47632 - Asset publisher back button does not work correctly

### DIFF
--- a/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherHelperImpl.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherHelperImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
+import com.liferay.portlet.PortletURLUtil;
 import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.model.AssetRenderer;
 import com.liferay.portlet.asset.model.AssetRendererFactory;
@@ -80,7 +81,10 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 
 		String viewURL = null;
 
-		String currentURL = PortalUtil.getCurrentURL(liferayPortletRequest);
+		PortletURL currentURLObj = PortletURLUtil.getCurrent(
+			liferayPortletRequest, liferayPortletResponse);
+
+		String currentURL = currentURLObj.toString();
 
 		if (viewInContext) {
 			String viewFullContentURLString = viewFullContentURL.toString();

--- a/portal-web/docroot/html/portlet/asset_publisher/display/full_content.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/display/full_content.jsp
@@ -17,9 +17,14 @@
 <%@ include file="/html/portlet/asset_publisher/init.jsp" %>
 
 <%
-String redirect = ParamUtil.getString(request, "redirect");
+
+String redirect = null;
 
 List results = (List)request.getAttribute("view.jsp-results");
+
+if (AssetUtil.isDefaultAssetPublisher(layout, portletDisplay.getId(), portletResource)) {
+	redirect = ParamUtil.getString(PortalUtil.getOriginalServletRequest(request), "redirect");
+}
 
 if (Validator.isNull(redirect) && results.isEmpty()) {
 	PortletURL portletURL = renderResponse.createRenderURL();


### PR DESCRIPTION
Hi Julio,

Attached is my attempt at a fix for https://issues.liferay.com/browse/LPS-47632.

As Preston stated in the ticket, there is a regression (potentially caused by LPS-47149) that makes it a little difficult to test sometimes.  When clicking an article that is to be 'viewed in context', you'll have to refresh the page after clicking in order for it to view it.  And then when you want to go back, you'll have to do the same after clicking the back button.

Please let me know if you have any questions.

Thanks!
