### PR TITLE
[Technical-Support] LPS-48007 Web Content > Display Page > Private pages not listed after se...

### DIFF
--- a/portal-web/docroot/html/portlet/journal/article/display_page.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/display_page.jsp
@@ -258,7 +258,7 @@ Group group = GroupLocalServiceUtil.fetchGroup(groupId);
 							tabView.render();
 
 							tabView.after(
-								'activeTabChange',
+								'selectionChange',
 								function() {
 									displayPageMessage('');
 


### PR DESCRIPTION
...lect

Hi Julio,

We need to depend on 'selectionChange' event instead of 'activeTabChange'. I think there was an API change in Alloy.

Thanks
