### PR TITLE
[TECH-SUPPORT] LPS-47903 Scope is not indicated on the multiple Add links in an Asset Publisher portlet which is scoped to more than one sites

### DIFF
--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -778,6 +778,7 @@ add-website=Add Website
 add-wiki=Add Wiki
 add-x=Add {0}
 add-x-as-a-search-provider=Add {0} as a Search Provider
+add-x-in-x=Add {0} in {1}
 added=Added
 additional-email-addresses=Additional Email Addresses
 additional-information=Additional Information

--- a/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
@@ -34,7 +34,7 @@
 				href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
 				iconCssClass="<%= assetRendererFactory.getIconCssClass() %>"
 				iconSrc="<%= assetRendererFactory.getIconPath(liferayPortletRequest) %>"
-				label='<%= LanguageUtil.format(request, "add-x", HtmlUtil.escape(message), false) %>'
+				label='<%= LanguageUtil.format(request, (groupIds.length == 1) ? "add-x" : "add-x-in-x", new Object [] {HtmlUtil.escape(message), HtmlUtil.escape((GroupLocalServiceUtil.getGroup(groupId)).getDescriptiveName(locale))}, false) %>'
 			/>
 		</c:when>
 		<c:otherwise>


### PR DESCRIPTION
Hey Julio,

Can you please check this pull request?

Thank you!

Best,
István
