### PR TITLE
LPS-48300 Making getters by UUID and companyId smarter

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/base/LayoutFriendlyURLLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutFriendlyURLLocalServiceBaseImpl.java
@@ -215,20 +215,6 @@ public abstract class LayoutFriendlyURLLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the layout friendly u r l with the matching UUID and company.
-	 *
-	 * @param uuid the layout friendly u r l's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching layout friendly u r l, or <code>null</code> if a matching layout friendly u r l could not be found
-	 */
-	@Override
-	public LayoutFriendlyURL fetchLayoutFriendlyURLByUuidAndCompanyId(
-		String uuid, long companyId) {
-		return layoutFriendlyURLPersistence.fetchByUuid_C_First(uuid,
-			companyId, null);
-	}
-
-	/**
 	 * Returns the layout friendly u r l matching the UUID and group.
 	 *
 	 * @param uuid the layout friendly u r l's UUID
@@ -347,18 +333,34 @@ public abstract class LayoutFriendlyURLLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the layout friendly u r l with the matching UUID and company.
+	 * Returns all the layout friendly u r ls that match the UUID and company.
 	 *
-	 * @param uuid the layout friendly u r l's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching layout friendly u r l
-	 * @throws PortalException if a matching layout friendly u r l could not be found
+	 * @param uuid the UUID of the layout friendly u r ls
+	 * @param companyId the primary key of the company
+	 * @return all the matching layout friendly u r ls, or an empty list if no matches were found
 	 */
 	@Override
-	public LayoutFriendlyURL getLayoutFriendlyURLByUuidAndCompanyId(
-		String uuid, long companyId) throws PortalException {
-		return layoutFriendlyURLPersistence.findByUuid_C_First(uuid, companyId,
-			null);
+	public List<LayoutFriendlyURL> getLayoutFriendlyURLsByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return layoutFriendlyURLPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of layout friendly u r ls that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the layout friendly u r ls
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of layout friendly u r ls
+	 * @param end the upper bound of the range of layout friendly u r ls (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching layout friendly u r ls, or an empty list if no matches were found
+	 */
+	@Override
+	public List<LayoutFriendlyURL> getLayoutFriendlyURLsByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return layoutFriendlyURLPersistence.findByUuid_C(uuid, companyId,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutLocalServiceBaseImpl.java
@@ -245,18 +245,6 @@ public abstract class LayoutLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the layout with the matching UUID and company.
-	 *
-	 * @param uuid the layout's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching layout, or <code>null</code> if a matching layout could not be found
-	 */
-	@Override
-	public Layout fetchLayoutByUuidAndCompanyId(String uuid, long companyId) {
-		return layoutPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the layout matching the UUID, group, and privacy.
 	 *
 	 * @param uuid the layout's UUID
@@ -375,17 +363,32 @@ public abstract class LayoutLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the layout with the matching UUID and company.
+	 * Returns all the layouts that match the UUID and company.
 	 *
-	 * @param uuid the layout's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching layout
-	 * @throws PortalException if a matching layout could not be found
+	 * @param uuid the UUID of the layouts
+	 * @param companyId the primary key of the company
+	 * @return all the matching layouts, or an empty list if no matches were found
 	 */
 	@Override
-	public Layout getLayoutByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return layoutPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<Layout> getLayoutsByUuidAndCompanyId(String uuid, long companyId) {
+		return layoutPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of layouts that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the layouts
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of layouts
+	 * @param end the upper bound of the range of layouts (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching layouts, or an empty list if no matches were found
+	 */
+	@Override
+	public List<Layout> getLayoutsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return layoutPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/base/RepositoryEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RepositoryEntryLocalServiceBaseImpl.java
@@ -214,20 +214,6 @@ public abstract class RepositoryEntryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the repository entry with the matching UUID and company.
-	 *
-	 * @param uuid the repository entry's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching repository entry, or <code>null</code> if a matching repository entry could not be found
-	 */
-	@Override
-	public RepositoryEntry fetchRepositoryEntryByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return repositoryEntryPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the repository entry matching the UUID and group.
 	 *
 	 * @param uuid the repository entry's UUID
@@ -346,18 +332,34 @@ public abstract class RepositoryEntryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the repository entry with the matching UUID and company.
+	 * Returns all the repository entries that match the UUID and company.
 	 *
-	 * @param uuid the repository entry's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching repository entry
-	 * @throws PortalException if a matching repository entry could not be found
+	 * @param uuid the UUID of the repository entries
+	 * @param companyId the primary key of the company
+	 * @return all the matching repository entries, or an empty list if no matches were found
 	 */
 	@Override
-	public RepositoryEntry getRepositoryEntryByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return repositoryEntryPersistence.findByUuid_C_First(uuid, companyId,
-			null);
+	public List<RepositoryEntry> getRepositoryEntriesByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return repositoryEntryPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of repository entries that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the repository entries
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of repository entries
+	 * @param end the upper bound of the range of repository entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching repository entries, or an empty list if no matches were found
+	 */
+	@Override
+	public List<RepositoryEntry> getRepositoryEntriesByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return repositoryEntryPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
@@ -232,19 +232,6 @@ public abstract class RepositoryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the repository with the matching UUID and company.
-	 *
-	 * @param uuid the repository's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching repository, or <code>null</code> if a matching repository could not be found
-	 */
-	@Override
-	public Repository fetchRepositoryByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return repositoryPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the repository matching the UUID and group.
 	 *
 	 * @param uuid the repository's UUID
@@ -372,17 +359,33 @@ public abstract class RepositoryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the repository with the matching UUID and company.
+	 * Returns all the repositories that match the UUID and company.
 	 *
-	 * @param uuid the repository's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching repository
-	 * @throws PortalException if a matching repository could not be found
+	 * @param uuid the UUID of the repositories
+	 * @param companyId the primary key of the company
+	 * @return all the matching repositories, or an empty list if no matches were found
 	 */
 	@Override
-	public Repository getRepositoryByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return repositoryPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<Repository> getRepositoriesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return repositoryPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of repositories that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the repositories
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of repositories
+	 * @param end the upper bound of the range of repositories (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching repositories, or an empty list if no matches were found
+	 */
+	@Override
+	public List<Repository> getRepositoriesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return repositoryPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/tools/dependencies/source-formatter.properties
+++ b/portal-impl/src/com/liferay/portal/tools/dependencies/source-formatter.properties
@@ -74,7 +74,7 @@
         portal-impl/src/com/liferay/portal/tools/WebXML23Converter.java@81,\
         portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java,\
         portal-impl/src/com/liferay/portal/util/WebKeys.java,\
-        portal-impl/src/com/liferay/portlet/journal/util/JournalUtil.java@843,\
+        portal-impl/src/com/liferay/portlet/journal/util/JournalUtil.java@870,\
         portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java@201,\
         portal-impl/test/integration/com/liferay/portal/model/impl/LayoutFriendlyURLTest.java@298,\
         portal-impl/test/integration/com/liferay/portal/util/PortalImplCanonicalURLTest.java,\

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_base_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_base_impl.ftl
@@ -286,7 +286,7 @@ import ${packagePath}.service.${entity.name}${sessionTypeName}Service;
 			return ${entity.varName}Persistence.fetchByPrimaryKey(${entity.PKVarName});
 		}
 
-		<#if entity.hasUuid() && entity.hasColumn("companyId")>
+		<#if entity.hasUuid() && entity.hasColumn("companyId") && (!entity.hasColumn("groupId") || (entity.name == "Group"))>
 			/**
 			 * Returns the ${entity.humanName} with the matching UUID and company.
 			 *
@@ -506,24 +506,53 @@ import ${packagePath}.service.${entity.name}${sessionTypeName}Service;
 		}
 
 		<#if entity.hasUuid() && entity.hasColumn("companyId")>
-			/**
-			 * Returns the ${entity.humanName} with the matching UUID and company.
-			 *
-			 * @param uuid the ${entity.humanName}'s UUID
-			 * @param  companyId the primary key of the company
-			 * @return the matching ${entity.humanName}
-			<#list serviceBaseExceptions as exception>
-			<#if exception == "PortalException">
-			 * @throws PortalException if a matching ${entity.humanName} could not be found
+			<#if entity.hasColumn("groupId") && (entity.name != "Group")>
+				/**
+				 * Returns all the ${entity.humanNames} that match the UUID and company.
+				 *
+				 * @param uuid the UUID of the ${entity.humanNames}
+				 * @param companyId the primary key of the company
+				 * @return all the matching ${entity.humanNames}, or an empty list if no matches were found
+				 */
+				@Override
+				public List<${entity.name}> get${entity.names}ByUuidAndCompanyId(String uuid, long companyId) {
+					return ${entity.varName}Persistence.findByUuid_C(uuid, companyId);
+				}
+
+				/**
+				 * Returns a range of ${entity.humanNames} that match the UUID and company.
+				 *
+				 * @param uuid the UUID of the ${entity.humanNames}
+				 * @param companyId the primary key of the company
+				 * @param start the lower bound of the range of ${entity.humanNames}
+				 * @param end the upper bound of the range of ${entity.humanNames} (not inclusive)
+				 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+				 * @return all the matching ${entity.humanNames}, or an empty list if no matches were found
+				 */
+				@Override
+				public List<${entity.name}> get${entity.names}ByUuidAndCompanyId(String uuid, long companyId, int start, int end, OrderByComparator orderByComparator) {
+					return ${entity.varName}Persistence.findByUuid_C(uuid, companyId, start, end, orderByComparator);
+				}
 			<#else>
-			 * @throws ${exception}
+				/**
+				 * Returns the ${entity.humanName} with the matching UUID and company.
+				 *
+				 * @param uuid the ${entity.humanName}'s UUID
+				 * @param  companyId the primary key of the company
+				 * @return the matching ${entity.humanName}
+				<#list serviceBaseExceptions as exception>
+				<#if exception == "PortalException">
+				 * @throws PortalException if a matching ${entity.humanName} could not be found
+				<#else>
+				 * @throws ${exception}
+				</#if>
+				</#list>
+				 */
+				@Override
+				public ${entity.name} get${entity.name}ByUuidAndCompanyId(String uuid, long companyId) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
+					return ${entity.varName}Persistence.findByUuid_C_First(uuid, companyId, null);
+				}
 			</#if>
-			</#list>
-			 */
-			@Override
-			public ${entity.name} get${entity.name}ByUuidAndCompanyId(String uuid, long companyId) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
-				return ${entity.varName}Persistence.findByUuid_C_First(uuid, companyId, null);
-			}
 		</#if>
 
 		<#if entity.hasUuid() && entity.hasColumn("groupId") && (entity.name != "Group")>

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetCategoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetCategoryLocalServiceBaseImpl.java
@@ -224,20 +224,6 @@ public abstract class AssetCategoryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the asset category with the matching UUID and company.
-	 *
-	 * @param uuid the asset category's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching asset category, or <code>null</code> if a matching asset category could not be found
-	 */
-	@Override
-	public AssetCategory fetchAssetCategoryByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return assetCategoryPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the asset category matching the UUID and group.
 	 *
 	 * @param uuid the asset category's UUID
@@ -356,17 +342,34 @@ public abstract class AssetCategoryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the asset category with the matching UUID and company.
+	 * Returns all the asset categories that match the UUID and company.
 	 *
-	 * @param uuid the asset category's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching asset category
-	 * @throws PortalException if a matching asset category could not be found
+	 * @param uuid the UUID of the asset categories
+	 * @param companyId the primary key of the company
+	 * @return all the matching asset categories, or an empty list if no matches were found
 	 */
 	@Override
-	public AssetCategory getAssetCategoryByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return assetCategoryPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<AssetCategory> getAssetCategoriesByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return assetCategoryPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of asset categories that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the asset categories
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of asset categories
+	 * @param end the upper bound of the range of asset categories (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching asset categories, or an empty list if no matches were found
+	 */
+	@Override
+	public List<AssetCategory> getAssetCategoriesByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return assetCategoryPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetVocabularyLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetVocabularyLocalServiceBaseImpl.java
@@ -221,20 +221,6 @@ public abstract class AssetVocabularyLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the asset vocabulary with the matching UUID and company.
-	 *
-	 * @param uuid the asset vocabulary's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching asset vocabulary, or <code>null</code> if a matching asset vocabulary could not be found
-	 */
-	@Override
-	public AssetVocabulary fetchAssetVocabularyByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return assetVocabularyPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the asset vocabulary matching the UUID and group.
 	 *
 	 * @param uuid the asset vocabulary's UUID
@@ -353,18 +339,34 @@ public abstract class AssetVocabularyLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the asset vocabulary with the matching UUID and company.
+	 * Returns all the asset vocabularies that match the UUID and company.
 	 *
-	 * @param uuid the asset vocabulary's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching asset vocabulary
-	 * @throws PortalException if a matching asset vocabulary could not be found
+	 * @param uuid the UUID of the asset vocabularies
+	 * @param companyId the primary key of the company
+	 * @return all the matching asset vocabularies, or an empty list if no matches were found
 	 */
 	@Override
-	public AssetVocabulary getAssetVocabularyByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return assetVocabularyPersistence.findByUuid_C_First(uuid, companyId,
-			null);
+	public List<AssetVocabulary> getAssetVocabulariesByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return assetVocabularyPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of asset vocabularies that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the asset vocabularies
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of asset vocabularies
+	 * @param end the upper bound of the range of asset vocabularies (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching asset vocabularies, or an empty list if no matches were found
+	 */
+	@Override
+	public List<AssetVocabulary> getAssetVocabulariesByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return assetVocabularyPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/blogs/service/base/BlogsEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/base/BlogsEntryLocalServiceBaseImpl.java
@@ -239,19 +239,6 @@ public abstract class BlogsEntryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the blogs entry with the matching UUID and company.
-	 *
-	 * @param uuid the blogs entry's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
-	 */
-	@Override
-	public BlogsEntry fetchBlogsEntryByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return blogsEntryPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the blogs entry matching the UUID and group.
 	 *
 	 * @param uuid the blogs entry's UUID
@@ -376,17 +363,33 @@ public abstract class BlogsEntryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the blogs entry with the matching UUID and company.
+	 * Returns all the blogs entries that match the UUID and company.
 	 *
-	 * @param uuid the blogs entry's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching blogs entry
-	 * @throws PortalException if a matching blogs entry could not be found
+	 * @param uuid the UUID of the blogs entries
+	 * @param companyId the primary key of the company
+	 * @return all the matching blogs entries, or an empty list if no matches were found
 	 */
 	@Override
-	public BlogsEntry getBlogsEntryByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return blogsEntryPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<BlogsEntry> getBlogsEntriesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return blogsEntryPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of blogs entries that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the blogs entries
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of blogs entries
+	 * @param end the upper bound of the range of blogs entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching blogs entries, or an empty list if no matches were found
+	 */
+	@Override
+	public List<BlogsEntry> getBlogsEntriesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return blogsEntryPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/bookmarks/service/base/BookmarksEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/service/base/BookmarksEntryLocalServiceBaseImpl.java
@@ -237,20 +237,6 @@ public abstract class BookmarksEntryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the bookmarks entry with the matching UUID and company.
-	 *
-	 * @param uuid the bookmarks entry's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching bookmarks entry, or <code>null</code> if a matching bookmarks entry could not be found
-	 */
-	@Override
-	public BookmarksEntry fetchBookmarksEntryByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return bookmarksEntryPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the bookmarks entry matching the UUID and group.
 	 *
 	 * @param uuid the bookmarks entry's UUID
@@ -377,18 +363,34 @@ public abstract class BookmarksEntryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the bookmarks entry with the matching UUID and company.
+	 * Returns all the bookmarks entries that match the UUID and company.
 	 *
-	 * @param uuid the bookmarks entry's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching bookmarks entry
-	 * @throws PortalException if a matching bookmarks entry could not be found
+	 * @param uuid the UUID of the bookmarks entries
+	 * @param companyId the primary key of the company
+	 * @return all the matching bookmarks entries, or an empty list if no matches were found
 	 */
 	@Override
-	public BookmarksEntry getBookmarksEntryByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return bookmarksEntryPersistence.findByUuid_C_First(uuid, companyId,
-			null);
+	public List<BookmarksEntry> getBookmarksEntriesByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return bookmarksEntryPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of bookmarks entries that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the bookmarks entries
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of bookmarks entries
+	 * @param end the upper bound of the range of bookmarks entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching bookmarks entries, or an empty list if no matches were found
+	 */
+	@Override
+	public List<BookmarksEntry> getBookmarksEntriesByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return bookmarksEntryPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/bookmarks/service/base/BookmarksFolderLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/service/base/BookmarksFolderLocalServiceBaseImpl.java
@@ -234,20 +234,6 @@ public abstract class BookmarksFolderLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the bookmarks folder with the matching UUID and company.
-	 *
-	 * @param uuid the bookmarks folder's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching bookmarks folder, or <code>null</code> if a matching bookmarks folder could not be found
-	 */
-	@Override
-	public BookmarksFolder fetchBookmarksFolderByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return bookmarksFolderPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the bookmarks folder matching the UUID and group.
 	 *
 	 * @param uuid the bookmarks folder's UUID
@@ -374,18 +360,34 @@ public abstract class BookmarksFolderLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the bookmarks folder with the matching UUID and company.
+	 * Returns all the bookmarks folders that match the UUID and company.
 	 *
-	 * @param uuid the bookmarks folder's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching bookmarks folder
-	 * @throws PortalException if a matching bookmarks folder could not be found
+	 * @param uuid the UUID of the bookmarks folders
+	 * @param companyId the primary key of the company
+	 * @return all the matching bookmarks folders, or an empty list if no matches were found
 	 */
 	@Override
-	public BookmarksFolder getBookmarksFolderByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return bookmarksFolderPersistence.findByUuid_C_First(uuid, companyId,
-			null);
+	public List<BookmarksFolder> getBookmarksFoldersByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return bookmarksFolderPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of bookmarks folders that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the bookmarks folders
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of bookmarks folders
+	 * @param end the upper bound of the range of bookmarks folders (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching bookmarks folders, or an empty list if no matches were found
+	 */
+	@Override
+	public List<BookmarksFolder> getBookmarksFoldersByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return bookmarksFolderPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/calendar/service/base/CalEventLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/calendar/service/base/CalEventLocalServiceBaseImpl.java
@@ -229,18 +229,6 @@ public abstract class CalEventLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the cal event with the matching UUID and company.
-	 *
-	 * @param uuid the cal event's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching cal event, or <code>null</code> if a matching cal event could not be found
-	 */
-	@Override
-	public CalEvent fetchCalEventByUuidAndCompanyId(String uuid, long companyId) {
-		return calEventPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the cal event matching the UUID and group.
 	 *
 	 * @param uuid the cal event's UUID
@@ -357,17 +345,33 @@ public abstract class CalEventLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the cal event with the matching UUID and company.
+	 * Returns all the cal events that match the UUID and company.
 	 *
-	 * @param uuid the cal event's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching cal event
-	 * @throws PortalException if a matching cal event could not be found
+	 * @param uuid the UUID of the cal events
+	 * @param companyId the primary key of the company
+	 * @return all the matching cal events, or an empty list if no matches were found
 	 */
 	@Override
-	public CalEvent getCalEventByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return calEventPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<CalEvent> getCalEventsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return calEventPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of cal events that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the cal events
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of cal events
+	 * @param end the upper bound of the range of cal events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching cal events, or an empty list if no matches were found
+	 */
+	@Override
+	public List<CalEvent> getCalEventsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return calEventPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryLocalServiceBaseImpl.java
@@ -244,19 +244,6 @@ public abstract class DLFileEntryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the document library file entry with the matching UUID and company.
-	 *
-	 * @param uuid the document library file entry's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
-	 */
-	@Override
-	public DLFileEntry fetchDLFileEntryByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return dlFileEntryPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the document library file entry matching the UUID and group.
 	 *
 	 * @param uuid the document library file entry's UUID
@@ -385,17 +372,33 @@ public abstract class DLFileEntryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the document library file entry with the matching UUID and company.
+	 * Returns all the document library file entries that match the UUID and company.
 	 *
-	 * @param uuid the document library file entry's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library file entry
-	 * @throws PortalException if a matching document library file entry could not be found
+	 * @param uuid the UUID of the document library file entries
+	 * @param companyId the primary key of the company
+	 * @return all the matching document library file entries, or an empty list if no matches were found
 	 */
 	@Override
-	public DLFileEntry getDLFileEntryByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return dlFileEntryPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<DLFileEntry> getDLFileEntriesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return dlFileEntryPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of document library file entries that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the document library file entries
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of document library file entries
+	 * @param end the upper bound of the range of document library file entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching document library file entries, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DLFileEntry> getDLFileEntriesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return dlFileEntryPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryTypeLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryTypeLocalServiceBaseImpl.java
@@ -226,20 +226,6 @@ public abstract class DLFileEntryTypeLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the document library file entry type with the matching UUID and company.
-	 *
-	 * @param uuid the document library file entry type's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
-	 */
-	@Override
-	public DLFileEntryType fetchDLFileEntryTypeByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return dlFileEntryTypePersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the document library file entry type matching the UUID and group.
 	 *
 	 * @param uuid the document library file entry type's UUID
@@ -358,18 +344,34 @@ public abstract class DLFileEntryTypeLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the document library file entry type with the matching UUID and company.
+	 * Returns all the document library file entry types that match the UUID and company.
 	 *
-	 * @param uuid the document library file entry type's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library file entry type
-	 * @throws PortalException if a matching document library file entry type could not be found
+	 * @param uuid the UUID of the document library file entry types
+	 * @param companyId the primary key of the company
+	 * @return all the matching document library file entry types, or an empty list if no matches were found
 	 */
 	@Override
-	public DLFileEntryType getDLFileEntryTypeByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return dlFileEntryTypePersistence.findByUuid_C_First(uuid, companyId,
-			null);
+	public List<DLFileEntryType> getDLFileEntryTypesByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return dlFileEntryTypePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of document library file entry types that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the document library file entry types
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of document library file entry types
+	 * @param end the upper bound of the range of document library file entry types (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching document library file entry types, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DLFileEntryType> getDLFileEntryTypesByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return dlFileEntryTypePersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileShortcutLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileShortcutLocalServiceBaseImpl.java
@@ -226,20 +226,6 @@ public abstract class DLFileShortcutLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the document library file shortcut with the matching UUID and company.
-	 *
-	 * @param uuid the document library file shortcut's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library file shortcut, or <code>null</code> if a matching document library file shortcut could not be found
-	 */
-	@Override
-	public DLFileShortcut fetchDLFileShortcutByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return dlFileShortcutPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the document library file shortcut matching the UUID and group.
 	 *
 	 * @param uuid the document library file shortcut's UUID
@@ -366,18 +352,34 @@ public abstract class DLFileShortcutLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the document library file shortcut with the matching UUID and company.
+	 * Returns all the document library file shortcuts that match the UUID and company.
 	 *
-	 * @param uuid the document library file shortcut's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library file shortcut
-	 * @throws PortalException if a matching document library file shortcut could not be found
+	 * @param uuid the UUID of the document library file shortcuts
+	 * @param companyId the primary key of the company
+	 * @return all the matching document library file shortcuts, or an empty list if no matches were found
 	 */
 	@Override
-	public DLFileShortcut getDLFileShortcutByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return dlFileShortcutPersistence.findByUuid_C_First(uuid, companyId,
-			null);
+	public List<DLFileShortcut> getDLFileShortcutsByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return dlFileShortcutPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of document library file shortcuts that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the document library file shortcuts
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of document library file shortcuts
+	 * @param end the upper bound of the range of document library file shortcuts (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching document library file shortcuts, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DLFileShortcut> getDLFileShortcutsByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return dlFileShortcutPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileVersionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileVersionLocalServiceBaseImpl.java
@@ -220,20 +220,6 @@ public abstract class DLFileVersionLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the document library file version with the matching UUID and company.
-	 *
-	 * @param uuid the document library file version's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library file version, or <code>null</code> if a matching document library file version could not be found
-	 */
-	@Override
-	public DLFileVersion fetchDLFileVersionByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return dlFileVersionPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the document library file version matching the UUID and group.
 	 *
 	 * @param uuid the document library file version's UUID
@@ -360,17 +346,34 @@ public abstract class DLFileVersionLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the document library file version with the matching UUID and company.
+	 * Returns all the document library file versions that match the UUID and company.
 	 *
-	 * @param uuid the document library file version's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library file version
-	 * @throws PortalException if a matching document library file version could not be found
+	 * @param uuid the UUID of the document library file versions
+	 * @param companyId the primary key of the company
+	 * @return all the matching document library file versions, or an empty list if no matches were found
 	 */
 	@Override
-	public DLFileVersion getDLFileVersionByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return dlFileVersionPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<DLFileVersion> getDLFileVersionsByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return dlFileVersionPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of document library file versions that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the document library file versions
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching document library file versions, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DLFileVersion> getDLFileVersionsByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return dlFileVersionPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFolderLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFolderLocalServiceBaseImpl.java
@@ -232,18 +232,6 @@ public abstract class DLFolderLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the document library folder with the matching UUID and company.
-	 *
-	 * @param uuid the document library folder's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library folder, or <code>null</code> if a matching document library folder could not be found
-	 */
-	@Override
-	public DLFolder fetchDLFolderByUuidAndCompanyId(String uuid, long companyId) {
-		return dlFolderPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the document library folder matching the UUID and group.
 	 *
 	 * @param uuid the document library folder's UUID
@@ -368,17 +356,33 @@ public abstract class DLFolderLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the document library folder with the matching UUID and company.
+	 * Returns all the document library folders that match the UUID and company.
 	 *
-	 * @param uuid the document library folder's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching document library folder
-	 * @throws PortalException if a matching document library folder could not be found
+	 * @param uuid the UUID of the document library folders
+	 * @param companyId the primary key of the company
+	 * @return all the matching document library folders, or an empty list if no matches were found
 	 */
 	@Override
-	public DLFolder getDLFolderByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return dlFolderPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<DLFolder> getDLFoldersByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return dlFolderPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of document library folders that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the document library folders
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of document library folders
+	 * @param end the upper bound of the range of document library folders (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching document library folders, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DLFolder> getDLFoldersByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return dlFolderPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/base/DDLRecordLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/base/DDLRecordLocalServiceBaseImpl.java
@@ -221,19 +221,6 @@ public abstract class DDLRecordLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the d d l record with the matching UUID and company.
-	 *
-	 * @param uuid the d d l record's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d l record, or <code>null</code> if a matching d d l record could not be found
-	 */
-	@Override
-	public DDLRecord fetchDDLRecordByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return ddlRecordPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the d d l record matching the UUID and group.
 	 *
 	 * @param uuid the d d l record's UUID
@@ -350,17 +337,33 @@ public abstract class DDLRecordLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the d d l record with the matching UUID and company.
+	 * Returns all the d d l records that match the UUID and company.
 	 *
-	 * @param uuid the d d l record's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d l record
-	 * @throws PortalException if a matching d d l record could not be found
+	 * @param uuid the UUID of the d d l records
+	 * @param companyId the primary key of the company
+	 * @return all the matching d d l records, or an empty list if no matches were found
 	 */
 	@Override
-	public DDLRecord getDDLRecordByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return ddlRecordPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<DDLRecord> getDDLRecordsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return ddlRecordPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of d d l records that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the d d l records
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of d d l records
+	 * @param end the upper bound of the range of d d l records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching d d l records, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DDLRecord> getDDLRecordsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return ddlRecordPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/base/DDLRecordSetLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/base/DDLRecordSetLocalServiceBaseImpl.java
@@ -222,19 +222,6 @@ public abstract class DDLRecordSetLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the d d l record set with the matching UUID and company.
-	 *
-	 * @param uuid the d d l record set's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d l record set, or <code>null</code> if a matching d d l record set could not be found
-	 */
-	@Override
-	public DDLRecordSet fetchDDLRecordSetByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return ddlRecordSetPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the d d l record set matching the UUID and group.
 	 *
 	 * @param uuid the d d l record set's UUID
@@ -353,17 +340,33 @@ public abstract class DDLRecordSetLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the d d l record set with the matching UUID and company.
+	 * Returns all the d d l record sets that match the UUID and company.
 	 *
-	 * @param uuid the d d l record set's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d l record set
-	 * @throws PortalException if a matching d d l record set could not be found
+	 * @param uuid the UUID of the d d l record sets
+	 * @param companyId the primary key of the company
+	 * @return all the matching d d l record sets, or an empty list if no matches were found
 	 */
 	@Override
-	public DDLRecordSet getDDLRecordSetByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return ddlRecordSetPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<DDLRecordSet> getDDLRecordSetsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return ddlRecordSetPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of d d l record sets that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the d d l record sets
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of d d l record sets
+	 * @param end the upper bound of the range of d d l record sets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching d d l record sets, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DDLRecordSet> getDDLRecordSetsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return ddlRecordSetPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMContentLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMContentLocalServiceBaseImpl.java
@@ -214,19 +214,6 @@ public abstract class DDMContentLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the d d m content with the matching UUID and company.
-	 *
-	 * @param uuid the d d m content's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d m content, or <code>null</code> if a matching d d m content could not be found
-	 */
-	@Override
-	public DDMContent fetchDDMContentByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return ddmContentPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the d d m content matching the UUID and group.
 	 *
 	 * @param uuid the d d m content's UUID
@@ -343,17 +330,33 @@ public abstract class DDMContentLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the d d m content with the matching UUID and company.
+	 * Returns all the d d m contents that match the UUID and company.
 	 *
-	 * @param uuid the d d m content's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d m content
-	 * @throws PortalException if a matching d d m content could not be found
+	 * @param uuid the UUID of the d d m contents
+	 * @param companyId the primary key of the company
+	 * @return all the matching d d m contents, or an empty list if no matches were found
 	 */
 	@Override
-	public DDMContent getDDMContentByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return ddmContentPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<DDMContent> getDDMContentsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return ddmContentPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of d d m contents that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the d d m contents
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of d d m contents
+	 * @param end the upper bound of the range of d d m contents (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching d d m contents, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DDMContent> getDDMContentsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return ddmContentPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMStructureLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMStructureLocalServiceBaseImpl.java
@@ -228,19 +228,6 @@ public abstract class DDMStructureLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the d d m structure with the matching UUID and company.
-	 *
-	 * @param uuid the d d m structure's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d m structure, or <code>null</code> if a matching d d m structure could not be found
-	 */
-	@Override
-	public DDMStructure fetchDDMStructureByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return ddmStructurePersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the d d m structure matching the UUID and group.
 	 *
 	 * @param uuid the d d m structure's UUID
@@ -369,17 +356,33 @@ public abstract class DDMStructureLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the d d m structure with the matching UUID and company.
+	 * Returns all the d d m structures that match the UUID and company.
 	 *
-	 * @param uuid the d d m structure's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d m structure
-	 * @throws PortalException if a matching d d m structure could not be found
+	 * @param uuid the UUID of the d d m structures
+	 * @param companyId the primary key of the company
+	 * @return all the matching d d m structures, or an empty list if no matches were found
 	 */
 	@Override
-	public DDMStructure getDDMStructureByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return ddmStructurePersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<DDMStructure> getDDMStructuresByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return ddmStructurePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of d d m structures that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the d d m structures
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of d d m structures
+	 * @param end the upper bound of the range of d d m structures (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching d d m structures, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DDMStructure> getDDMStructuresByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return ddmStructurePersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMTemplateLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMTemplateLocalServiceBaseImpl.java
@@ -224,19 +224,6 @@ public abstract class DDMTemplateLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the d d m template with the matching UUID and company.
-	 *
-	 * @param uuid the d d m template's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d m template, or <code>null</code> if a matching d d m template could not be found
-	 */
-	@Override
-	public DDMTemplate fetchDDMTemplateByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return ddmTemplatePersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the d d m template matching the UUID and group.
 	 *
 	 * @param uuid the d d m template's UUID
@@ -365,17 +352,33 @@ public abstract class DDMTemplateLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the d d m template with the matching UUID and company.
+	 * Returns all the d d m templates that match the UUID and company.
 	 *
-	 * @param uuid the d d m template's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching d d m template
-	 * @throws PortalException if a matching d d m template could not be found
+	 * @param uuid the UUID of the d d m templates
+	 * @param companyId the primary key of the company
+	 * @return all the matching d d m templates, or an empty list if no matches were found
 	 */
 	@Override
-	public DDMTemplate getDDMTemplateByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return ddmTemplatePersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<DDMTemplate> getDDMTemplatesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return ddmTemplatePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of d d m templates that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the d d m templates
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of d d m templates
+	 * @param end the upper bound of the range of d d m templates (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching d d m templates, or an empty list if no matches were found
+	 */
+	@Override
+	public List<DDMTemplate> getDDMTemplatesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return ddmTemplatePersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/journal/action/EditArticleAction.java
+++ b/portal-impl/src/com/liferay/portlet/journal/action/EditArticleAction.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.TrashedModel;
 import com.liferay.portal.security.auth.PrincipalException;
-import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextFactory;
 import com.liferay.portal.struts.PortletAction;
@@ -578,16 +577,7 @@ public class EditArticleAction extends PortletAction {
 		String layoutUuid = ParamUtil.getString(
 			uploadPortletRequest, "layoutUuid");
 
-		// The target page and the article must belong to the same group
-
-		Layout targetLayout =
-			LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
-				layoutUuid, groupId, false);
-
-		if (targetLayout == null) {
-			targetLayout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
-				layoutUuid, groupId, true);
-		}
+		Layout targetLayout = JournalUtil.getArticleLayout(layoutUuid, groupId);
 
 		if (targetLayout == null) {
 			layoutUuid = null;

--- a/portal-impl/src/com/liferay/portlet/journal/asset/JournalArticleAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/journal/asset/JournalArticleAssetRenderer.java
@@ -44,6 +44,7 @@ import com.liferay.portlet.journal.model.JournalArticleDisplay;
 import com.liferay.portlet.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.portlet.journal.service.JournalContentSearchLocalServiceUtil;
 import com.liferay.portlet.journal.service.permission.JournalArticlePermission;
+import com.liferay.portlet.journal.util.JournalUtil;
 
 import java.util.Date;
 import java.util.List;
@@ -286,8 +287,7 @@ public class JournalArticleAssetRenderer
 		Layout layout = themeDisplay.getLayout();
 
 		if (Validator.isNotNull(_article.getLayoutUuid())) {
-			layout = LayoutLocalServiceUtil.getLayoutByUuidAndCompanyId(
-				_article.getLayoutUuid(), _article.getCompanyId());
+			layout = JournalUtil.getArticleLayout(_article);
 		}
 
 		String portletId = (String)liferayPortletRequest.getAttribute(

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalArticleStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalArticleStagedModelDataHandler.java
@@ -40,7 +40,6 @@ import com.liferay.portal.model.Image;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.ImageLocalServiceUtil;
-import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
@@ -57,6 +56,7 @@ import com.liferay.portlet.journal.model.JournalFolderConstants;
 import com.liferay.portlet.journal.service.JournalArticleImageLocalServiceUtil;
 import com.liferay.portlet.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.portlet.journal.service.JournalArticleResourceLocalServiceUtil;
+import com.liferay.portlet.journal.util.JournalUtil;
 
 import java.io.File;
 
@@ -308,10 +308,9 @@ public class JournalArticleStagedModelDataHandler
 			portletDataContext, article, ddmTemplate,
 			PortletDataContext.REFERENCE_TYPE_STRONG);
 
-		if (Validator.isNotNull(article.getLayoutUuid())) {
-			Layout layout = LayoutLocalServiceUtil.getLayoutByUuidAndCompanyId(
-				article.getLayoutUuid(), portletDataContext.getCompanyId());
+		Layout layout = JournalUtil.getArticleLayout(article);
 
+		if (layout != null) {
 			portletDataContext.addReferenceElement(
 				article, articleElement, layout,
 				PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);

--- a/portal-impl/src/com/liferay/portlet/journal/service/base/JournalArticleLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/base/JournalArticleLocalServiceBaseImpl.java
@@ -256,20 +256,6 @@ public abstract class JournalArticleLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the journal article with the matching UUID and company.
-	 *
-	 * @param uuid the journal article's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching journal article, or <code>null</code> if a matching journal article could not be found
-	 */
-	@Override
-	public JournalArticle fetchJournalArticleByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return journalArticlePersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the journal article matching the UUID and group.
 	 *
 	 * @param uuid the journal article's UUID
@@ -411,18 +397,34 @@ public abstract class JournalArticleLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the journal article with the matching UUID and company.
+	 * Returns all the journal articles that match the UUID and company.
 	 *
-	 * @param uuid the journal article's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching journal article
-	 * @throws PortalException if a matching journal article could not be found
+	 * @param uuid the UUID of the journal articles
+	 * @param companyId the primary key of the company
+	 * @return all the matching journal articles, or an empty list if no matches were found
 	 */
 	@Override
-	public JournalArticle getJournalArticleByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return journalArticlePersistence.findByUuid_C_First(uuid, companyId,
-			null);
+	public List<JournalArticle> getJournalArticlesByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return journalArticlePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of journal articles that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the journal articles
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching journal articles, or an empty list if no matches were found
+	 */
+	@Override
+	public List<JournalArticle> getJournalArticlesByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return journalArticlePersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/journal/service/base/JournalFeedLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/base/JournalFeedLocalServiceBaseImpl.java
@@ -219,19 +219,6 @@ public abstract class JournalFeedLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the journal feed with the matching UUID and company.
-	 *
-	 * @param uuid the journal feed's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching journal feed, or <code>null</code> if a matching journal feed could not be found
-	 */
-	@Override
-	public JournalFeed fetchJournalFeedByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return journalFeedPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the journal feed matching the UUID and group.
 	 *
 	 * @param uuid the journal feed's UUID
@@ -349,17 +336,33 @@ public abstract class JournalFeedLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the journal feed with the matching UUID and company.
+	 * Returns all the journal feeds that match the UUID and company.
 	 *
-	 * @param uuid the journal feed's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching journal feed
-	 * @throws PortalException if a matching journal feed could not be found
+	 * @param uuid the UUID of the journal feeds
+	 * @param companyId the primary key of the company
+	 * @return all the matching journal feeds, or an empty list if no matches were found
 	 */
 	@Override
-	public JournalFeed getJournalFeedByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return journalFeedPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<JournalFeed> getJournalFeedsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return journalFeedPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of journal feeds that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the journal feeds
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of journal feeds
+	 * @param end the upper bound of the range of journal feeds (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching journal feeds, or an empty list if no matches were found
+	 */
+	@Override
+	public List<JournalFeed> getJournalFeedsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return journalFeedPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/journal/service/base/JournalFolderLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/base/JournalFolderLocalServiceBaseImpl.java
@@ -237,20 +237,6 @@ public abstract class JournalFolderLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the journal folder with the matching UUID and company.
-	 *
-	 * @param uuid the journal folder's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
-	 */
-	@Override
-	public JournalFolder fetchJournalFolderByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return journalFolderPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the journal folder matching the UUID and group.
 	 *
 	 * @param uuid the journal folder's UUID
@@ -377,17 +363,34 @@ public abstract class JournalFolderLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the journal folder with the matching UUID and company.
+	 * Returns all the journal folders that match the UUID and company.
 	 *
-	 * @param uuid the journal folder's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching journal folder
-	 * @throws PortalException if a matching journal folder could not be found
+	 * @param uuid the UUID of the journal folders
+	 * @param companyId the primary key of the company
+	 * @return all the matching journal folders, or an empty list if no matches were found
 	 */
 	@Override
-	public JournalFolder getJournalFolderByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return journalFolderPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<JournalFolder> getJournalFoldersByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return journalFolderPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of journal folders that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the journal folders
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of journal folders
+	 * @param end the upper bound of the range of journal folders (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching journal folders, or an empty list if no matches were found
+	 */
+	@Override
+	public List<JournalFolder> getJournalFoldersByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return journalFolderPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/journal/util/JournalUtil.java
+++ b/portal-impl/src/com/liferay/portlet/journal/util/JournalUtil.java
@@ -559,6 +559,33 @@ public class JournalUtil {
 		return sb.toString();
 	}
 
+	public static Layout getArticleLayout(JournalArticle journalArticle) {
+		if (Validator.isNull(journalArticle)) {
+			return null;
+		}
+
+		return getArticleLayout(
+			journalArticle.getLayoutUuid(), journalArticle.getGroupId());
+	}
+
+	public static Layout getArticleLayout(String layoutUuid, long groupId) {
+		if (Validator.isNull(layoutUuid)) {
+			return null;
+		}
+
+		// The target page and the article must belong to the same group
+
+		Layout layout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
+			layoutUuid, groupId, false);
+
+		if (layout == null) {
+			layout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
+				layoutUuid, groupId, false);
+		}
+
+		return layout;
+	}
+
 	public static OrderByComparator<JournalArticle> getArticleOrderByComparator(
 		String orderByCol, String orderByType) {
 
@@ -1002,15 +1029,13 @@ public class JournalUtil {
 			JournalArticle article, ThemeDisplay themeDisplay)
 		throws Exception {
 
-		if ((article != null) && Validator.isNotNull(article.getLayoutUuid())) {
-			Layout layout =
-				LayoutLocalServiceUtil.getLayoutByUuidAndCompanyId(
-					article.getLayoutUuid(), themeDisplay.getCompanyId());
+		Layout layout = getArticleLayout(article);
 
+		if (layout != null) {
 			return layout.getPlid();
 		}
 
-		Layout layout = LayoutLocalServiceUtil.fetchFirstLayout(
+		layout = LayoutLocalServiceUtil.fetchFirstLayout(
 			themeDisplay.getScopeGroupId(), false,
 			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBBanLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBBanLocalServiceBaseImpl.java
@@ -211,18 +211,6 @@ public abstract class MBBanLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the message boards ban with the matching UUID and company.
-	 *
-	 * @param uuid the message boards ban's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards ban, or <code>null</code> if a matching message boards ban could not be found
-	 */
-	@Override
-	public MBBan fetchMBBanByUuidAndCompanyId(String uuid, long companyId) {
-		return mbBanPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the message boards ban matching the UUID and group.
 	 *
 	 * @param uuid the message boards ban's UUID
@@ -339,17 +327,32 @@ public abstract class MBBanLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the message boards ban with the matching UUID and company.
+	 * Returns all the message boards bans that match the UUID and company.
 	 *
-	 * @param uuid the message boards ban's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards ban
-	 * @throws PortalException if a matching message boards ban could not be found
+	 * @param uuid the UUID of the message boards bans
+	 * @param companyId the primary key of the company
+	 * @return all the matching message boards bans, or an empty list if no matches were found
 	 */
 	@Override
-	public MBBan getMBBanByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return mbBanPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MBBan> getMBBansByUuidAndCompanyId(String uuid, long companyId) {
+		return mbBanPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of message boards bans that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the message boards bans
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of message boards bans
+	 * @param end the upper bound of the range of message boards bans (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching message boards bans, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MBBan> getMBBansByUuidAndCompanyId(String uuid, long companyId,
+		int start, int end, OrderByComparator orderByComparator) {
+		return mbBanPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBCategoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBCategoryLocalServiceBaseImpl.java
@@ -235,19 +235,6 @@ public abstract class MBCategoryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the message boards category with the matching UUID and company.
-	 *
-	 * @param uuid the message boards category's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
-	 */
-	@Override
-	public MBCategory fetchMBCategoryByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return mbCategoryPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the message boards category matching the UUID and group.
 	 *
 	 * @param uuid the message boards category's UUID
@@ -372,17 +359,33 @@ public abstract class MBCategoryLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the message boards category with the matching UUID and company.
+	 * Returns all the message boards categories that match the UUID and company.
 	 *
-	 * @param uuid the message boards category's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards category
-	 * @throws PortalException if a matching message boards category could not be found
+	 * @param uuid the UUID of the message boards categories
+	 * @param companyId the primary key of the company
+	 * @return all the matching message boards categories, or an empty list if no matches were found
 	 */
 	@Override
-	public MBCategory getMBCategoryByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return mbCategoryPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MBCategory> getMBCategoriesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return mbCategoryPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of message boards categories that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the message boards categories
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of message boards categories
+	 * @param end the upper bound of the range of message boards categories (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching message boards categories, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MBCategory> getMBCategoriesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return mbCategoryPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBDiscussionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBDiscussionLocalServiceBaseImpl.java
@@ -223,19 +223,6 @@ public abstract class MBDiscussionLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the message boards discussion with the matching UUID and company.
-	 *
-	 * @param uuid the message boards discussion's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards discussion, or <code>null</code> if a matching message boards discussion could not be found
-	 */
-	@Override
-	public MBDiscussion fetchMBDiscussionByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return mbDiscussionPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the message boards discussion matching the UUID and group.
 	 *
 	 * @param uuid the message boards discussion's UUID
@@ -364,17 +351,33 @@ public abstract class MBDiscussionLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the message boards discussion with the matching UUID and company.
+	 * Returns all the message boards discussions that match the UUID and company.
 	 *
-	 * @param uuid the message boards discussion's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards discussion
-	 * @throws PortalException if a matching message boards discussion could not be found
+	 * @param uuid the UUID of the message boards discussions
+	 * @param companyId the primary key of the company
+	 * @return all the matching message boards discussions, or an empty list if no matches were found
 	 */
 	@Override
-	public MBDiscussion getMBDiscussionByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return mbDiscussionPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MBDiscussion> getMBDiscussionsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return mbDiscussionPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of message boards discussions that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the message boards discussions
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of message boards discussions
+	 * @param end the upper bound of the range of message boards discussions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching message boards discussions, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MBDiscussion> getMBDiscussionsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return mbDiscussionPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBMailingListLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBMailingListLocalServiceBaseImpl.java
@@ -214,20 +214,6 @@ public abstract class MBMailingListLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the message boards mailing list with the matching UUID and company.
-	 *
-	 * @param uuid the message boards mailing list's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards mailing list, or <code>null</code> if a matching message boards mailing list could not be found
-	 */
-	@Override
-	public MBMailingList fetchMBMailingListByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return mbMailingListPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the message boards mailing list matching the UUID and group.
 	 *
 	 * @param uuid the message boards mailing list's UUID
@@ -346,17 +332,34 @@ public abstract class MBMailingListLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the message boards mailing list with the matching UUID and company.
+	 * Returns all the message boards mailing lists that match the UUID and company.
 	 *
-	 * @param uuid the message boards mailing list's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards mailing list
-	 * @throws PortalException if a matching message boards mailing list could not be found
+	 * @param uuid the UUID of the message boards mailing lists
+	 * @param companyId the primary key of the company
+	 * @return all the matching message boards mailing lists, or an empty list if no matches were found
 	 */
 	@Override
-	public MBMailingList getMBMailingListByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return mbMailingListPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MBMailingList> getMBMailingListsByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return mbMailingListPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of message boards mailing lists that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the message boards mailing lists
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of message boards mailing lists
+	 * @param end the upper bound of the range of message boards mailing lists (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching message boards mailing lists, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MBMailingList> getMBMailingListsByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return mbMailingListPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBMessageLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBMessageLocalServiceBaseImpl.java
@@ -247,19 +247,6 @@ public abstract class MBMessageLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the message-boards message with the matching UUID and company.
-	 *
-	 * @param uuid the message-boards message's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
-	 */
-	@Override
-	public MBMessage fetchMBMessageByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return mbMessagePersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the message-boards message matching the UUID and group.
 	 *
 	 * @param uuid the message-boards message's UUID
@@ -394,17 +381,33 @@ public abstract class MBMessageLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the message-boards message with the matching UUID and company.
+	 * Returns all the message-boards messages that match the UUID and company.
 	 *
-	 * @param uuid the message-boards message's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message-boards message
-	 * @throws PortalException if a matching message-boards message could not be found
+	 * @param uuid the UUID of the message-boards messages
+	 * @param companyId the primary key of the company
+	 * @return all the matching message-boards messages, or an empty list if no matches were found
 	 */
 	@Override
-	public MBMessage getMBMessageByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return mbMessagePersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MBMessage> getMBMessagesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return mbMessagePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of message-boards messages that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the message-boards messages
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of message-boards messages
+	 * @param end the upper bound of the range of message-boards messages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching message-boards messages, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MBMessage> getMBMessagesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return mbMessagePersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBThreadFlagLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBThreadFlagLocalServiceBaseImpl.java
@@ -214,19 +214,6 @@ public abstract class MBThreadFlagLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the message boards thread flag with the matching UUID and company.
-	 *
-	 * @param uuid the message boards thread flag's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards thread flag, or <code>null</code> if a matching message boards thread flag could not be found
-	 */
-	@Override
-	public MBThreadFlag fetchMBThreadFlagByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return mbThreadFlagPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the message boards thread flag matching the UUID and group.
 	 *
 	 * @param uuid the message boards thread flag's UUID
@@ -345,17 +332,33 @@ public abstract class MBThreadFlagLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the message boards thread flag with the matching UUID and company.
+	 * Returns all the message boards thread flags that match the UUID and company.
 	 *
-	 * @param uuid the message boards thread flag's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards thread flag
-	 * @throws PortalException if a matching message boards thread flag could not be found
+	 * @param uuid the UUID of the message boards thread flags
+	 * @param companyId the primary key of the company
+	 * @return all the matching message boards thread flags, or an empty list if no matches were found
 	 */
 	@Override
-	public MBThreadFlag getMBThreadFlagByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return mbThreadFlagPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MBThreadFlag> getMBThreadFlagsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return mbThreadFlagPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of message boards thread flags that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the message boards thread flags
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of message boards thread flags
+	 * @param end the upper bound of the range of message boards thread flags (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching message boards thread flags, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MBThreadFlag> getMBThreadFlagsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return mbThreadFlagPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBThreadLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBThreadLocalServiceBaseImpl.java
@@ -236,18 +236,6 @@ public abstract class MBThreadLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the message boards thread with the matching UUID and company.
-	 *
-	 * @param uuid the message boards thread's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards thread, or <code>null</code> if a matching message boards thread could not be found
-	 */
-	@Override
-	public MBThread fetchMBThreadByUuidAndCompanyId(String uuid, long companyId) {
-		return mbThreadPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the message boards thread matching the UUID and group.
 	 *
 	 * @param uuid the message boards thread's UUID
@@ -372,17 +360,33 @@ public abstract class MBThreadLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the message boards thread with the matching UUID and company.
+	 * Returns all the message boards threads that match the UUID and company.
 	 *
-	 * @param uuid the message boards thread's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching message boards thread
-	 * @throws PortalException if a matching message boards thread could not be found
+	 * @param uuid the UUID of the message boards threads
+	 * @param companyId the primary key of the company
+	 * @return all the matching message boards threads, or an empty list if no matches were found
 	 */
 	@Override
-	public MBThread getMBThreadByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return mbThreadPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MBThread> getMBThreadsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return mbThreadPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of message boards threads that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the message boards threads
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of message boards threads
+	 * @param end the upper bound of the range of message boards threads (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching message boards threads, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MBThread> getMBThreadsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return mbThreadPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRActionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRActionLocalServiceBaseImpl.java
@@ -216,19 +216,6 @@ public abstract class MDRActionLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the m d r action with the matching UUID and company.
-	 *
-	 * @param uuid the m d r action's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching m d r action, or <code>null</code> if a matching m d r action could not be found
-	 */
-	@Override
-	public MDRAction fetchMDRActionByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return mdrActionPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the m d r action matching the UUID and group.
 	 *
 	 * @param uuid the m d r action's UUID
@@ -355,17 +342,33 @@ public abstract class MDRActionLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the m d r action with the matching UUID and company.
+	 * Returns all the m d r actions that match the UUID and company.
 	 *
-	 * @param uuid the m d r action's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching m d r action
-	 * @throws PortalException if a matching m d r action could not be found
+	 * @param uuid the UUID of the m d r actions
+	 * @param companyId the primary key of the company
+	 * @return all the matching m d r actions, or an empty list if no matches were found
 	 */
 	@Override
-	public MDRAction getMDRActionByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return mdrActionPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MDRAction> getMDRActionsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return mdrActionPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of m d r actions that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the m d r actions
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of m d r actions
+	 * @param end the upper bound of the range of m d r actions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching m d r actions, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MDRAction> getMDRActionsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return mdrActionPersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleGroupInstanceLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleGroupInstanceLocalServiceBaseImpl.java
@@ -228,20 +228,6 @@ public abstract class MDRRuleGroupInstanceLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the m d r rule group instance with the matching UUID and company.
-	 *
-	 * @param uuid the m d r rule group instance's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching m d r rule group instance, or <code>null</code> if a matching m d r rule group instance could not be found
-	 */
-	@Override
-	public MDRRuleGroupInstance fetchMDRRuleGroupInstanceByUuidAndCompanyId(
-		String uuid, long companyId) {
-		return mdrRuleGroupInstancePersistence.fetchByUuid_C_First(uuid,
-			companyId, null);
-	}
-
-	/**
 	 * Returns the m d r rule group instance matching the UUID and group.
 	 *
 	 * @param uuid the m d r rule group instance's UUID
@@ -370,18 +356,34 @@ public abstract class MDRRuleGroupInstanceLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the m d r rule group instance with the matching UUID and company.
+	 * Returns all the m d r rule group instances that match the UUID and company.
 	 *
-	 * @param uuid the m d r rule group instance's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching m d r rule group instance
-	 * @throws PortalException if a matching m d r rule group instance could not be found
+	 * @param uuid the UUID of the m d r rule group instances
+	 * @param companyId the primary key of the company
+	 * @return all the matching m d r rule group instances, or an empty list if no matches were found
 	 */
 	@Override
-	public MDRRuleGroupInstance getMDRRuleGroupInstanceByUuidAndCompanyId(
-		String uuid, long companyId) throws PortalException {
-		return mdrRuleGroupInstancePersistence.findByUuid_C_First(uuid,
-			companyId, null);
+	public List<MDRRuleGroupInstance> getMDRRuleGroupInstancesByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return mdrRuleGroupInstancePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of m d r rule group instances that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the m d r rule group instances
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of m d r rule group instances
+	 * @param end the upper bound of the range of m d r rule group instances (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching m d r rule group instances, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MDRRuleGroupInstance> getMDRRuleGroupInstancesByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return mdrRuleGroupInstancePersistence.findByUuid_C(uuid, companyId,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleGroupLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleGroupLocalServiceBaseImpl.java
@@ -220,19 +220,6 @@ public abstract class MDRRuleGroupLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the m d r rule group with the matching UUID and company.
-	 *
-	 * @param uuid the m d r rule group's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching m d r rule group, or <code>null</code> if a matching m d r rule group could not be found
-	 */
-	@Override
-	public MDRRuleGroup fetchMDRRuleGroupByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return mdrRuleGroupPersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the m d r rule group matching the UUID and group.
 	 *
 	 * @param uuid the m d r rule group's UUID
@@ -351,17 +338,33 @@ public abstract class MDRRuleGroupLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the m d r rule group with the matching UUID and company.
+	 * Returns all the m d r rule groups that match the UUID and company.
 	 *
-	 * @param uuid the m d r rule group's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching m d r rule group
-	 * @throws PortalException if a matching m d r rule group could not be found
+	 * @param uuid the UUID of the m d r rule groups
+	 * @param companyId the primary key of the company
+	 * @return all the matching m d r rule groups, or an empty list if no matches were found
 	 */
 	@Override
-	public MDRRuleGroup getMDRRuleGroupByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return mdrRuleGroupPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MDRRuleGroup> getMDRRuleGroupsByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return mdrRuleGroupPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of m d r rule groups that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the m d r rule groups
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of m d r rule groups
+	 * @param end the upper bound of the range of m d r rule groups (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching m d r rule groups, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MDRRuleGroup> getMDRRuleGroupsByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return mdrRuleGroupPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleLocalServiceBaseImpl.java
@@ -213,18 +213,6 @@ public abstract class MDRRuleLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the m d r rule with the matching UUID and company.
-	 *
-	 * @param uuid the m d r rule's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching m d r rule, or <code>null</code> if a matching m d r rule could not be found
-	 */
-	@Override
-	public MDRRule fetchMDRRuleByUuidAndCompanyId(String uuid, long companyId) {
-		return mdrRulePersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the m d r rule matching the UUID and group.
 	 *
 	 * @param uuid the m d r rule's UUID
@@ -341,17 +329,33 @@ public abstract class MDRRuleLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the m d r rule with the matching UUID and company.
+	 * Returns all the m d r rules that match the UUID and company.
 	 *
-	 * @param uuid the m d r rule's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching m d r rule
-	 * @throws PortalException if a matching m d r rule could not be found
+	 * @param uuid the UUID of the m d r rules
+	 * @param companyId the primary key of the company
+	 * @return all the matching m d r rules, or an empty list if no matches were found
 	 */
 	@Override
-	public MDRRule getMDRRuleByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return mdrRulePersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<MDRRule> getMDRRulesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return mdrRulePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of m d r rules that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the m d r rules
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of m d r rules
+	 * @param end the upper bound of the range of m d r rules (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching m d r rules, or an empty list if no matches were found
+	 */
+	@Override
+	public List<MDRRule> getMDRRulesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return mdrRulePersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/polls/service/base/PollsChoiceLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/service/base/PollsChoiceLocalServiceBaseImpl.java
@@ -215,19 +215,6 @@ public abstract class PollsChoiceLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the polls choice with the matching UUID and company.
-	 *
-	 * @param uuid the polls choice's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching polls choice, or <code>null</code> if a matching polls choice could not be found
-	 */
-	@Override
-	public PollsChoice fetchPollsChoiceByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return pollsChoicePersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the polls choice matching the UUID and group.
 	 *
 	 * @param uuid the polls choice's UUID
@@ -345,17 +332,33 @@ public abstract class PollsChoiceLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the polls choice with the matching UUID and company.
+	 * Returns all the polls choices that match the UUID and company.
 	 *
-	 * @param uuid the polls choice's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching polls choice
-	 * @throws PortalException if a matching polls choice could not be found
+	 * @param uuid the UUID of the polls choices
+	 * @param companyId the primary key of the company
+	 * @return all the matching polls choices, or an empty list if no matches were found
 	 */
 	@Override
-	public PollsChoice getPollsChoiceByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return pollsChoicePersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<PollsChoice> getPollsChoicesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return pollsChoicePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of polls choices that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the polls choices
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of polls choices
+	 * @param end the upper bound of the range of polls choices (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching polls choices, or an empty list if no matches were found
+	 */
+	@Override
+	public List<PollsChoice> getPollsChoicesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return pollsChoicePersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/polls/service/base/PollsQuestionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/service/base/PollsQuestionLocalServiceBaseImpl.java
@@ -217,20 +217,6 @@ public abstract class PollsQuestionLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the polls question with the matching UUID and company.
-	 *
-	 * @param uuid the polls question's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching polls question, or <code>null</code> if a matching polls question could not be found
-	 */
-	@Override
-	public PollsQuestion fetchPollsQuestionByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return pollsQuestionPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the polls question matching the UUID and group.
 	 *
 	 * @param uuid the polls question's UUID
@@ -349,17 +335,34 @@ public abstract class PollsQuestionLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the polls question with the matching UUID and company.
+	 * Returns all the polls questions that match the UUID and company.
 	 *
-	 * @param uuid the polls question's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching polls question
-	 * @throws PortalException if a matching polls question could not be found
+	 * @param uuid the UUID of the polls questions
+	 * @param companyId the primary key of the company
+	 * @return all the matching polls questions, or an empty list if no matches were found
 	 */
 	@Override
-	public PollsQuestion getPollsQuestionByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return pollsQuestionPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<PollsQuestion> getPollsQuestionsByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return pollsQuestionPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of polls questions that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the polls questions
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of polls questions
+	 * @param end the upper bound of the range of polls questions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching polls questions, or an empty list if no matches were found
+	 */
+	@Override
+	public List<PollsQuestion> getPollsQuestionsByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return pollsQuestionPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/polls/service/base/PollsVoteLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/service/base/PollsVoteLocalServiceBaseImpl.java
@@ -214,19 +214,6 @@ public abstract class PollsVoteLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the polls vote with the matching UUID and company.
-	 *
-	 * @param uuid the polls vote's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching polls vote, or <code>null</code> if a matching polls vote could not be found
-	 */
-	@Override
-	public PollsVote fetchPollsVoteByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return pollsVotePersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the polls vote matching the UUID and group.
 	 *
 	 * @param uuid the polls vote's UUID
@@ -343,17 +330,33 @@ public abstract class PollsVoteLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the polls vote with the matching UUID and company.
+	 * Returns all the polls votes that match the UUID and company.
 	 *
-	 * @param uuid the polls vote's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching polls vote
-	 * @throws PortalException if a matching polls vote could not be found
+	 * @param uuid the UUID of the polls votes
+	 * @param companyId the primary key of the company
+	 * @return all the matching polls votes, or an empty list if no matches were found
 	 */
 	@Override
-	public PollsVote getPollsVoteByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return pollsVotePersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<PollsVote> getPollsVotesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return pollsVotePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of polls votes that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the polls votes
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of polls votes
+	 * @param end the upper bound of the range of polls votes (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching polls votes, or an empty list if no matches were found
+	 */
+	@Override
+	public List<PollsVote> getPollsVotesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return pollsVotePersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/social/service/base/SocialRequestLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/base/SocialRequestLocalServiceBaseImpl.java
@@ -209,20 +209,6 @@ public abstract class SocialRequestLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the social request with the matching UUID and company.
-	 *
-	 * @param uuid the social request's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching social request, or <code>null</code> if a matching social request could not be found
-	 */
-	@Override
-	public SocialRequest fetchSocialRequestByUuidAndCompanyId(String uuid,
-		long companyId) {
-		return socialRequestPersistence.fetchByUuid_C_First(uuid, companyId,
-			null);
-	}
-
-	/**
 	 * Returns the social request matching the UUID and group.
 	 *
 	 * @param uuid the social request's UUID
@@ -286,17 +272,34 @@ public abstract class SocialRequestLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the social request with the matching UUID and company.
+	 * Returns all the social requests that match the UUID and company.
 	 *
-	 * @param uuid the social request's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching social request
-	 * @throws PortalException if a matching social request could not be found
+	 * @param uuid the UUID of the social requests
+	 * @param companyId the primary key of the company
+	 * @return all the matching social requests, or an empty list if no matches were found
 	 */
 	@Override
-	public SocialRequest getSocialRequestByUuidAndCompanyId(String uuid,
-		long companyId) throws PortalException {
-		return socialRequestPersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<SocialRequest> getSocialRequestsByUuidAndCompanyId(
+		String uuid, long companyId) {
+		return socialRequestPersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of social requests that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the social requests
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of social requests
+	 * @param end the upper bound of the range of social requests (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching social requests, or an empty list if no matches were found
+	 */
+	@Override
+	public List<SocialRequest> getSocialRequestsByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		OrderByComparator orderByComparator) {
+		return socialRequestPersistence.findByUuid_C(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiNodeLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiNodeLocalServiceBaseImpl.java
@@ -226,18 +226,6 @@ public abstract class WikiNodeLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the wiki node with the matching UUID and company.
-	 *
-	 * @param uuid the wiki node's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
-	 */
-	@Override
-	public WikiNode fetchWikiNodeByUuidAndCompanyId(String uuid, long companyId) {
-		return wikiNodePersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the wiki node matching the UUID and group.
 	 *
 	 * @param uuid the wiki node's UUID
@@ -362,17 +350,33 @@ public abstract class WikiNodeLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the wiki node with the matching UUID and company.
+	 * Returns all the wiki nodes that match the UUID and company.
 	 *
-	 * @param uuid the wiki node's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching wiki node
-	 * @throws PortalException if a matching wiki node could not be found
+	 * @param uuid the UUID of the wiki nodes
+	 * @param companyId the primary key of the company
+	 * @return all the matching wiki nodes, or an empty list if no matches were found
 	 */
 	@Override
-	public WikiNode getWikiNodeByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return wikiNodePersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<WikiNode> getWikiNodesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return wikiNodePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of wiki nodes that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the wiki nodes
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of wiki nodes
+	 * @param end the upper bound of the range of wiki nodes (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching wiki nodes, or an empty list if no matches were found
+	 */
+	@Override
+	public List<WikiNode> getWikiNodesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return wikiNodePersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiPageLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiPageLocalServiceBaseImpl.java
@@ -243,18 +243,6 @@ public abstract class WikiPageLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the wiki page with the matching UUID and company.
-	 *
-	 * @param uuid the wiki page's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	 */
-	@Override
-	public WikiPage fetchWikiPageByUuidAndCompanyId(String uuid, long companyId) {
-		return wikiPagePersistence.fetchByUuid_C_First(uuid, companyId, null);
-	}
-
-	/**
 	 * Returns the wiki page matching the UUID and group.
 	 *
 	 * @param uuid the wiki page's UUID
@@ -385,17 +373,33 @@ public abstract class WikiPageLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
-	 * Returns the wiki page with the matching UUID and company.
+	 * Returns all the wiki pages that match the UUID and company.
 	 *
-	 * @param uuid the wiki page's UUID
-	 * @param  companyId the primary key of the company
-	 * @return the matching wiki page
-	 * @throws PortalException if a matching wiki page could not be found
+	 * @param uuid the UUID of the wiki pages
+	 * @param companyId the primary key of the company
+	 * @return all the matching wiki pages, or an empty list if no matches were found
 	 */
 	@Override
-	public WikiPage getWikiPageByUuidAndCompanyId(String uuid, long companyId)
-		throws PortalException {
-		return wikiPagePersistence.findByUuid_C_First(uuid, companyId, null);
+	public List<WikiPage> getWikiPagesByUuidAndCompanyId(String uuid,
+		long companyId) {
+		return wikiPagePersistence.findByUuid_C(uuid, companyId);
+	}
+
+	/**
+	 * Returns a range of wiki pages that match the UUID and company.
+	 *
+	 * @param uuid the UUID of the wiki pages
+	 * @param companyId the primary key of the company
+	 * @param start the lower bound of the range of wiki pages
+	 * @param end the upper bound of the range of wiki pages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return all the matching wiki pages, or an empty list if no matches were found
+	 */
+	@Override
+	public List<WikiPage> getWikiPagesByUuidAndCompanyId(String uuid,
+		long companyId, int start, int end, OrderByComparator orderByComparator) {
+		return wikiPagePersistence.findByUuid_C(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/LayoutFriendlyURLLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutFriendlyURLLocalService.java
@@ -200,17 +200,6 @@ public interface LayoutFriendlyURLLocalService extends BaseLocalService,
 		long plid, java.lang.String languageId, boolean useDefault);
 
 	/**
-	* Returns the layout friendly u r l with the matching UUID and company.
-	*
-	* @param uuid the layout friendly u r l's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout friendly u r l, or <code>null</code> if a matching layout friendly u r l could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portal.model.LayoutFriendlyURL fetchLayoutFriendlyURLByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the layout friendly u r l matching the UUID and group.
 	*
 	* @param uuid the layout friendly u r l's UUID
@@ -258,19 +247,6 @@ public interface LayoutFriendlyURLLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the layout friendly u r l with the matching UUID and company.
-	*
-	* @param uuid the layout friendly u r l's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout friendly u r l
-	* @throws PortalException if a matching layout friendly u r l could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portal.model.LayoutFriendlyURL getLayoutFriendlyURLByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the layout friendly u r l matching the UUID and group.
 	*
 	* @param uuid the layout friendly u r l's UUID
@@ -305,6 +281,32 @@ public interface LayoutFriendlyURLLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portal.model.LayoutFriendlyURL> getLayoutFriendlyURLs(
 		int start, int end);
+
+	/**
+	* Returns all the layout friendly u r ls that match the UUID and company.
+	*
+	* @param uuid the UUID of the layout friendly u r ls
+	* @param companyId the primary key of the company
+	* @return all the matching layout friendly u r ls, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.LayoutFriendlyURL> getLayoutFriendlyURLsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of layout friendly u r ls that match the UUID and company.
+	*
+	* @param uuid the UUID of the layout friendly u r ls
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of layout friendly u r ls
+	* @param end the upper bound of the range of layout friendly u r ls (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching layout friendly u r ls, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.LayoutFriendlyURL> getLayoutFriendlyURLsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of layout friendly u r ls.

--- a/portal-service/src/com/liferay/portal/service/LayoutFriendlyURLLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutFriendlyURLLocalServiceUtil.java
@@ -236,19 +236,6 @@ public class LayoutFriendlyURLLocalServiceUtil {
 	}
 
 	/**
-	* Returns the layout friendly u r l with the matching UUID and company.
-	*
-	* @param uuid the layout friendly u r l's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout friendly u r l, or <code>null</code> if a matching layout friendly u r l could not be found
-	*/
-	public static com.liferay.portal.model.LayoutFriendlyURL fetchLayoutFriendlyURLByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService()
-				   .fetchLayoutFriendlyURLByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the layout friendly u r l matching the UUID and group.
 	*
 	* @param uuid the layout friendly u r l's UUID
@@ -304,21 +291,6 @@ public class LayoutFriendlyURLLocalServiceUtil {
 	}
 
 	/**
-	* Returns the layout friendly u r l with the matching UUID and company.
-	*
-	* @param uuid the layout friendly u r l's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout friendly u r l
-	* @throws PortalException if a matching layout friendly u r l could not be found
-	*/
-	public static com.liferay.portal.model.LayoutFriendlyURL getLayoutFriendlyURLByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .getLayoutFriendlyURLByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the layout friendly u r l matching the UUID and group.
 	*
 	* @param uuid the layout friendly u r l's UUID
@@ -356,6 +328,37 @@ public class LayoutFriendlyURLLocalServiceUtil {
 	public static java.util.List<com.liferay.portal.model.LayoutFriendlyURL> getLayoutFriendlyURLs(
 		int start, int end) {
 		return getService().getLayoutFriendlyURLs(start, end);
+	}
+
+	/**
+	* Returns all the layout friendly u r ls that match the UUID and company.
+	*
+	* @param uuid the UUID of the layout friendly u r ls
+	* @param companyId the primary key of the company
+	* @return all the matching layout friendly u r ls, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portal.model.LayoutFriendlyURL> getLayoutFriendlyURLsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService()
+				   .getLayoutFriendlyURLsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of layout friendly u r ls that match the UUID and company.
+	*
+	* @param uuid the UUID of the layout friendly u r ls
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of layout friendly u r ls
+	* @param end the upper bound of the range of layout friendly u r ls (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching layout friendly u r ls, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portal.model.LayoutFriendlyURL> getLayoutFriendlyURLsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getLayoutFriendlyURLsByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/LayoutFriendlyURLLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutFriendlyURLLocalServiceWrapper.java
@@ -248,20 +248,6 @@ public class LayoutFriendlyURLLocalServiceWrapper
 	}
 
 	/**
-	* Returns the layout friendly u r l with the matching UUID and company.
-	*
-	* @param uuid the layout friendly u r l's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout friendly u r l, or <code>null</code> if a matching layout friendly u r l could not be found
-	*/
-	@Override
-	public com.liferay.portal.model.LayoutFriendlyURL fetchLayoutFriendlyURLByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _layoutFriendlyURLLocalService.fetchLayoutFriendlyURLByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the layout friendly u r l matching the UUID and group.
 	*
 	* @param uuid the layout friendly u r l's UUID
@@ -327,22 +313,6 @@ public class LayoutFriendlyURLLocalServiceWrapper
 	}
 
 	/**
-	* Returns the layout friendly u r l with the matching UUID and company.
-	*
-	* @param uuid the layout friendly u r l's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout friendly u r l
-	* @throws PortalException if a matching layout friendly u r l could not be found
-	*/
-	@Override
-	public com.liferay.portal.model.LayoutFriendlyURL getLayoutFriendlyURLByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _layoutFriendlyURLLocalService.getLayoutFriendlyURLByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the layout friendly u r l matching the UUID and group.
 	*
 	* @param uuid the layout friendly u r l's UUID
@@ -386,6 +356,38 @@ public class LayoutFriendlyURLLocalServiceWrapper
 	public java.util.List<com.liferay.portal.model.LayoutFriendlyURL> getLayoutFriendlyURLs(
 		int start, int end) {
 		return _layoutFriendlyURLLocalService.getLayoutFriendlyURLs(start, end);
+	}
+
+	/**
+	* Returns all the layout friendly u r ls that match the UUID and company.
+	*
+	* @param uuid the UUID of the layout friendly u r ls
+	* @param companyId the primary key of the company
+	* @return all the matching layout friendly u r ls, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portal.model.LayoutFriendlyURL> getLayoutFriendlyURLsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _layoutFriendlyURLLocalService.getLayoutFriendlyURLsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of layout friendly u r ls that match the UUID and company.
+	*
+	* @param uuid the UUID of the layout friendly u r ls
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of layout friendly u r ls
+	* @param end the upper bound of the range of layout friendly u r ls (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching layout friendly u r ls, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portal.model.LayoutFriendlyURL> getLayoutFriendlyURLsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _layoutFriendlyURLLocalService.getLayoutFriendlyURLsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/LayoutLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutLocalService.java
@@ -598,17 +598,6 @@ public interface LayoutLocalService extends BaseLocalService,
 		long groupId, boolean privateLayout, java.lang.String friendlyURL);
 
 	/**
-	* Returns the layout with the matching UUID and company.
-	*
-	* @param uuid the layout's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout, or <code>null</code> if a matching layout could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portal.model.Layout fetchLayoutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the layout matching the UUID, group, and privacy.
 	*
 	* @param uuid the layout's UUID
@@ -725,19 +714,6 @@ public interface LayoutLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portal.model.Layout getLayoutByIconImageId(
 		long iconImageId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
-	* Returns the layout with the matching UUID and company.
-	*
-	* @param uuid the layout's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout
-	* @throws PortalException if a matching layout could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portal.model.Layout getLayoutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
@@ -875,6 +851,32 @@ public interface LayoutLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getLayoutsByLayoutPrototypeUuidCount(
 		java.lang.String layoutPrototypeUuid);
+
+	/**
+	* Returns all the layouts that match the UUID and company.
+	*
+	* @param uuid the UUID of the layouts
+	* @param companyId the primary key of the company
+	* @return all the matching layouts, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.Layout> getLayoutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of layouts that match the UUID and company.
+	*
+	* @param uuid the UUID of the layouts
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of layouts
+	* @param end the upper bound of the range of layouts (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching layouts, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.Layout> getLayoutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of layouts.

--- a/portal-service/src/com/liferay/portal/service/LayoutLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutLocalServiceUtil.java
@@ -693,18 +693,6 @@ public class LayoutLocalServiceUtil {
 	}
 
 	/**
-	* Returns the layout with the matching UUID and company.
-	*
-	* @param uuid the layout's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout, or <code>null</code> if a matching layout could not be found
-	*/
-	public static com.liferay.portal.model.Layout fetchLayoutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchLayoutByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the layout matching the UUID, group, and privacy.
 	*
 	* @param uuid the layout's UUID
@@ -835,20 +823,6 @@ public class LayoutLocalServiceUtil {
 		long iconImageId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().getLayoutByIconImageId(iconImageId);
-	}
-
-	/**
-	* Returns the layout with the matching UUID and company.
-	*
-	* @param uuid the layout's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout
-	* @throws PortalException if a matching layout could not be found
-	*/
-	public static com.liferay.portal.model.Layout getLayoutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getLayoutByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**
@@ -1001,6 +975,36 @@ public class LayoutLocalServiceUtil {
 		java.lang.String layoutPrototypeUuid) {
 		return getService()
 				   .getLayoutsByLayoutPrototypeUuidCount(layoutPrototypeUuid);
+	}
+
+	/**
+	* Returns all the layouts that match the UUID and company.
+	*
+	* @param uuid the UUID of the layouts
+	* @param companyId the primary key of the company
+	* @return all the matching layouts, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portal.model.Layout> getLayoutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getLayoutsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of layouts that match the UUID and company.
+	*
+	* @param uuid the UUID of the layouts
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of layouts
+	* @param end the upper bound of the range of layouts (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching layouts, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portal.model.Layout> getLayoutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getLayoutsByUuidAndCompanyId(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/LayoutLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutLocalServiceWrapper.java
@@ -704,19 +704,6 @@ public class LayoutLocalServiceWrapper implements LayoutLocalService,
 	}
 
 	/**
-	* Returns the layout with the matching UUID and company.
-	*
-	* @param uuid the layout's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout, or <code>null</code> if a matching layout could not be found
-	*/
-	@Override
-	public com.liferay.portal.model.Layout fetchLayoutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _layoutLocalService.fetchLayoutByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the layout matching the UUID, group, and privacy.
 	*
 	* @param uuid the layout's UUID
@@ -859,21 +846,6 @@ public class LayoutLocalServiceWrapper implements LayoutLocalService,
 		long iconImageId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _layoutLocalService.getLayoutByIconImageId(iconImageId);
-	}
-
-	/**
-	* Returns the layout with the matching UUID and company.
-	*
-	* @param uuid the layout's UUID
-	* @param companyId the primary key of the company
-	* @return the matching layout
-	* @throws PortalException if a matching layout could not be found
-	*/
-	@Override
-	public com.liferay.portal.model.Layout getLayoutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _layoutLocalService.getLayoutByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**
@@ -1034,6 +1006,37 @@ public class LayoutLocalServiceWrapper implements LayoutLocalService,
 	public int getLayoutsByLayoutPrototypeUuidCount(
 		java.lang.String layoutPrototypeUuid) {
 		return _layoutLocalService.getLayoutsByLayoutPrototypeUuidCount(layoutPrototypeUuid);
+	}
+
+	/**
+	* Returns all the layouts that match the UUID and company.
+	*
+	* @param uuid the UUID of the layouts
+	* @param companyId the primary key of the company
+	* @return all the matching layouts, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portal.model.Layout> getLayoutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _layoutLocalService.getLayoutsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of layouts that match the UUID and company.
+	*
+	* @param uuid the UUID of the layouts
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of layouts
+	* @param end the upper bound of the range of layouts (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching layouts, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portal.model.Layout> getLayoutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _layoutLocalService.getLayoutsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/RepositoryEntryLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/RepositoryEntryLocalService.java
@@ -171,17 +171,6 @@ public interface RepositoryEntryLocalService extends BaseLocalService,
 		long repositoryEntryId);
 
 	/**
-	* Returns the repository entry with the matching UUID and company.
-	*
-	* @param uuid the repository entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository entry, or <code>null</code> if a matching repository entry could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portal.model.RepositoryEntry fetchRepositoryEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the repository entry matching the UUID and group.
 	*
 	* @param uuid the repository entry's UUID
@@ -232,6 +221,32 @@ public interface RepositoryEntryLocalService extends BaseLocalService,
 		int start, int end);
 
 	/**
+	* Returns all the repository entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the repository entries
+	* @param companyId the primary key of the company
+	* @return all the matching repository entries, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.RepositoryEntry> getRepositoryEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of repository entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the repository entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of repository entries
+	* @param end the upper bound of the range of repository entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching repository entries, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.RepositoryEntry> getRepositoryEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
+
+	/**
 	* Returns the number of repository entries.
 	*
 	* @return the number of repository entries
@@ -249,19 +264,6 @@ public interface RepositoryEntryLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portal.model.RepositoryEntry getRepositoryEntry(
 		long repositoryEntryId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
-	* Returns the repository entry with the matching UUID and company.
-	*
-	* @param uuid the repository entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository entry
-	* @throws PortalException if a matching repository entry could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portal.model.RepositoryEntry getRepositoryEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/RepositoryEntryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/RepositoryEntryLocalServiceUtil.java
@@ -190,19 +190,6 @@ public class RepositoryEntryLocalServiceUtil {
 	}
 
 	/**
-	* Returns the repository entry with the matching UUID and company.
-	*
-	* @param uuid the repository entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository entry, or <code>null</code> if a matching repository entry could not be found
-	*/
-	public static com.liferay.portal.model.RepositoryEntry fetchRepositoryEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService()
-				   .fetchRepositoryEntryByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the repository entry matching the UUID and group.
 	*
 	* @param uuid the repository entry's UUID
@@ -260,6 +247,37 @@ public class RepositoryEntryLocalServiceUtil {
 	}
 
 	/**
+	* Returns all the repository entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the repository entries
+	* @param companyId the primary key of the company
+	* @return all the matching repository entries, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portal.model.RepositoryEntry> getRepositoryEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService()
+				   .getRepositoryEntriesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of repository entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the repository entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of repository entries
+	* @param end the upper bound of the range of repository entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching repository entries, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portal.model.RepositoryEntry> getRepositoryEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getRepositoryEntriesByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of repository entries.
 	*
 	* @return the number of repository entries
@@ -279,20 +297,6 @@ public class RepositoryEntryLocalServiceUtil {
 		long repositoryEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().getRepositoryEntry(repositoryEntryId);
-	}
-
-	/**
-	* Returns the repository entry with the matching UUID and company.
-	*
-	* @param uuid the repository entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository entry
-	* @throws PortalException if a matching repository entry could not be found
-	*/
-	public static com.liferay.portal.model.RepositoryEntry getRepositoryEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getRepositoryEntryByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/RepositoryEntryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/RepositoryEntryLocalServiceWrapper.java
@@ -195,20 +195,6 @@ public class RepositoryEntryLocalServiceWrapper
 	}
 
 	/**
-	* Returns the repository entry with the matching UUID and company.
-	*
-	* @param uuid the repository entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository entry, or <code>null</code> if a matching repository entry could not be found
-	*/
-	@Override
-	public com.liferay.portal.model.RepositoryEntry fetchRepositoryEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _repositoryEntryLocalService.fetchRepositoryEntryByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the repository entry matching the UUID and group.
 	*
 	* @param uuid the repository entry's UUID
@@ -274,6 +260,38 @@ public class RepositoryEntryLocalServiceWrapper
 	}
 
 	/**
+	* Returns all the repository entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the repository entries
+	* @param companyId the primary key of the company
+	* @return all the matching repository entries, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portal.model.RepositoryEntry> getRepositoryEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _repositoryEntryLocalService.getRepositoryEntriesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of repository entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the repository entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of repository entries
+	* @param end the upper bound of the range of repository entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching repository entries, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portal.model.RepositoryEntry> getRepositoryEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _repositoryEntryLocalService.getRepositoryEntriesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of repository entries.
 	*
 	* @return the number of repository entries
@@ -295,22 +313,6 @@ public class RepositoryEntryLocalServiceWrapper
 		long repositoryEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _repositoryEntryLocalService.getRepositoryEntry(repositoryEntryId);
-	}
-
-	/**
-	* Returns the repository entry with the matching UUID and company.
-	*
-	* @param uuid the repository entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository entry
-	* @throws PortalException if a matching repository entry could not be found
-	*/
-	@Override
-	public com.liferay.portal.model.RepositoryEntry getRepositoryEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _repositoryEntryLocalService.getRepositoryEntryByUuidAndCompanyId(uuid,
-			companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/RepositoryLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/RepositoryLocalService.java
@@ -202,17 +202,6 @@ public interface RepositoryLocalService extends BaseLocalService,
 		long repositoryId);
 
 	/**
-	* Returns the repository with the matching UUID and company.
-	*
-	* @param uuid the repository's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository, or <code>null</code> if a matching repository could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portal.model.Repository fetchRepositoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the repository matching the UUID and group.
 	*
 	* @param uuid the repository's UUID
@@ -277,6 +266,32 @@ public interface RepositoryLocalService extends BaseLocalService,
 		int start, int end);
 
 	/**
+	* Returns all the repositories that match the UUID and company.
+	*
+	* @param uuid the UUID of the repositories
+	* @param companyId the primary key of the company
+	* @return all the matching repositories, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.Repository> getRepositoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of repositories that match the UUID and company.
+	*
+	* @param uuid the UUID of the repositories
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of repositories
+	* @param end the upper bound of the range of repositories (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching repositories, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.Repository> getRepositoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
+
+	/**
 	* Returns the number of repositories.
 	*
 	* @return the number of repositories
@@ -303,19 +318,6 @@ public interface RepositoryLocalService extends BaseLocalService,
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portal.model.Repository getRepository(long repositoryId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
-	* Returns the repository with the matching UUID and company.
-	*
-	* @param uuid the repository's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository
-	* @throws PortalException if a matching repository could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portal.model.Repository getRepositoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/RepositoryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/RepositoryLocalServiceUtil.java
@@ -230,18 +230,6 @@ public class RepositoryLocalServiceUtil {
 	}
 
 	/**
-	* Returns the repository with the matching UUID and company.
-	*
-	* @param uuid the repository's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository, or <code>null</code> if a matching repository could not be found
-	*/
-	public static com.liferay.portal.model.Repository fetchRepositoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchRepositoryByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the repository matching the UUID and group.
 	*
 	* @param uuid the repository's UUID
@@ -317,6 +305,36 @@ public class RepositoryLocalServiceUtil {
 	}
 
 	/**
+	* Returns all the repositories that match the UUID and company.
+	*
+	* @param uuid the UUID of the repositories
+	* @param companyId the primary key of the company
+	* @return all the matching repositories, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portal.model.Repository> getRepositoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getRepositoriesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of repositories that match the UUID and company.
+	*
+	* @param uuid the UUID of the repositories
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of repositories
+	* @param end the upper bound of the range of repositories (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching repositories, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portal.model.Repository> getRepositoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getRepositoriesByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of repositories.
 	*
 	* @return the number of repositories
@@ -348,20 +366,6 @@ public class RepositoryLocalServiceUtil {
 		long repositoryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().getRepository(repositoryId);
-	}
-
-	/**
-	* Returns the repository with the matching UUID and company.
-	*
-	* @param uuid the repository's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository
-	* @throws PortalException if a matching repository could not be found
-	*/
-	public static com.liferay.portal.model.Repository getRepositoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getRepositoryByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/RepositoryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/RepositoryLocalServiceWrapper.java
@@ -238,20 +238,6 @@ public class RepositoryLocalServiceWrapper implements RepositoryLocalService,
 	}
 
 	/**
-	* Returns the repository with the matching UUID and company.
-	*
-	* @param uuid the repository's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository, or <code>null</code> if a matching repository could not be found
-	*/
-	@Override
-	public com.liferay.portal.model.Repository fetchRepositoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _repositoryLocalService.fetchRepositoryByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the repository matching the UUID and group.
 	*
 	* @param uuid the repository's UUID
@@ -338,6 +324,38 @@ public class RepositoryLocalServiceWrapper implements RepositoryLocalService,
 	}
 
 	/**
+	* Returns all the repositories that match the UUID and company.
+	*
+	* @param uuid the UUID of the repositories
+	* @param companyId the primary key of the company
+	* @return all the matching repositories, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portal.model.Repository> getRepositoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _repositoryLocalService.getRepositoriesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of repositories that match the UUID and company.
+	*
+	* @param uuid the UUID of the repositories
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of repositories
+	* @param end the upper bound of the range of repositories (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching repositories, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portal.model.Repository> getRepositoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _repositoryLocalService.getRepositoriesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of repositories.
 	*
 	* @return the number of repositories
@@ -372,22 +390,6 @@ public class RepositoryLocalServiceWrapper implements RepositoryLocalService,
 	public com.liferay.portal.model.Repository getRepository(long repositoryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _repositoryLocalService.getRepository(repositoryId);
-	}
-
-	/**
-	* Returns the repository with the matching UUID and company.
-	*
-	* @param uuid the repository's UUID
-	* @param companyId the primary key of the company
-	* @return the matching repository
-	* @throws PortalException if a matching repository could not be found
-	*/
-	@Override
-	public com.liferay.portal.model.Repository getRepositoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _repositoryLocalService.getRepositoryByUuidAndCompanyId(uuid,
-			companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryLocalService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryLocalService.java
@@ -232,17 +232,6 @@ public interface AssetCategoryLocalService extends BaseLocalService,
 		long categoryId);
 
 	/**
-	* Returns the asset category with the matching UUID and company.
-	*
-	* @param uuid the asset category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset category, or <code>null</code> if a matching asset category could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.asset.model.AssetCategory fetchAssetCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the asset category matching the UUID and group.
 	*
 	* @param uuid the asset category's UUID
@@ -276,6 +265,32 @@ public interface AssetCategoryLocalService extends BaseLocalService,
 		int start, int end);
 
 	/**
+	* Returns all the asset categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset categories
+	* @param companyId the primary key of the company
+	* @return all the matching asset categories, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.asset.model.AssetCategory> getAssetCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of asset categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset categories
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of asset categories
+	* @param end the upper bound of the range of asset categories (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching asset categories, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.asset.model.AssetCategory> getAssetCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
+
+	/**
 	* Returns the number of asset categories.
 	*
 	* @return the number of asset categories
@@ -293,19 +308,6 @@ public interface AssetCategoryLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.asset.model.AssetCategory getAssetCategory(
 		long categoryId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
-	* Returns the asset category with the matching UUID and company.
-	*
-	* @param uuid the asset category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset category
-	* @throws PortalException if a matching asset category could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.asset.model.AssetCategory getAssetCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryLocalServiceUtil.java
@@ -284,18 +284,6 @@ public class AssetCategoryLocalServiceUtil {
 	}
 
 	/**
-	* Returns the asset category with the matching UUID and company.
-	*
-	* @param uuid the asset category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset category, or <code>null</code> if a matching asset category could not be found
-	*/
-	public static com.liferay.portlet.asset.model.AssetCategory fetchAssetCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchAssetCategoryByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the asset category matching the UUID and group.
 	*
 	* @param uuid the asset category's UUID
@@ -333,6 +321,36 @@ public class AssetCategoryLocalServiceUtil {
 	}
 
 	/**
+	* Returns all the asset categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset categories
+	* @param companyId the primary key of the company
+	* @return all the matching asset categories, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.asset.model.AssetCategory> getAssetCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getAssetCategoriesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of asset categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset categories
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of asset categories
+	* @param end the upper bound of the range of asset categories (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching asset categories, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.asset.model.AssetCategory> getAssetCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getAssetCategoriesByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of asset categories.
 	*
 	* @return the number of asset categories
@@ -352,20 +370,6 @@ public class AssetCategoryLocalServiceUtil {
 		long categoryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().getAssetCategory(categoryId);
-	}
-
-	/**
-	* Returns the asset category with the matching UUID and company.
-	*
-	* @param uuid the asset category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset category
-	* @throws PortalException if a matching asset category could not be found
-	*/
-	public static com.liferay.portlet.asset.model.AssetCategory getAssetCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getAssetCategoryByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryLocalServiceWrapper.java
@@ -311,20 +311,6 @@ public class AssetCategoryLocalServiceWrapper
 	}
 
 	/**
-	* Returns the asset category with the matching UUID and company.
-	*
-	* @param uuid the asset category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset category, or <code>null</code> if a matching asset category could not be found
-	*/
-	@Override
-	public com.liferay.portlet.asset.model.AssetCategory fetchAssetCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _assetCategoryLocalService.fetchAssetCategoryByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the asset category matching the UUID and group.
 	*
 	* @param uuid the asset category's UUID
@@ -367,6 +353,38 @@ public class AssetCategoryLocalServiceWrapper
 	}
 
 	/**
+	* Returns all the asset categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset categories
+	* @param companyId the primary key of the company
+	* @return all the matching asset categories, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.asset.model.AssetCategory> getAssetCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _assetCategoryLocalService.getAssetCategoriesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of asset categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset categories
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of asset categories
+	* @param end the upper bound of the range of asset categories (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching asset categories, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.asset.model.AssetCategory> getAssetCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _assetCategoryLocalService.getAssetCategoriesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of asset categories.
 	*
 	* @return the number of asset categories
@@ -388,22 +406,6 @@ public class AssetCategoryLocalServiceWrapper
 		long categoryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _assetCategoryLocalService.getAssetCategory(categoryId);
-	}
-
-	/**
-	* Returns the asset category with the matching UUID and company.
-	*
-	* @param uuid the asset category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset category
-	* @throws PortalException if a matching asset category could not be found
-	*/
-	@Override
-	public com.liferay.portlet.asset.model.AssetCategory getAssetCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _assetCategoryLocalService.getAssetCategoryByUuidAndCompanyId(uuid,
-			companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalService.java
@@ -220,17 +220,6 @@ public interface AssetVocabularyLocalService extends BaseLocalService,
 		long vocabularyId);
 
 	/**
-	* Returns the asset vocabulary with the matching UUID and company.
-	*
-	* @param uuid the asset vocabulary's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset vocabulary, or <code>null</code> if a matching asset vocabulary could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.asset.model.AssetVocabulary fetchAssetVocabularyByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the asset vocabulary matching the UUID and group.
 	*
 	* @param uuid the asset vocabulary's UUID
@@ -260,6 +249,32 @@ public interface AssetVocabularyLocalService extends BaseLocalService,
 		int start, int end);
 
 	/**
+	* Returns all the asset vocabularies that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset vocabularies
+	* @param companyId the primary key of the company
+	* @return all the matching asset vocabularies, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getAssetVocabulariesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of asset vocabularies that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset vocabularies
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of asset vocabularies
+	* @param end the upper bound of the range of asset vocabularies (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching asset vocabularies, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getAssetVocabulariesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
+
+	/**
 	* Returns the number of asset vocabularies.
 	*
 	* @return the number of asset vocabularies
@@ -277,19 +292,6 @@ public interface AssetVocabularyLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.asset.model.AssetVocabulary getAssetVocabulary(
 		long vocabularyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
-	* Returns the asset vocabulary with the matching UUID and company.
-	*
-	* @param uuid the asset vocabulary's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset vocabulary
-	* @throws PortalException if a matching asset vocabulary could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.asset.model.AssetVocabulary getAssetVocabularyByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceUtil.java
@@ -255,19 +255,6 @@ public class AssetVocabularyLocalServiceUtil {
 	}
 
 	/**
-	* Returns the asset vocabulary with the matching UUID and company.
-	*
-	* @param uuid the asset vocabulary's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset vocabulary, or <code>null</code> if a matching asset vocabulary could not be found
-	*/
-	public static com.liferay.portlet.asset.model.AssetVocabulary fetchAssetVocabularyByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService()
-				   .fetchAssetVocabularyByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the asset vocabulary matching the UUID and group.
 	*
 	* @param uuid the asset vocabulary's UUID
@@ -300,6 +287,37 @@ public class AssetVocabularyLocalServiceUtil {
 	}
 
 	/**
+	* Returns all the asset vocabularies that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset vocabularies
+	* @param companyId the primary key of the company
+	* @return all the matching asset vocabularies, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getAssetVocabulariesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService()
+				   .getAssetVocabulariesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of asset vocabularies that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset vocabularies
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of asset vocabularies
+	* @param end the upper bound of the range of asset vocabularies (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching asset vocabularies, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getAssetVocabulariesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getAssetVocabulariesByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of asset vocabularies.
 	*
 	* @return the number of asset vocabularies
@@ -319,20 +337,6 @@ public class AssetVocabularyLocalServiceUtil {
 		long vocabularyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().getAssetVocabulary(vocabularyId);
-	}
-
-	/**
-	* Returns the asset vocabulary with the matching UUID and company.
-	*
-	* @param uuid the asset vocabulary's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset vocabulary
-	* @throws PortalException if a matching asset vocabulary could not be found
-	*/
-	public static com.liferay.portlet.asset.model.AssetVocabulary getAssetVocabularyByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getAssetVocabularyByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceWrapper.java
@@ -268,20 +268,6 @@ public class AssetVocabularyLocalServiceWrapper
 	}
 
 	/**
-	* Returns the asset vocabulary with the matching UUID and company.
-	*
-	* @param uuid the asset vocabulary's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset vocabulary, or <code>null</code> if a matching asset vocabulary could not be found
-	*/
-	@Override
-	public com.liferay.portlet.asset.model.AssetVocabulary fetchAssetVocabularyByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _assetVocabularyLocalService.fetchAssetVocabularyByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the asset vocabulary matching the UUID and group.
 	*
 	* @param uuid the asset vocabulary's UUID
@@ -318,6 +304,38 @@ public class AssetVocabularyLocalServiceWrapper
 	}
 
 	/**
+	* Returns all the asset vocabularies that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset vocabularies
+	* @param companyId the primary key of the company
+	* @return all the matching asset vocabularies, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getAssetVocabulariesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _assetVocabularyLocalService.getAssetVocabulariesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of asset vocabularies that match the UUID and company.
+	*
+	* @param uuid the UUID of the asset vocabularies
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of asset vocabularies
+	* @param end the upper bound of the range of asset vocabularies (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching asset vocabularies, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getAssetVocabulariesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _assetVocabularyLocalService.getAssetVocabulariesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of asset vocabularies.
 	*
 	* @return the number of asset vocabularies
@@ -339,22 +357,6 @@ public class AssetVocabularyLocalServiceWrapper
 		long vocabularyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _assetVocabularyLocalService.getAssetVocabulary(vocabularyId);
-	}
-
-	/**
-	* Returns the asset vocabulary with the matching UUID and company.
-	*
-	* @param uuid the asset vocabulary's UUID
-	* @param companyId the primary key of the company
-	* @return the matching asset vocabulary
-	* @throws PortalException if a matching asset vocabulary could not be found
-	*/
-	@Override
-	public com.liferay.portlet.asset.model.AssetVocabulary getAssetVocabularyByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _assetVocabularyLocalService.getAssetVocabularyByUuidAndCompanyId(uuid,
-			companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryLocalService.java
+++ b/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryLocalService.java
@@ -231,17 +231,6 @@ public interface BlogsEntryLocalService extends BaseLocalService,
 		long entryId);
 
 	/**
-	* Returns the blogs entry with the matching UUID and company.
-	*
-	* @param uuid the blogs entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.blogs.model.BlogsEntry fetchBlogsEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the blogs entry matching the UUID and group.
 	*
 	* @param uuid the blogs entry's UUID
@@ -278,6 +267,32 @@ public interface BlogsEntryLocalService extends BaseLocalService,
 		int start, int end);
 
 	/**
+	* Returns all the blogs entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the blogs entries
+	* @param companyId the primary key of the company
+	* @return all the matching blogs entries, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getBlogsEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of blogs entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the blogs entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of blogs entries
+	* @param end the upper bound of the range of blogs entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching blogs entries, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getBlogsEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
+
+	/**
 	* Returns the number of blogs entries.
 	*
 	* @return the number of blogs entries
@@ -295,19 +310,6 @@ public interface BlogsEntryLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.blogs.model.BlogsEntry getBlogsEntry(
 		long entryId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
-	* Returns the blogs entry with the matching UUID and company.
-	*
-	* @param uuid the blogs entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching blogs entry
-	* @throws PortalException if a matching blogs entry could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.blogs.model.BlogsEntry getBlogsEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryLocalServiceUtil.java
@@ -274,18 +274,6 @@ public class BlogsEntryLocalServiceUtil {
 	}
 
 	/**
-	* Returns the blogs entry with the matching UUID and company.
-	*
-	* @param uuid the blogs entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
-	*/
-	public static com.liferay.portlet.blogs.model.BlogsEntry fetchBlogsEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchBlogsEntryByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the blogs entry matching the UUID and group.
 	*
 	* @param uuid the blogs entry's UUID
@@ -327,6 +315,36 @@ public class BlogsEntryLocalServiceUtil {
 	}
 
 	/**
+	* Returns all the blogs entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the blogs entries
+	* @param companyId the primary key of the company
+	* @return all the matching blogs entries, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getBlogsEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getBlogsEntriesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of blogs entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the blogs entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of blogs entries
+	* @param end the upper bound of the range of blogs entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching blogs entries, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getBlogsEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getBlogsEntriesByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of blogs entries.
 	*
 	* @return the number of blogs entries
@@ -346,20 +364,6 @@ public class BlogsEntryLocalServiceUtil {
 		long entryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().getBlogsEntry(entryId);
-	}
-
-	/**
-	* Returns the blogs entry with the matching UUID and company.
-	*
-	* @param uuid the blogs entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching blogs entry
-	* @throws PortalException if a matching blogs entry could not be found
-	*/
-	public static com.liferay.portlet.blogs.model.BlogsEntry getBlogsEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getBlogsEntryByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryLocalServiceWrapper.java
@@ -289,20 +289,6 @@ public class BlogsEntryLocalServiceWrapper implements BlogsEntryLocalService,
 	}
 
 	/**
-	* Returns the blogs entry with the matching UUID and company.
-	*
-	* @param uuid the blogs entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
-	*/
-	@Override
-	public com.liferay.portlet.blogs.model.BlogsEntry fetchBlogsEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _blogsEntryLocalService.fetchBlogsEntryByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the blogs entry matching the UUID and group.
 	*
 	* @param uuid the blogs entry's UUID
@@ -349,6 +335,38 @@ public class BlogsEntryLocalServiceWrapper implements BlogsEntryLocalService,
 	}
 
 	/**
+	* Returns all the blogs entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the blogs entries
+	* @param companyId the primary key of the company
+	* @return all the matching blogs entries, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getBlogsEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _blogsEntryLocalService.getBlogsEntriesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of blogs entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the blogs entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of blogs entries
+	* @param end the upper bound of the range of blogs entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching blogs entries, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getBlogsEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _blogsEntryLocalService.getBlogsEntriesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of blogs entries.
 	*
 	* @return the number of blogs entries
@@ -370,22 +388,6 @@ public class BlogsEntryLocalServiceWrapper implements BlogsEntryLocalService,
 		long entryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _blogsEntryLocalService.getBlogsEntry(entryId);
-	}
-
-	/**
-	* Returns the blogs entry with the matching UUID and company.
-	*
-	* @param uuid the blogs entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching blogs entry
-	* @throws PortalException if a matching blogs entry could not be found
-	*/
-	@Override
-	public com.liferay.portlet.blogs.model.BlogsEntry getBlogsEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _blogsEntryLocalService.getBlogsEntryByUuidAndCompanyId(uuid,
-			companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksEntryLocalService.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksEntryLocalService.java
@@ -193,17 +193,6 @@ public interface BookmarksEntryLocalService extends BaseLocalService,
 		long entryId);
 
 	/**
-	* Returns the bookmarks entry with the matching UUID and company.
-	*
-	* @param uuid the bookmarks entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks entry, or <code>null</code> if a matching bookmarks entry could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.bookmarks.model.BookmarksEntry fetchBookmarksEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the bookmarks entry matching the UUID and group.
 	*
 	* @param uuid the bookmarks entry's UUID
@@ -240,6 +229,32 @@ public interface BookmarksEntryLocalService extends BaseLocalService,
 		int start, int end);
 
 	/**
+	* Returns all the bookmarks entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks entries
+	* @param companyId the primary key of the company
+	* @return all the matching bookmarks entries, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksEntry> getBookmarksEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of bookmarks entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of bookmarks entries
+	* @param end the upper bound of the range of bookmarks entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching bookmarks entries, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksEntry> getBookmarksEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
+
+	/**
 	* Returns the number of bookmarks entries.
 	*
 	* @return the number of bookmarks entries
@@ -257,19 +272,6 @@ public interface BookmarksEntryLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.bookmarks.model.BookmarksEntry getBookmarksEntry(
 		long entryId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
-	* Returns the bookmarks entry with the matching UUID and company.
-	*
-	* @param uuid the bookmarks entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks entry
-	* @throws PortalException if a matching bookmarks entry could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.bookmarks.model.BookmarksEntry getBookmarksEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksEntryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksEntryLocalServiceUtil.java
@@ -213,19 +213,6 @@ public class BookmarksEntryLocalServiceUtil {
 	}
 
 	/**
-	* Returns the bookmarks entry with the matching UUID and company.
-	*
-	* @param uuid the bookmarks entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks entry, or <code>null</code> if a matching bookmarks entry could not be found
-	*/
-	public static com.liferay.portlet.bookmarks.model.BookmarksEntry fetchBookmarksEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService()
-				   .fetchBookmarksEntryByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the bookmarks entry matching the UUID and group.
 	*
 	* @param uuid the bookmarks entry's UUID
@@ -267,6 +254,37 @@ public class BookmarksEntryLocalServiceUtil {
 	}
 
 	/**
+	* Returns all the bookmarks entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks entries
+	* @param companyId the primary key of the company
+	* @return all the matching bookmarks entries, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.bookmarks.model.BookmarksEntry> getBookmarksEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService()
+				   .getBookmarksEntriesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of bookmarks entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of bookmarks entries
+	* @param end the upper bound of the range of bookmarks entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching bookmarks entries, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.bookmarks.model.BookmarksEntry> getBookmarksEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getBookmarksEntriesByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of bookmarks entries.
 	*
 	* @return the number of bookmarks entries
@@ -286,20 +304,6 @@ public class BookmarksEntryLocalServiceUtil {
 		long entryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().getBookmarksEntry(entryId);
-	}
-
-	/**
-	* Returns the bookmarks entry with the matching UUID and company.
-	*
-	* @param uuid the bookmarks entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks entry
-	* @throws PortalException if a matching bookmarks entry could not be found
-	*/
-	public static com.liferay.portlet.bookmarks.model.BookmarksEntry getBookmarksEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getBookmarksEntryByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksEntryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksEntryLocalServiceWrapper.java
@@ -224,20 +224,6 @@ public class BookmarksEntryLocalServiceWrapper
 	}
 
 	/**
-	* Returns the bookmarks entry with the matching UUID and company.
-	*
-	* @param uuid the bookmarks entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks entry, or <code>null</code> if a matching bookmarks entry could not be found
-	*/
-	@Override
-	public com.liferay.portlet.bookmarks.model.BookmarksEntry fetchBookmarksEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _bookmarksEntryLocalService.fetchBookmarksEntryByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the bookmarks entry matching the UUID and group.
 	*
 	* @param uuid the bookmarks entry's UUID
@@ -284,6 +270,38 @@ public class BookmarksEntryLocalServiceWrapper
 	}
 
 	/**
+	* Returns all the bookmarks entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks entries
+	* @param companyId the primary key of the company
+	* @return all the matching bookmarks entries, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksEntry> getBookmarksEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _bookmarksEntryLocalService.getBookmarksEntriesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of bookmarks entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of bookmarks entries
+	* @param end the upper bound of the range of bookmarks entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching bookmarks entries, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksEntry> getBookmarksEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _bookmarksEntryLocalService.getBookmarksEntriesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of bookmarks entries.
 	*
 	* @return the number of bookmarks entries
@@ -305,22 +323,6 @@ public class BookmarksEntryLocalServiceWrapper
 		long entryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _bookmarksEntryLocalService.getBookmarksEntry(entryId);
-	}
-
-	/**
-	* Returns the bookmarks entry with the matching UUID and company.
-	*
-	* @param uuid the bookmarks entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks entry
-	* @throws PortalException if a matching bookmarks entry could not be found
-	*/
-	@Override
-	public com.liferay.portlet.bookmarks.model.BookmarksEntry getBookmarksEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _bookmarksEntryLocalService.getBookmarksEntryByUuidAndCompanyId(uuid,
-			companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksFolderLocalService.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksFolderLocalService.java
@@ -200,17 +200,6 @@ public interface BookmarksFolderLocalService extends BaseLocalService,
 		long folderId);
 
 	/**
-	* Returns the bookmarks folder with the matching UUID and company.
-	*
-	* @param uuid the bookmarks folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks folder, or <code>null</code> if a matching bookmarks folder could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.bookmarks.model.BookmarksFolder fetchBookmarksFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the bookmarks folder matching the UUID and group.
 	*
 	* @param uuid the bookmarks folder's UUID
@@ -244,19 +233,6 @@ public interface BookmarksFolderLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the bookmarks folder with the matching UUID and company.
-	*
-	* @param uuid the bookmarks folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks folder
-	* @throws PortalException if a matching bookmarks folder could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.bookmarks.model.BookmarksFolder getBookmarksFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the bookmarks folder matching the UUID and group.
 	*
 	* @param uuid the bookmarks folder's UUID
@@ -283,6 +259,32 @@ public interface BookmarksFolderLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksFolder> getBookmarksFolders(
 		int start, int end);
+
+	/**
+	* Returns all the bookmarks folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks folders
+	* @param companyId the primary key of the company
+	* @return all the matching bookmarks folders, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksFolder> getBookmarksFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of bookmarks folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks folders
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of bookmarks folders
+	* @param end the upper bound of the range of bookmarks folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching bookmarks folders, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksFolder> getBookmarksFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of bookmarks folders.

--- a/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksFolderLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksFolderLocalServiceUtil.java
@@ -220,19 +220,6 @@ public class BookmarksFolderLocalServiceUtil {
 	}
 
 	/**
-	* Returns the bookmarks folder with the matching UUID and company.
-	*
-	* @param uuid the bookmarks folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks folder, or <code>null</code> if a matching bookmarks folder could not be found
-	*/
-	public static com.liferay.portlet.bookmarks.model.BookmarksFolder fetchBookmarksFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService()
-				   .fetchBookmarksFolderByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the bookmarks folder matching the UUID and group.
 	*
 	* @param uuid the bookmarks folder's UUID
@@ -271,20 +258,6 @@ public class BookmarksFolderLocalServiceUtil {
 	}
 
 	/**
-	* Returns the bookmarks folder with the matching UUID and company.
-	*
-	* @param uuid the bookmarks folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks folder
-	* @throws PortalException if a matching bookmarks folder could not be found
-	*/
-	public static com.liferay.portlet.bookmarks.model.BookmarksFolder getBookmarksFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getBookmarksFolderByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the bookmarks folder matching the UUID and group.
 	*
 	* @param uuid the bookmarks folder's UUID
@@ -312,6 +285,37 @@ public class BookmarksFolderLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.bookmarks.model.BookmarksFolder> getBookmarksFolders(
 		int start, int end) {
 		return getService().getBookmarksFolders(start, end);
+	}
+
+	/**
+	* Returns all the bookmarks folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks folders
+	* @param companyId the primary key of the company
+	* @return all the matching bookmarks folders, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.bookmarks.model.BookmarksFolder> getBookmarksFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService()
+				   .getBookmarksFoldersByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of bookmarks folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks folders
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of bookmarks folders
+	* @param end the upper bound of the range of bookmarks folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching bookmarks folders, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.bookmarks.model.BookmarksFolder> getBookmarksFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getBookmarksFoldersByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksFolderLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/service/BookmarksFolderLocalServiceWrapper.java
@@ -234,20 +234,6 @@ public class BookmarksFolderLocalServiceWrapper
 	}
 
 	/**
-	* Returns the bookmarks folder with the matching UUID and company.
-	*
-	* @param uuid the bookmarks folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks folder, or <code>null</code> if a matching bookmarks folder could not be found
-	*/
-	@Override
-	public com.liferay.portlet.bookmarks.model.BookmarksFolder fetchBookmarksFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _bookmarksFolderLocalService.fetchBookmarksFolderByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the bookmarks folder matching the UUID and group.
 	*
 	* @param uuid the bookmarks folder's UUID
@@ -291,22 +277,6 @@ public class BookmarksFolderLocalServiceWrapper
 	}
 
 	/**
-	* Returns the bookmarks folder with the matching UUID and company.
-	*
-	* @param uuid the bookmarks folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching bookmarks folder
-	* @throws PortalException if a matching bookmarks folder could not be found
-	*/
-	@Override
-	public com.liferay.portlet.bookmarks.model.BookmarksFolder getBookmarksFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _bookmarksFolderLocalService.getBookmarksFolderByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the bookmarks folder matching the UUID and group.
 	*
 	* @param uuid the bookmarks folder's UUID
@@ -337,6 +307,38 @@ public class BookmarksFolderLocalServiceWrapper
 	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksFolder> getBookmarksFolders(
 		int start, int end) {
 		return _bookmarksFolderLocalService.getBookmarksFolders(start, end);
+	}
+
+	/**
+	* Returns all the bookmarks folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks folders
+	* @param companyId the primary key of the company
+	* @return all the matching bookmarks folders, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksFolder> getBookmarksFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _bookmarksFolderLocalService.getBookmarksFoldersByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of bookmarks folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the bookmarks folders
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of bookmarks folders
+	* @param end the upper bound of the range of bookmarks folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching bookmarks folders, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.bookmarks.model.BookmarksFolder> getBookmarksFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _bookmarksFolderLocalService.getBookmarksFoldersByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/calendar/service/CalEventLocalService.java
+++ b/portal-service/src/com/liferay/portlet/calendar/service/CalEventLocalService.java
@@ -243,17 +243,6 @@ public interface CalEventLocalService extends BaseLocalService,
 		long eventId);
 
 	/**
-	* Returns the cal event with the matching UUID and company.
-	*
-	* @param uuid the cal event's UUID
-	* @param companyId the primary key of the company
-	* @return the matching cal event, or <code>null</code> if a matching cal event could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.calendar.model.CalEvent fetchCalEventByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the cal event matching the UUID and group.
 	*
 	* @param uuid the cal event's UUID
@@ -286,19 +275,6 @@ public interface CalEventLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the cal event with the matching UUID and company.
-	*
-	* @param uuid the cal event's UUID
-	* @param companyId the primary key of the company
-	* @return the matching cal event
-	* @throws PortalException if a matching cal event could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.calendar.model.CalEvent getCalEventByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the cal event matching the UUID and group.
 	*
 	* @param uuid the cal event's UUID
@@ -325,6 +301,32 @@ public interface CalEventLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.calendar.model.CalEvent> getCalEvents(
 		int start, int end);
+
+	/**
+	* Returns all the cal events that match the UUID and company.
+	*
+	* @param uuid the UUID of the cal events
+	* @param companyId the primary key of the company
+	* @return all the matching cal events, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.calendar.model.CalEvent> getCalEventsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of cal events that match the UUID and company.
+	*
+	* @param uuid the UUID of the cal events
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of cal events
+	* @param end the upper bound of the range of cal events (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching cal events, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.calendar.model.CalEvent> getCalEventsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of cal events.

--- a/portal-service/src/com/liferay/portlet/calendar/service/CalEventLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/calendar/service/CalEventLocalServiceUtil.java
@@ -293,18 +293,6 @@ public class CalEventLocalServiceUtil {
 	}
 
 	/**
-	* Returns the cal event with the matching UUID and company.
-	*
-	* @param uuid the cal event's UUID
-	* @param companyId the primary key of the company
-	* @return the matching cal event, or <code>null</code> if a matching cal event could not be found
-	*/
-	public static com.liferay.portlet.calendar.model.CalEvent fetchCalEventByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchCalEventByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the cal event matching the UUID and group.
 	*
 	* @param uuid the cal event's UUID
@@ -343,20 +331,6 @@ public class CalEventLocalServiceUtil {
 	}
 
 	/**
-	* Returns the cal event with the matching UUID and company.
-	*
-	* @param uuid the cal event's UUID
-	* @param companyId the primary key of the company
-	* @return the matching cal event
-	* @throws PortalException if a matching cal event could not be found
-	*/
-	public static com.liferay.portlet.calendar.model.CalEvent getCalEventByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getCalEventByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the cal event matching the UUID and group.
 	*
 	* @param uuid the cal event's UUID
@@ -384,6 +358,36 @@ public class CalEventLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.calendar.model.CalEvent> getCalEvents(
 		int start, int end) {
 		return getService().getCalEvents(start, end);
+	}
+
+	/**
+	* Returns all the cal events that match the UUID and company.
+	*
+	* @param uuid the UUID of the cal events
+	* @param companyId the primary key of the company
+	* @return all the matching cal events, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.calendar.model.CalEvent> getCalEventsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getCalEventsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of cal events that match the UUID and company.
+	*
+	* @param uuid the UUID of the cal events
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of cal events
+	* @param end the upper bound of the range of cal events (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching cal events, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.calendar.model.CalEvent> getCalEventsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getCalEventsByUuidAndCompanyId(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/calendar/service/CalEventLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/calendar/service/CalEventLocalServiceWrapper.java
@@ -308,20 +308,6 @@ public class CalEventLocalServiceWrapper implements CalEventLocalService,
 	}
 
 	/**
-	* Returns the cal event with the matching UUID and company.
-	*
-	* @param uuid the cal event's UUID
-	* @param companyId the primary key of the company
-	* @return the matching cal event, or <code>null</code> if a matching cal event could not be found
-	*/
-	@Override
-	public com.liferay.portlet.calendar.model.CalEvent fetchCalEventByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _calEventLocalService.fetchCalEventByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the cal event matching the UUID and group.
 	*
 	* @param uuid the cal event's UUID
@@ -363,22 +349,6 @@ public class CalEventLocalServiceWrapper implements CalEventLocalService,
 	}
 
 	/**
-	* Returns the cal event with the matching UUID and company.
-	*
-	* @param uuid the cal event's UUID
-	* @param companyId the primary key of the company
-	* @return the matching cal event
-	* @throws PortalException if a matching cal event could not be found
-	*/
-	@Override
-	public com.liferay.portlet.calendar.model.CalEvent getCalEventByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _calEventLocalService.getCalEventByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the cal event matching the UUID and group.
 	*
 	* @param uuid the cal event's UUID
@@ -408,6 +378,38 @@ public class CalEventLocalServiceWrapper implements CalEventLocalService,
 	public java.util.List<com.liferay.portlet.calendar.model.CalEvent> getCalEvents(
 		int start, int end) {
 		return _calEventLocalService.getCalEvents(start, end);
+	}
+
+	/**
+	* Returns all the cal events that match the UUID and company.
+	*
+	* @param uuid the UUID of the cal events
+	* @param companyId the primary key of the company
+	* @return all the matching cal events, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.calendar.model.CalEvent> getCalEventsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _calEventLocalService.getCalEventsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of cal events that match the UUID and company.
+	*
+	* @param uuid the UUID of the cal events
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of cal events
+	* @param end the upper bound of the range of cal events (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching cal events, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.calendar.model.CalEvent> getCalEventsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _calEventLocalService.getCalEventsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalService.java
@@ -267,17 +267,6 @@ public interface DLFileEntryLocalService extends BaseLocalService,
 		long fileEntryId);
 
 	/**
-	* Returns the document library file entry with the matching UUID and company.
-	*
-	* @param uuid the document library file entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFileEntry fetchDLFileEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the document library file entry matching the UUID and group.
 	*
 	* @param uuid the document library file entry's UUID
@@ -330,6 +319,32 @@ public interface DLFileEntryLocalService extends BaseLocalService,
 		int start, int end);
 
 	/**
+	* Returns all the document library file entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entries
+	* @param companyId the primary key of the company
+	* @return all the matching document library file entries, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getDLFileEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of document library file entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file entries
+	* @param end the upper bound of the range of document library file entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file entries, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getDLFileEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
+
+	/**
 	* Returns the number of document library file entries.
 	*
 	* @return the number of document library file entries
@@ -347,19 +362,6 @@ public interface DLFileEntryLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.documentlibrary.model.DLFileEntry getDLFileEntry(
 		long fileEntryId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
-	* Returns the document library file entry with the matching UUID and company.
-	*
-	* @param uuid the document library file entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry
-	* @throws PortalException if a matching document library file entry could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFileEntry getDLFileEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalServiceUtil.java
@@ -321,18 +321,6 @@ public class DLFileEntryLocalServiceUtil {
 	}
 
 	/**
-	* Returns the document library file entry with the matching UUID and company.
-	*
-	* @param uuid the document library file entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFileEntry fetchDLFileEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchDLFileEntryByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the document library file entry matching the UUID and group.
 	*
 	* @param uuid the document library file entry's UUID
@@ -394,6 +382,36 @@ public class DLFileEntryLocalServiceUtil {
 	}
 
 	/**
+	* Returns all the document library file entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entries
+	* @param companyId the primary key of the company
+	* @return all the matching document library file entries, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getDLFileEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getDLFileEntriesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of document library file entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file entries
+	* @param end the upper bound of the range of document library file entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file entries, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getDLFileEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDLFileEntriesByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of document library file entries.
 	*
 	* @return the number of document library file entries
@@ -413,20 +431,6 @@ public class DLFileEntryLocalServiceUtil {
 		long fileEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().getDLFileEntry(fileEntryId);
-	}
-
-	/**
-	* Returns the document library file entry with the matching UUID and company.
-	*
-	* @param uuid the document library file entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry
-	* @throws PortalException if a matching document library file entry could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFileEntry getDLFileEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDLFileEntryByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalServiceWrapper.java
@@ -342,20 +342,6 @@ public class DLFileEntryLocalServiceWrapper implements DLFileEntryLocalService,
 	}
 
 	/**
-	* Returns the document library file entry with the matching UUID and company.
-	*
-	* @param uuid the document library file entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFileEntry fetchDLFileEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _dlFileEntryLocalService.fetchDLFileEntryByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the document library file entry matching the UUID and group.
 	*
 	* @param uuid the document library file entry's UUID
@@ -427,6 +413,38 @@ public class DLFileEntryLocalServiceWrapper implements DLFileEntryLocalService,
 	}
 
 	/**
+	* Returns all the document library file entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entries
+	* @param companyId the primary key of the company
+	* @return all the matching document library file entries, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getDLFileEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _dlFileEntryLocalService.getDLFileEntriesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of document library file entries that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entries
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file entries
+	* @param end the upper bound of the range of document library file entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file entries, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getDLFileEntriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _dlFileEntryLocalService.getDLFileEntriesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of document library file entries.
 	*
 	* @return the number of document library file entries
@@ -448,22 +466,6 @@ public class DLFileEntryLocalServiceWrapper implements DLFileEntryLocalService,
 		long fileEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _dlFileEntryLocalService.getDLFileEntry(fileEntryId);
-	}
-
-	/**
-	* Returns the document library file entry with the matching UUID and company.
-	*
-	* @param uuid the document library file entry's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry
-	* @throws PortalException if a matching document library file entry could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFileEntry getDLFileEntryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _dlFileEntryLocalService.getDLFileEntryByUuidAndCompanyId(uuid,
-			companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeLocalService.java
@@ -247,17 +247,6 @@ public interface DLFileEntryTypeLocalService extends BaseLocalService,
 		long fileEntryTypeId);
 
 	/**
-	* Returns the document library file entry type with the matching UUID and company.
-	*
-	* @param uuid the document library file entry type's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFileEntryType fetchDLFileEntryTypeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the document library file entry type matching the UUID and group.
 	*
 	* @param uuid the document library file entry type's UUID
@@ -324,19 +313,6 @@ public interface DLFileEntryTypeLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the document library file entry type with the matching UUID and company.
-	*
-	* @param uuid the document library file entry type's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry type
-	* @throws PortalException if a matching document library file entry type could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFileEntryType getDLFileEntryTypeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the document library file entry type matching the UUID and group.
 	*
 	* @param uuid the document library file entry type's UUID
@@ -363,6 +339,32 @@ public interface DLFileEntryTypeLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntryType> getDLFileEntryTypes(
 		int start, int end);
+
+	/**
+	* Returns all the document library file entry types that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entry types
+	* @param companyId the primary key of the company
+	* @return all the matching document library file entry types, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntryType> getDLFileEntryTypesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of document library file entry types that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entry types
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file entry types
+	* @param end the upper bound of the range of document library file entry types (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file entry types, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntryType> getDLFileEntryTypesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of document library file entry types.

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeLocalServiceUtil.java
@@ -317,19 +317,6 @@ public class DLFileEntryTypeLocalServiceUtil {
 	}
 
 	/**
-	* Returns the document library file entry type with the matching UUID and company.
-	*
-	* @param uuid the document library file entry type's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFileEntryType fetchDLFileEntryTypeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService()
-				   .fetchDLFileEntryTypeByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the document library file entry type matching the UUID and group.
 	*
 	* @param uuid the document library file entry type's UUID
@@ -411,20 +398,6 @@ public class DLFileEntryTypeLocalServiceUtil {
 	}
 
 	/**
-	* Returns the document library file entry type with the matching UUID and company.
-	*
-	* @param uuid the document library file entry type's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry type
-	* @throws PortalException if a matching document library file entry type could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFileEntryType getDLFileEntryTypeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDLFileEntryTypeByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the document library file entry type matching the UUID and group.
 	*
 	* @param uuid the document library file entry type's UUID
@@ -452,6 +425,37 @@ public class DLFileEntryTypeLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntryType> getDLFileEntryTypes(
 		int start, int end) {
 		return getService().getDLFileEntryTypes(start, end);
+	}
+
+	/**
+	* Returns all the document library file entry types that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entry types
+	* @param companyId the primary key of the company
+	* @return all the matching document library file entry types, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntryType> getDLFileEntryTypesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService()
+				   .getDLFileEntryTypesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of document library file entry types that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entry types
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file entry types
+	* @param end the upper bound of the range of document library file entry types (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file entry types, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntryType> getDLFileEntryTypesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDLFileEntryTypesByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeLocalServiceWrapper.java
@@ -357,20 +357,6 @@ public class DLFileEntryTypeLocalServiceWrapper
 	}
 
 	/**
-	* Returns the document library file entry type with the matching UUID and company.
-	*
-	* @param uuid the document library file entry type's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFileEntryType fetchDLFileEntryTypeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _dlFileEntryTypeLocalService.fetchDLFileEntryTypeByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the document library file entry type matching the UUID and group.
 	*
 	* @param uuid the document library file entry type's UUID
@@ -464,22 +450,6 @@ public class DLFileEntryTypeLocalServiceWrapper
 	}
 
 	/**
-	* Returns the document library file entry type with the matching UUID and company.
-	*
-	* @param uuid the document library file entry type's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file entry type
-	* @throws PortalException if a matching document library file entry type could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFileEntryType getDLFileEntryTypeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _dlFileEntryTypeLocalService.getDLFileEntryTypeByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the document library file entry type matching the UUID and group.
 	*
 	* @param uuid the document library file entry type's UUID
@@ -510,6 +480,38 @@ public class DLFileEntryTypeLocalServiceWrapper
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntryType> getDLFileEntryTypes(
 		int start, int end) {
 		return _dlFileEntryTypeLocalService.getDLFileEntryTypes(start, end);
+	}
+
+	/**
+	* Returns all the document library file entry types that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entry types
+	* @param companyId the primary key of the company
+	* @return all the matching document library file entry types, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntryType> getDLFileEntryTypesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _dlFileEntryTypeLocalService.getDLFileEntryTypesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of document library file entry types that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file entry types
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file entry types
+	* @param end the upper bound of the range of document library file entry types (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file entry types, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntryType> getDLFileEntryTypesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _dlFileEntryTypeLocalService.getDLFileEntryTypesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileShortcutLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileShortcutLocalService.java
@@ -213,17 +213,6 @@ public interface DLFileShortcutLocalService extends BaseLocalService,
 		long fileShortcutId);
 
 	/**
-	* Returns the document library file shortcut with the matching UUID and company.
-	*
-	* @param uuid the document library file shortcut's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file shortcut, or <code>null</code> if a matching document library file shortcut could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFileShortcut fetchDLFileShortcutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the document library file shortcut matching the UUID and group.
 	*
 	* @param uuid the document library file shortcut's UUID
@@ -257,19 +246,6 @@ public interface DLFileShortcutLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the document library file shortcut with the matching UUID and company.
-	*
-	* @param uuid the document library file shortcut's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file shortcut
-	* @throws PortalException if a matching document library file shortcut could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFileShortcut getDLFileShortcutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the document library file shortcut matching the UUID and group.
 	*
 	* @param uuid the document library file shortcut's UUID
@@ -296,6 +272,32 @@ public interface DLFileShortcutLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileShortcut> getDLFileShortcuts(
 		int start, int end);
+
+	/**
+	* Returns all the document library file shortcuts that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file shortcuts
+	* @param companyId the primary key of the company
+	* @return all the matching document library file shortcuts, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileShortcut> getDLFileShortcutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of document library file shortcuts that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file shortcuts
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file shortcuts
+	* @param end the upper bound of the range of document library file shortcuts (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file shortcuts, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileShortcut> getDLFileShortcutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of document library file shortcuts.

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileShortcutLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileShortcutLocalServiceUtil.java
@@ -259,19 +259,6 @@ public class DLFileShortcutLocalServiceUtil {
 	}
 
 	/**
-	* Returns the document library file shortcut with the matching UUID and company.
-	*
-	* @param uuid the document library file shortcut's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file shortcut, or <code>null</code> if a matching document library file shortcut could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFileShortcut fetchDLFileShortcutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService()
-				   .fetchDLFileShortcutByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the document library file shortcut matching the UUID and group.
 	*
 	* @param uuid the document library file shortcut's UUID
@@ -310,20 +297,6 @@ public class DLFileShortcutLocalServiceUtil {
 	}
 
 	/**
-	* Returns the document library file shortcut with the matching UUID and company.
-	*
-	* @param uuid the document library file shortcut's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file shortcut
-	* @throws PortalException if a matching document library file shortcut could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFileShortcut getDLFileShortcutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDLFileShortcutByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the document library file shortcut matching the UUID and group.
 	*
 	* @param uuid the document library file shortcut's UUID
@@ -351,6 +324,36 @@ public class DLFileShortcutLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileShortcut> getDLFileShortcuts(
 		int start, int end) {
 		return getService().getDLFileShortcuts(start, end);
+	}
+
+	/**
+	* Returns all the document library file shortcuts that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file shortcuts
+	* @param companyId the primary key of the company
+	* @return all the matching document library file shortcuts, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileShortcut> getDLFileShortcutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getDLFileShortcutsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of document library file shortcuts that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file shortcuts
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file shortcuts
+	* @param end the upper bound of the range of document library file shortcuts (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file shortcuts, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileShortcut> getDLFileShortcutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDLFileShortcutsByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileShortcutLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileShortcutLocalServiceWrapper.java
@@ -272,20 +272,6 @@ public class DLFileShortcutLocalServiceWrapper
 	}
 
 	/**
-	* Returns the document library file shortcut with the matching UUID and company.
-	*
-	* @param uuid the document library file shortcut's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file shortcut, or <code>null</code> if a matching document library file shortcut could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFileShortcut fetchDLFileShortcutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _dlFileShortcutLocalService.fetchDLFileShortcutByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the document library file shortcut matching the UUID and group.
 	*
 	* @param uuid the document library file shortcut's UUID
@@ -329,22 +315,6 @@ public class DLFileShortcutLocalServiceWrapper
 	}
 
 	/**
-	* Returns the document library file shortcut with the matching UUID and company.
-	*
-	* @param uuid the document library file shortcut's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file shortcut
-	* @throws PortalException if a matching document library file shortcut could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFileShortcut getDLFileShortcutByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _dlFileShortcutLocalService.getDLFileShortcutByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the document library file shortcut matching the UUID and group.
 	*
 	* @param uuid the document library file shortcut's UUID
@@ -375,6 +345,38 @@ public class DLFileShortcutLocalServiceWrapper
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileShortcut> getDLFileShortcuts(
 		int start, int end) {
 		return _dlFileShortcutLocalService.getDLFileShortcuts(start, end);
+	}
+
+	/**
+	* Returns all the document library file shortcuts that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file shortcuts
+	* @param companyId the primary key of the company
+	* @return all the matching document library file shortcuts, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileShortcut> getDLFileShortcutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _dlFileShortcutLocalService.getDLFileShortcutsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of document library file shortcuts that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file shortcuts
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file shortcuts
+	* @param end the upper bound of the range of document library file shortcuts (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file shortcuts, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileShortcut> getDLFileShortcutsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _dlFileShortcutLocalService.getDLFileShortcutsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionLocalService.java
@@ -167,17 +167,6 @@ public interface DLFileVersionLocalService extends BaseLocalService,
 		long fileVersionId);
 
 	/**
-	* Returns the document library file version with the matching UUID and company.
-	*
-	* @param uuid the document library file version's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file version, or <code>null</code> if a matching document library file version could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFileVersion fetchDLFileVersionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the document library file version matching the UUID and group.
 	*
 	* @param uuid the document library file version's UUID
@@ -211,19 +200,6 @@ public interface DLFileVersionLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the document library file version with the matching UUID and company.
-	*
-	* @param uuid the document library file version's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file version
-	* @throws PortalException if a matching document library file version could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFileVersion getDLFileVersionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the document library file version matching the UUID and group.
 	*
 	* @param uuid the document library file version's UUID
@@ -250,6 +226,32 @@ public interface DLFileVersionLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileVersion> getDLFileVersions(
 		int start, int end);
+
+	/**
+	* Returns all the document library file versions that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file versions
+	* @param companyId the primary key of the company
+	* @return all the matching document library file versions, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileVersion> getDLFileVersionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of document library file versions that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file versions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file versions
+	* @param end the upper bound of the range of document library file versions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file versions, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileVersion> getDLFileVersionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of document library file versions.

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionLocalServiceUtil.java
@@ -180,18 +180,6 @@ public class DLFileVersionLocalServiceUtil {
 	}
 
 	/**
-	* Returns the document library file version with the matching UUID and company.
-	*
-	* @param uuid the document library file version's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file version, or <code>null</code> if a matching document library file version could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFileVersion fetchDLFileVersionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchDLFileVersionByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the document library file version matching the UUID and group.
 	*
 	* @param uuid the document library file version's UUID
@@ -230,20 +218,6 @@ public class DLFileVersionLocalServiceUtil {
 	}
 
 	/**
-	* Returns the document library file version with the matching UUID and company.
-	*
-	* @param uuid the document library file version's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file version
-	* @throws PortalException if a matching document library file version could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFileVersion getDLFileVersionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDLFileVersionByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the document library file version matching the UUID and group.
 	*
 	* @param uuid the document library file version's UUID
@@ -271,6 +245,36 @@ public class DLFileVersionLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileVersion> getDLFileVersions(
 		int start, int end) {
 		return getService().getDLFileVersions(start, end);
+	}
+
+	/**
+	* Returns all the document library file versions that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file versions
+	* @param companyId the primary key of the company
+	* @return all the matching document library file versions, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileVersion> getDLFileVersionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getDLFileVersionsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of document library file versions that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file versions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file versions
+	* @param end the upper bound of the range of document library file versions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file versions, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileVersion> getDLFileVersionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDLFileVersionsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionLocalServiceWrapper.java
@@ -186,20 +186,6 @@ public class DLFileVersionLocalServiceWrapper
 	}
 
 	/**
-	* Returns the document library file version with the matching UUID and company.
-	*
-	* @param uuid the document library file version's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file version, or <code>null</code> if a matching document library file version could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFileVersion fetchDLFileVersionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _dlFileVersionLocalService.fetchDLFileVersionByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the document library file version matching the UUID and group.
 	*
 	* @param uuid the document library file version's UUID
@@ -243,22 +229,6 @@ public class DLFileVersionLocalServiceWrapper
 	}
 
 	/**
-	* Returns the document library file version with the matching UUID and company.
-	*
-	* @param uuid the document library file version's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library file version
-	* @throws PortalException if a matching document library file version could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFileVersion getDLFileVersionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _dlFileVersionLocalService.getDLFileVersionByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the document library file version matching the UUID and group.
 	*
 	* @param uuid the document library file version's UUID
@@ -289,6 +259,38 @@ public class DLFileVersionLocalServiceWrapper
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileVersion> getDLFileVersions(
 		int start, int end) {
 		return _dlFileVersionLocalService.getDLFileVersions(start, end);
+	}
+
+	/**
+	* Returns all the document library file versions that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file versions
+	* @param companyId the primary key of the company
+	* @return all the matching document library file versions, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileVersion> getDLFileVersionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _dlFileVersionLocalService.getDLFileVersionsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of document library file versions that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library file versions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library file versions
+	* @param end the upper bound of the range of document library file versions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library file versions, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileVersion> getDLFileVersionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _dlFileVersionLocalService.getDLFileVersionsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalService.java
@@ -243,17 +243,6 @@ public interface DLFolderLocalService extends BaseLocalService,
 		long folderId);
 
 	/**
-	* Returns the document library folder with the matching UUID and company.
-	*
-	* @param uuid the document library folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library folder, or <code>null</code> if a matching document library folder could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFolder fetchDLFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the document library folder matching the UUID and group.
 	*
 	* @param uuid the document library folder's UUID
@@ -327,19 +316,6 @@ public interface DLFolderLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the document library folder with the matching UUID and company.
-	*
-	* @param uuid the document library folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library folder
-	* @throws PortalException if a matching document library folder could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.documentlibrary.model.DLFolder getDLFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the document library folder matching the UUID and group.
 	*
 	* @param uuid the document library folder's UUID
@@ -366,6 +342,32 @@ public interface DLFolderLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> getDLFolders(
 		int start, int end);
+
+	/**
+	* Returns all the document library folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library folders
+	* @param companyId the primary key of the company
+	* @return all the matching document library folders, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> getDLFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of document library folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library folders
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library folders, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> getDLFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of document library folders.

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalServiceUtil.java
@@ -287,18 +287,6 @@ public class DLFolderLocalServiceUtil {
 	}
 
 	/**
-	* Returns the document library folder with the matching UUID and company.
-	*
-	* @param uuid the document library folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library folder, or <code>null</code> if a matching document library folder could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFolder fetchDLFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchDLFolderByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the document library folder matching the UUID and group.
 	*
 	* @param uuid the document library folder's UUID
@@ -389,20 +377,6 @@ public class DLFolderLocalServiceUtil {
 	}
 
 	/**
-	* Returns the document library folder with the matching UUID and company.
-	*
-	* @param uuid the document library folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library folder
-	* @throws PortalException if a matching document library folder could not be found
-	*/
-	public static com.liferay.portlet.documentlibrary.model.DLFolder getDLFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDLFolderByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the document library folder matching the UUID and group.
 	*
 	* @param uuid the document library folder's UUID
@@ -430,6 +404,36 @@ public class DLFolderLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> getDLFolders(
 		int start, int end) {
 		return getService().getDLFolders(start, end);
+	}
+
+	/**
+	* Returns all the document library folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library folders
+	* @param companyId the primary key of the company
+	* @return all the matching document library folders, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> getDLFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getDLFoldersByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of document library folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library folders
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library folders, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> getDLFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDLFoldersByUuidAndCompanyId(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalServiceWrapper.java
@@ -318,20 +318,6 @@ public class DLFolderLocalServiceWrapper implements DLFolderLocalService,
 	}
 
 	/**
-	* Returns the document library folder with the matching UUID and company.
-	*
-	* @param uuid the document library folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library folder, or <code>null</code> if a matching document library folder could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFolder fetchDLFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _dlFolderLocalService.fetchDLFolderByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the document library folder matching the UUID and group.
 	*
 	* @param uuid the document library folder's UUID
@@ -434,22 +420,6 @@ public class DLFolderLocalServiceWrapper implements DLFolderLocalService,
 	}
 
 	/**
-	* Returns the document library folder with the matching UUID and company.
-	*
-	* @param uuid the document library folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching document library folder
-	* @throws PortalException if a matching document library folder could not be found
-	*/
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFolder getDLFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _dlFolderLocalService.getDLFolderByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the document library folder matching the UUID and group.
 	*
 	* @param uuid the document library folder's UUID
@@ -479,6 +449,38 @@ public class DLFolderLocalServiceWrapper implements DLFolderLocalService,
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> getDLFolders(
 		int start, int end) {
 		return _dlFolderLocalService.getDLFolders(start, end);
+	}
+
+	/**
+	* Returns all the document library folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library folders
+	* @param companyId the primary key of the company
+	* @return all the matching document library folders, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> getDLFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _dlFolderLocalService.getDLFoldersByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of document library folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the document library folders
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching document library folders, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> getDLFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _dlFolderLocalService.getDLFoldersByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordLocalService.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordLocalService.java
@@ -198,17 +198,6 @@ public interface DDLRecordLocalService extends BaseLocalService,
 		long recordId);
 
 	/**
-	* Returns the d d l record with the matching UUID and company.
-	*
-	* @param uuid the d d l record's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record, or <code>null</code> if a matching d d l record could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatalists.model.DDLRecord fetchDDLRecordByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the d d l record matching the UUID and group.
 	*
 	* @param uuid the d d l record's UUID
@@ -272,19 +261,6 @@ public interface DDLRecordLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the d d l record with the matching UUID and company.
-	*
-	* @param uuid the d d l record's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record
-	* @throws PortalException if a matching d d l record could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatalists.model.DDLRecord getDDLRecordByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the d d l record matching the UUID and group.
 	*
 	* @param uuid the d d l record's UUID
@@ -311,6 +287,32 @@ public interface DDLRecordLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecord> getDDLRecords(
 		int start, int end);
+
+	/**
+	* Returns all the d d l records that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l records
+	* @param companyId the primary key of the company
+	* @return all the matching d d l records, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecord> getDDLRecordsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of d d l records that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l records
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d l records
+	* @param end the upper bound of the range of d d l records (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d l records, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecord> getDDLRecordsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of d d l records.

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordLocalServiceUtil.java
@@ -223,18 +223,6 @@ public class DDLRecordLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d l record with the matching UUID and company.
-	*
-	* @param uuid the d d l record's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record, or <code>null</code> if a matching d d l record could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatalists.model.DDLRecord fetchDDLRecordByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchDDLRecordByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d l record matching the UUID and group.
 	*
 	* @param uuid the d d l record's UUID
@@ -313,20 +301,6 @@ public class DDLRecordLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d l record with the matching UUID and company.
-	*
-	* @param uuid the d d l record's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record
-	* @throws PortalException if a matching d d l record could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatalists.model.DDLRecord getDDLRecordByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDDLRecordByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d l record matching the UUID and group.
 	*
 	* @param uuid the d d l record's UUID
@@ -354,6 +328,36 @@ public class DDLRecordLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecord> getDDLRecords(
 		int start, int end) {
 		return getService().getDDLRecords(start, end);
+	}
+
+	/**
+	* Returns all the d d l records that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l records
+	* @param companyId the primary key of the company
+	* @return all the matching d d l records, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecord> getDDLRecordsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getDDLRecordsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of d d l records that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l records
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d l records
+	* @param end the upper bound of the range of d d l records (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d l records, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecord> getDDLRecordsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDDLRecordsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordLocalServiceWrapper.java
@@ -232,20 +232,6 @@ public class DDLRecordLocalServiceWrapper implements DDLRecordLocalService,
 	}
 
 	/**
-	* Returns the d d l record with the matching UUID and company.
-	*
-	* @param uuid the d d l record's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record, or <code>null</code> if a matching d d l record could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatalists.model.DDLRecord fetchDDLRecordByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _ddlRecordLocalService.fetchDDLRecordByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d l record matching the UUID and group.
 	*
 	* @param uuid the d d l record's UUID
@@ -332,22 +318,6 @@ public class DDLRecordLocalServiceWrapper implements DDLRecordLocalService,
 	}
 
 	/**
-	* Returns the d d l record with the matching UUID and company.
-	*
-	* @param uuid the d d l record's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record
-	* @throws PortalException if a matching d d l record could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatalists.model.DDLRecord getDDLRecordByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _ddlRecordLocalService.getDDLRecordByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d l record matching the UUID and group.
 	*
 	* @param uuid the d d l record's UUID
@@ -377,6 +347,38 @@ public class DDLRecordLocalServiceWrapper implements DDLRecordLocalService,
 	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecord> getDDLRecords(
 		int start, int end) {
 		return _ddlRecordLocalService.getDDLRecords(start, end);
+	}
+
+	/**
+	* Returns all the d d l records that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l records
+	* @param companyId the primary key of the company
+	* @return all the matching d d l records, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecord> getDDLRecordsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _ddlRecordLocalService.getDDLRecordsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of d d l records that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l records
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d l records
+	* @param end the upper bound of the range of d d l records (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d l records, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecord> getDDLRecordsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _ddlRecordLocalService.getDDLRecordsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordSetLocalService.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordSetLocalService.java
@@ -201,17 +201,6 @@ public interface DDLRecordSetLocalService extends BaseLocalService,
 		long recordSetId);
 
 	/**
-	* Returns the d d l record set with the matching UUID and company.
-	*
-	* @param uuid the d d l record set's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record set, or <code>null</code> if a matching d d l record set could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatalists.model.DDLRecordSet fetchDDLRecordSetByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the d d l record set matching the UUID and group.
 	*
 	* @param uuid the d d l record set's UUID
@@ -253,19 +242,6 @@ public interface DDLRecordSetLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the d d l record set with the matching UUID and company.
-	*
-	* @param uuid the d d l record set's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record set
-	* @throws PortalException if a matching d d l record set could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatalists.model.DDLRecordSet getDDLRecordSetByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the d d l record set matching the UUID and group.
 	*
 	* @param uuid the d d l record set's UUID
@@ -292,6 +268,32 @@ public interface DDLRecordSetLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecordSet> getDDLRecordSets(
 		int start, int end);
+
+	/**
+	* Returns all the d d l record sets that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l record sets
+	* @param companyId the primary key of the company
+	* @return all the matching d d l record sets, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecordSet> getDDLRecordSetsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of d d l record sets that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l record sets
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d l record sets
+	* @param end the upper bound of the range of d d l record sets (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d l record sets, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecordSet> getDDLRecordSetsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of d d l record sets.

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordSetLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordSetLocalServiceUtil.java
@@ -232,18 +232,6 @@ public class DDLRecordSetLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d l record set with the matching UUID and company.
-	*
-	* @param uuid the d d l record set's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record set, or <code>null</code> if a matching d d l record set could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatalists.model.DDLRecordSet fetchDDLRecordSetByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchDDLRecordSetByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d l record set matching the UUID and group.
 	*
 	* @param uuid the d d l record set's UUID
@@ -292,20 +280,6 @@ public class DDLRecordSetLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d l record set with the matching UUID and company.
-	*
-	* @param uuid the d d l record set's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record set
-	* @throws PortalException if a matching d d l record set could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatalists.model.DDLRecordSet getDDLRecordSetByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDDLRecordSetByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d l record set matching the UUID and group.
 	*
 	* @param uuid the d d l record set's UUID
@@ -333,6 +307,36 @@ public class DDLRecordSetLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecordSet> getDDLRecordSets(
 		int start, int end) {
 		return getService().getDDLRecordSets(start, end);
+	}
+
+	/**
+	* Returns all the d d l record sets that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l record sets
+	* @param companyId the primary key of the company
+	* @return all the matching d d l record sets, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecordSet> getDDLRecordSetsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getDDLRecordSetsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of d d l record sets that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l record sets
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d l record sets
+	* @param end the upper bound of the range of d d l record sets (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d l record sets, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecordSet> getDDLRecordSetsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDDLRecordSetsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordSetLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/service/DDLRecordSetLocalServiceWrapper.java
@@ -242,20 +242,6 @@ public class DDLRecordSetLocalServiceWrapper implements DDLRecordSetLocalService
 	}
 
 	/**
-	* Returns the d d l record set with the matching UUID and company.
-	*
-	* @param uuid the d d l record set's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record set, or <code>null</code> if a matching d d l record set could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatalists.model.DDLRecordSet fetchDDLRecordSetByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _ddlRecordSetLocalService.fetchDDLRecordSetByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d l record set matching the UUID and group.
 	*
 	* @param uuid the d d l record set's UUID
@@ -311,22 +297,6 @@ public class DDLRecordSetLocalServiceWrapper implements DDLRecordSetLocalService
 	}
 
 	/**
-	* Returns the d d l record set with the matching UUID and company.
-	*
-	* @param uuid the d d l record set's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d l record set
-	* @throws PortalException if a matching d d l record set could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatalists.model.DDLRecordSet getDDLRecordSetByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _ddlRecordSetLocalService.getDDLRecordSetByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d l record set matching the UUID and group.
 	*
 	* @param uuid the d d l record set's UUID
@@ -357,6 +327,38 @@ public class DDLRecordSetLocalServiceWrapper implements DDLRecordSetLocalService
 	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecordSet> getDDLRecordSets(
 		int start, int end) {
 		return _ddlRecordSetLocalService.getDDLRecordSets(start, end);
+	}
+
+	/**
+	* Returns all the d d l record sets that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l record sets
+	* @param companyId the primary key of the company
+	* @return all the matching d d l record sets, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecordSet> getDDLRecordSetsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _ddlRecordSetLocalService.getDDLRecordSetsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of d d l record sets that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d l record sets
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d l record sets
+	* @param end the upper bound of the range of d d l record sets (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d l record sets, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatalists.model.DDLRecordSet> getDDLRecordSetsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _ddlRecordSetLocalService.getDDLRecordSetsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMContentLocalService.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMContentLocalService.java
@@ -177,17 +177,6 @@ public interface DDMContentLocalService extends BaseLocalService,
 		long contentId);
 
 	/**
-	* Returns the d d m content with the matching UUID and company.
-	*
-	* @param uuid the d d m content's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m content, or <code>null</code> if a matching d d m content could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatamapping.model.DDMContent fetchDDMContentByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the d d m content matching the UUID and group.
 	*
 	* @param uuid the d d m content's UUID
@@ -240,19 +229,6 @@ public interface DDMContentLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the d d m content with the matching UUID and company.
-	*
-	* @param uuid the d d m content's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m content
-	* @throws PortalException if a matching d d m content could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatamapping.model.DDMContent getDDMContentByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the d d m content matching the UUID and group.
 	*
 	* @param uuid the d d m content's UUID
@@ -279,6 +255,32 @@ public interface DDMContentLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMContent> getDDMContents(
 		int start, int end);
+
+	/**
+	* Returns all the d d m contents that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m contents
+	* @param companyId the primary key of the company
+	* @return all the matching d d m contents, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMContent> getDDMContentsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of d d m contents that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m contents
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d m contents
+	* @param end the upper bound of the range of d d m contents (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d m contents, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMContent> getDDMContentsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of d d m contents.

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMContentLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMContentLocalServiceUtil.java
@@ -198,18 +198,6 @@ public class DDMContentLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d m content with the matching UUID and company.
-	*
-	* @param uuid the d d m content's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m content, or <code>null</code> if a matching d d m content could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatamapping.model.DDMContent fetchDDMContentByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchDDMContentByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d m content matching the UUID and group.
 	*
 	* @param uuid the d d m content's UUID
@@ -272,20 +260,6 @@ public class DDMContentLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d m content with the matching UUID and company.
-	*
-	* @param uuid the d d m content's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m content
-	* @throws PortalException if a matching d d m content could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatamapping.model.DDMContent getDDMContentByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDDMContentByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d m content matching the UUID and group.
 	*
 	* @param uuid the d d m content's UUID
@@ -313,6 +287,36 @@ public class DDMContentLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMContent> getDDMContents(
 		int start, int end) {
 		return getService().getDDMContents(start, end);
+	}
+
+	/**
+	* Returns all the d d m contents that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m contents
+	* @param companyId the primary key of the company
+	* @return all the matching d d m contents, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMContent> getDDMContentsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getDDMContentsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of d d m contents that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m contents
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d m contents
+	* @param end the upper bound of the range of d d m contents (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d m contents, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMContent> getDDMContentsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDDMContentsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMContentLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMContentLocalServiceWrapper.java
@@ -206,20 +206,6 @@ public class DDMContentLocalServiceWrapper implements DDMContentLocalService,
 	}
 
 	/**
-	* Returns the d d m content with the matching UUID and company.
-	*
-	* @param uuid the d d m content's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m content, or <code>null</code> if a matching d d m content could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatamapping.model.DDMContent fetchDDMContentByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _ddmContentLocalService.fetchDDMContentByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d m content matching the UUID and group.
 	*
 	* @param uuid the d d m content's UUID
@@ -292,22 +278,6 @@ public class DDMContentLocalServiceWrapper implements DDMContentLocalService,
 	}
 
 	/**
-	* Returns the d d m content with the matching UUID and company.
-	*
-	* @param uuid the d d m content's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m content
-	* @throws PortalException if a matching d d m content could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatamapping.model.DDMContent getDDMContentByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _ddmContentLocalService.getDDMContentByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d m content matching the UUID and group.
 	*
 	* @param uuid the d d m content's UUID
@@ -338,6 +308,38 @@ public class DDMContentLocalServiceWrapper implements DDMContentLocalService,
 	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMContent> getDDMContents(
 		int start, int end) {
 		return _ddmContentLocalService.getDDMContents(start, end);
+	}
+
+	/**
+	* Returns all the d d m contents that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m contents
+	* @param companyId the primary key of the company
+	* @return all the matching d d m contents, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMContent> getDDMContentsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _ddmContentLocalService.getDDMContentsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of d d m contents that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m contents
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d m contents
+	* @param end the upper bound of the range of d d m contents (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d m contents, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMContent> getDDMContentsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _ddmContentLocalService.getDDMContentsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMStructureLocalService.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMStructureLocalService.java
@@ -436,17 +436,6 @@ public interface DDMStructureLocalService extends BaseLocalService,
 		long structureId);
 
 	/**
-	* Returns the d d m structure with the matching UUID and company.
-	*
-	* @param uuid the d d m structure's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m structure, or <code>null</code> if a matching d d m structure could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatamapping.model.DDMStructure fetchDDMStructureByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the d d m structure matching the UUID and group.
 	*
 	* @param uuid the d d m structure's UUID
@@ -613,19 +602,6 @@ public interface DDMStructureLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the d d m structure with the matching UUID and company.
-	*
-	* @param uuid the d d m structure's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m structure
-	* @throws PortalException if a matching d d m structure could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatamapping.model.DDMStructure getDDMStructureByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the d d m structure matching the UUID and group.
 	*
 	* @param uuid the d d m structure's UUID
@@ -652,6 +628,32 @@ public interface DDMStructureLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getDDMStructures(
 		int start, int end);
+
+	/**
+	* Returns all the d d m structures that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m structures
+	* @param companyId the primary key of the company
+	* @return all the matching d d m structures, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getDDMStructuresByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of d d m structures that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m structures
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d m structures
+	* @param end the upper bound of the range of d d m structures (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d m structures, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getDDMStructuresByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of d d m structures.

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMStructureLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMStructureLocalServiceUtil.java
@@ -529,18 +529,6 @@ public class DDMStructureLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d m structure with the matching UUID and company.
-	*
-	* @param uuid the d d m structure's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m structure, or <code>null</code> if a matching d d m structure could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatamapping.model.DDMStructure fetchDDMStructureByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchDDMStructureByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d m structure matching the UUID and group.
 	*
 	* @param uuid the d d m structure's UUID
@@ -725,20 +713,6 @@ public class DDMStructureLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d m structure with the matching UUID and company.
-	*
-	* @param uuid the d d m structure's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m structure
-	* @throws PortalException if a matching d d m structure could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatamapping.model.DDMStructure getDDMStructureByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDDMStructureByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d m structure matching the UUID and group.
 	*
 	* @param uuid the d d m structure's UUID
@@ -766,6 +740,36 @@ public class DDMStructureLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getDDMStructures(
 		int start, int end) {
 		return getService().getDDMStructures(start, end);
+	}
+
+	/**
+	* Returns all the d d m structures that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m structures
+	* @param companyId the primary key of the company
+	* @return all the matching d d m structures, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getDDMStructuresByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getDDMStructuresByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of d d m structures that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m structures
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d m structures
+	* @param end the upper bound of the range of d d m structures (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d m structures, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getDDMStructuresByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDDMStructuresByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMStructureLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMStructureLocalServiceWrapper.java
@@ -565,20 +565,6 @@ public class DDMStructureLocalServiceWrapper implements DDMStructureLocalService
 	}
 
 	/**
-	* Returns the d d m structure with the matching UUID and company.
-	*
-	* @param uuid the d d m structure's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m structure, or <code>null</code> if a matching d d m structure could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatamapping.model.DDMStructure fetchDDMStructureByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _ddmStructureLocalService.fetchDDMStructureByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d m structure matching the UUID and group.
 	*
 	* @param uuid the d d m structure's UUID
@@ -780,22 +766,6 @@ public class DDMStructureLocalServiceWrapper implements DDMStructureLocalService
 	}
 
 	/**
-	* Returns the d d m structure with the matching UUID and company.
-	*
-	* @param uuid the d d m structure's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m structure
-	* @throws PortalException if a matching d d m structure could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatamapping.model.DDMStructure getDDMStructureByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _ddmStructureLocalService.getDDMStructureByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d m structure matching the UUID and group.
 	*
 	* @param uuid the d d m structure's UUID
@@ -826,6 +796,38 @@ public class DDMStructureLocalServiceWrapper implements DDMStructureLocalService
 	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getDDMStructures(
 		int start, int end) {
 		return _ddmStructureLocalService.getDDMStructures(start, end);
+	}
+
+	/**
+	* Returns all the d d m structures that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m structures
+	* @param companyId the primary key of the company
+	* @return all the matching d d m structures, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getDDMStructuresByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _ddmStructureLocalService.getDDMStructuresByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of d d m structures that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m structures
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d m structures
+	* @param end the upper bound of the range of d d m structures (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d m structures, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getDDMStructuresByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _ddmStructureLocalService.getDDMStructuresByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMTemplateLocalService.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMTemplateLocalService.java
@@ -352,17 +352,6 @@ public interface DDMTemplateLocalService extends BaseLocalService,
 		long templateId);
 
 	/**
-	* Returns the d d m template with the matching UUID and company.
-	*
-	* @param uuid the d d m template's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m template, or <code>null</code> if a matching d d m template could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatamapping.model.DDMTemplate fetchDDMTemplateByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the d d m template matching the UUID and group.
 	*
 	* @param uuid the d d m template's UUID
@@ -436,19 +425,6 @@ public interface DDMTemplateLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the d d m template with the matching UUID and company.
-	*
-	* @param uuid the d d m template's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m template
-	* @throws PortalException if a matching d d m template could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.dynamicdatamapping.model.DDMTemplate getDDMTemplateByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the d d m template matching the UUID and group.
 	*
 	* @param uuid the d d m template's UUID
@@ -475,6 +451,32 @@ public interface DDMTemplateLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMTemplate> getDDMTemplates(
 		int start, int end);
+
+	/**
+	* Returns all the d d m templates that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m templates
+	* @param companyId the primary key of the company
+	* @return all the matching d d m templates, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMTemplate> getDDMTemplatesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of d d m templates that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m templates
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d m templates
+	* @param end the upper bound of the range of d d m templates (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d m templates, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMTemplate> getDDMTemplatesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of d d m templates.

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMTemplateLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMTemplateLocalServiceUtil.java
@@ -395,18 +395,6 @@ public class DDMTemplateLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d m template with the matching UUID and company.
-	*
-	* @param uuid the d d m template's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m template, or <code>null</code> if a matching d d m template could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatamapping.model.DDMTemplate fetchDDMTemplateByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchDDMTemplateByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d m template matching the UUID and group.
 	*
 	* @param uuid the d d m template's UUID
@@ -489,20 +477,6 @@ public class DDMTemplateLocalServiceUtil {
 	}
 
 	/**
-	* Returns the d d m template with the matching UUID and company.
-	*
-	* @param uuid the d d m template's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m template
-	* @throws PortalException if a matching d d m template could not be found
-	*/
-	public static com.liferay.portlet.dynamicdatamapping.model.DDMTemplate getDDMTemplateByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getDDMTemplateByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the d d m template matching the UUID and group.
 	*
 	* @param uuid the d d m template's UUID
@@ -530,6 +504,36 @@ public class DDMTemplateLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMTemplate> getDDMTemplates(
 		int start, int end) {
 		return getService().getDDMTemplates(start, end);
+	}
+
+	/**
+	* Returns all the d d m templates that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m templates
+	* @param companyId the primary key of the company
+	* @return all the matching d d m templates, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMTemplate> getDDMTemplatesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getDDMTemplatesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of d d m templates that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m templates
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d m templates
+	* @param end the upper bound of the range of d d m templates (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d m templates, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMTemplate> getDDMTemplatesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getDDMTemplatesByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMTemplateLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/service/DDMTemplateLocalServiceWrapper.java
@@ -408,20 +408,6 @@ public class DDMTemplateLocalServiceWrapper implements DDMTemplateLocalService,
 	}
 
 	/**
-	* Returns the d d m template with the matching UUID and company.
-	*
-	* @param uuid the d d m template's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m template, or <code>null</code> if a matching d d m template could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatamapping.model.DDMTemplate fetchDDMTemplateByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _ddmTemplateLocalService.fetchDDMTemplateByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d m template matching the UUID and group.
 	*
 	* @param uuid the d d m template's UUID
@@ -511,22 +497,6 @@ public class DDMTemplateLocalServiceWrapper implements DDMTemplateLocalService,
 	}
 
 	/**
-	* Returns the d d m template with the matching UUID and company.
-	*
-	* @param uuid the d d m template's UUID
-	* @param companyId the primary key of the company
-	* @return the matching d d m template
-	* @throws PortalException if a matching d d m template could not be found
-	*/
-	@Override
-	public com.liferay.portlet.dynamicdatamapping.model.DDMTemplate getDDMTemplateByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _ddmTemplateLocalService.getDDMTemplateByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the d d m template matching the UUID and group.
 	*
 	* @param uuid the d d m template's UUID
@@ -557,6 +527,38 @@ public class DDMTemplateLocalServiceWrapper implements DDMTemplateLocalService,
 	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMTemplate> getDDMTemplates(
 		int start, int end) {
 		return _ddmTemplateLocalService.getDDMTemplates(start, end);
+	}
+
+	/**
+	* Returns all the d d m templates that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m templates
+	* @param companyId the primary key of the company
+	* @return all the matching d d m templates, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMTemplate> getDDMTemplatesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _ddmTemplateLocalService.getDDMTemplatesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of d d m templates that match the UUID and company.
+	*
+	* @param uuid the UUID of the d d m templates
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of d d m templates
+	* @param end the upper bound of the range of d d m templates (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching d d m templates, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.dynamicdatamapping.model.DDMTemplate> getDDMTemplatesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _ddmTemplateLocalService.getDDMTemplatesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/journal/service/JournalArticleLocalService.java
+++ b/portal-service/src/com/liferay/portlet/journal/service/JournalArticleLocalService.java
@@ -612,17 +612,6 @@ public interface JournalArticleLocalService extends BaseLocalService,
 		long id);
 
 	/**
-	* Returns the journal article with the matching UUID and company.
-	*
-	* @param uuid the journal article's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal article, or <code>null</code> if a matching journal article could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.journal.model.JournalArticle fetchJournalArticleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the journal article matching the UUID and group.
 	*
 	* @param uuid the journal article's UUID
@@ -1409,19 +1398,6 @@ public interface JournalArticleLocalService extends BaseLocalService,
 		long id) throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the journal article with the matching UUID and company.
-	*
-	* @param uuid the journal article's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal article
-	* @throws PortalException if a matching journal article could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.journal.model.JournalArticle getJournalArticleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the journal article matching the UUID and group.
 	*
 	* @param uuid the journal article's UUID
@@ -1448,6 +1424,32 @@ public interface JournalArticleLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.journal.model.JournalArticle> getJournalArticles(
 		int start, int end);
+
+	/**
+	* Returns all the journal articles that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal articles
+	* @param companyId the primary key of the company
+	* @return all the matching journal articles, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.journal.model.JournalArticle> getJournalArticlesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of journal articles that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal articles
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of journal articles
+	* @param end the upper bound of the range of journal articles (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching journal articles, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.journal.model.JournalArticle> getJournalArticlesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of journal articles.

--- a/portal-service/src/com/liferay/portlet/journal/service/JournalArticleLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/journal/service/JournalArticleLocalServiceUtil.java
@@ -692,19 +692,6 @@ public class JournalArticleLocalServiceUtil {
 	}
 
 	/**
-	* Returns the journal article with the matching UUID and company.
-	*
-	* @param uuid the journal article's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal article, or <code>null</code> if a matching journal article could not be found
-	*/
-	public static com.liferay.portlet.journal.model.JournalArticle fetchJournalArticleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService()
-				   .fetchJournalArticleByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the journal article matching the UUID and group.
 	*
 	* @param uuid the journal article's UUID
@@ -1583,20 +1570,6 @@ public class JournalArticleLocalServiceUtil {
 	}
 
 	/**
-	* Returns the journal article with the matching UUID and company.
-	*
-	* @param uuid the journal article's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal article
-	* @throws PortalException if a matching journal article could not be found
-	*/
-	public static com.liferay.portlet.journal.model.JournalArticle getJournalArticleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getJournalArticleByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the journal article matching the UUID and group.
 	*
 	* @param uuid the journal article's UUID
@@ -1624,6 +1597,36 @@ public class JournalArticleLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.journal.model.JournalArticle> getJournalArticles(
 		int start, int end) {
 		return getService().getJournalArticles(start, end);
+	}
+
+	/**
+	* Returns all the journal articles that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal articles
+	* @param companyId the primary key of the company
+	* @return all the matching journal articles, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.journal.model.JournalArticle> getJournalArticlesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getJournalArticlesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of journal articles that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal articles
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of journal articles
+	* @param end the upper bound of the range of journal articles (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching journal articles, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.journal.model.JournalArticle> getJournalArticlesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getJournalArticlesByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/service/JournalArticleLocalServiceWrapper.java
@@ -714,20 +714,6 @@ public class JournalArticleLocalServiceWrapper
 	}
 
 	/**
-	* Returns the journal article with the matching UUID and company.
-	*
-	* @param uuid the journal article's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal article, or <code>null</code> if a matching journal article could not be found
-	*/
-	@Override
-	public com.liferay.portlet.journal.model.JournalArticle fetchJournalArticleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _journalArticleLocalService.fetchJournalArticleByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the journal article matching the UUID and group.
 	*
 	* @param uuid the journal article's UUID
@@ -1660,22 +1646,6 @@ public class JournalArticleLocalServiceWrapper
 	}
 
 	/**
-	* Returns the journal article with the matching UUID and company.
-	*
-	* @param uuid the journal article's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal article
-	* @throws PortalException if a matching journal article could not be found
-	*/
-	@Override
-	public com.liferay.portlet.journal.model.JournalArticle getJournalArticleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _journalArticleLocalService.getJournalArticleByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the journal article matching the UUID and group.
 	*
 	* @param uuid the journal article's UUID
@@ -1706,6 +1676,38 @@ public class JournalArticleLocalServiceWrapper
 	public java.util.List<com.liferay.portlet.journal.model.JournalArticle> getJournalArticles(
 		int start, int end) {
 		return _journalArticleLocalService.getJournalArticles(start, end);
+	}
+
+	/**
+	* Returns all the journal articles that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal articles
+	* @param companyId the primary key of the company
+	* @return all the matching journal articles, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.journal.model.JournalArticle> getJournalArticlesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _journalArticleLocalService.getJournalArticlesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of journal articles that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal articles
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of journal articles
+	* @param end the upper bound of the range of journal articles (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching journal articles, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.journal.model.JournalArticle> getJournalArticlesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _journalArticleLocalService.getJournalArticlesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/journal/service/JournalFeedLocalService.java
+++ b/portal-service/src/com/liferay/portlet/journal/service/JournalFeedLocalService.java
@@ -210,17 +210,6 @@ public interface JournalFeedLocalService extends BaseLocalService,
 		long id);
 
 	/**
-	* Returns the journal feed with the matching UUID and company.
-	*
-	* @param uuid the journal feed's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal feed, or <code>null</code> if a matching journal feed could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.journal.model.JournalFeed fetchJournalFeedByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the journal feed matching the UUID and group.
 	*
 	* @param uuid the journal feed's UUID
@@ -280,19 +269,6 @@ public interface JournalFeedLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the journal feed with the matching UUID and company.
-	*
-	* @param uuid the journal feed's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal feed
-	* @throws PortalException if a matching journal feed could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.journal.model.JournalFeed getJournalFeedByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the journal feed matching the UUID and group.
 	*
 	* @param uuid the journal feed's UUID
@@ -319,6 +295,32 @@ public interface JournalFeedLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.journal.model.JournalFeed> getJournalFeeds(
 		int start, int end);
+
+	/**
+	* Returns all the journal feeds that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal feeds
+	* @param companyId the primary key of the company
+	* @return all the matching journal feeds, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.journal.model.JournalFeed> getJournalFeedsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of journal feeds that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal feeds
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of journal feeds
+	* @param end the upper bound of the range of journal feeds (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching journal feeds, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.journal.model.JournalFeed> getJournalFeedsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of journal feeds.

--- a/portal-service/src/com/liferay/portlet/journal/service/JournalFeedLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/journal/service/JournalFeedLocalServiceUtil.java
@@ -246,18 +246,6 @@ public class JournalFeedLocalServiceUtil {
 	}
 
 	/**
-	* Returns the journal feed with the matching UUID and company.
-	*
-	* @param uuid the journal feed's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal feed, or <code>null</code> if a matching journal feed could not be found
-	*/
-	public static com.liferay.portlet.journal.model.JournalFeed fetchJournalFeedByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchJournalFeedByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the journal feed matching the UUID and group.
 	*
 	* @param uuid the journal feed's UUID
@@ -329,20 +317,6 @@ public class JournalFeedLocalServiceUtil {
 	}
 
 	/**
-	* Returns the journal feed with the matching UUID and company.
-	*
-	* @param uuid the journal feed's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal feed
-	* @throws PortalException if a matching journal feed could not be found
-	*/
-	public static com.liferay.portlet.journal.model.JournalFeed getJournalFeedByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getJournalFeedByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the journal feed matching the UUID and group.
 	*
 	* @param uuid the journal feed's UUID
@@ -370,6 +344,36 @@ public class JournalFeedLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.journal.model.JournalFeed> getJournalFeeds(
 		int start, int end) {
 		return getService().getJournalFeeds(start, end);
+	}
+
+	/**
+	* Returns all the journal feeds that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal feeds
+	* @param companyId the primary key of the company
+	* @return all the matching journal feeds, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.journal.model.JournalFeed> getJournalFeedsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getJournalFeedsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of journal feeds that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal feeds
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of journal feeds
+	* @param end the upper bound of the range of journal feeds (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching journal feeds, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.journal.model.JournalFeed> getJournalFeedsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getJournalFeedsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/journal/service/JournalFeedLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/service/JournalFeedLocalServiceWrapper.java
@@ -261,20 +261,6 @@ public class JournalFeedLocalServiceWrapper implements JournalFeedLocalService,
 	}
 
 	/**
-	* Returns the journal feed with the matching UUID and company.
-	*
-	* @param uuid the journal feed's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal feed, or <code>null</code> if a matching journal feed could not be found
-	*/
-	@Override
-	public com.liferay.portlet.journal.model.JournalFeed fetchJournalFeedByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _journalFeedLocalService.fetchJournalFeedByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the journal feed matching the UUID and group.
 	*
 	* @param uuid the journal feed's UUID
@@ -358,22 +344,6 @@ public class JournalFeedLocalServiceWrapper implements JournalFeedLocalService,
 	}
 
 	/**
-	* Returns the journal feed with the matching UUID and company.
-	*
-	* @param uuid the journal feed's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal feed
-	* @throws PortalException if a matching journal feed could not be found
-	*/
-	@Override
-	public com.liferay.portlet.journal.model.JournalFeed getJournalFeedByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _journalFeedLocalService.getJournalFeedByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the journal feed matching the UUID and group.
 	*
 	* @param uuid the journal feed's UUID
@@ -404,6 +374,38 @@ public class JournalFeedLocalServiceWrapper implements JournalFeedLocalService,
 	public java.util.List<com.liferay.portlet.journal.model.JournalFeed> getJournalFeeds(
 		int start, int end) {
 		return _journalFeedLocalService.getJournalFeeds(start, end);
+	}
+
+	/**
+	* Returns all the journal feeds that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal feeds
+	* @param companyId the primary key of the company
+	* @return all the matching journal feeds, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.journal.model.JournalFeed> getJournalFeedsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _journalFeedLocalService.getJournalFeedsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of journal feeds that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal feeds
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of journal feeds
+	* @param end the upper bound of the range of journal feeds (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching journal feeds, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.journal.model.JournalFeed> getJournalFeedsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _journalFeedLocalService.getJournalFeedsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/journal/service/JournalFolderLocalService.java
+++ b/portal-service/src/com/liferay/portlet/journal/service/JournalFolderLocalService.java
@@ -234,17 +234,6 @@ public interface JournalFolderLocalService extends BaseLocalService,
 		long folderId);
 
 	/**
-	* Returns the journal folder with the matching UUID and company.
-	*
-	* @param uuid the journal folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.journal.model.JournalFolder fetchJournalFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the journal folder matching the UUID and group.
 	*
 	* @param uuid the journal folder's UUID
@@ -373,19 +362,6 @@ public interface JournalFolderLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the journal folder with the matching UUID and company.
-	*
-	* @param uuid the journal folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal folder
-	* @throws PortalException if a matching journal folder could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.journal.model.JournalFolder getJournalFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the journal folder matching the UUID and group.
 	*
 	* @param uuid the journal folder's UUID
@@ -412,6 +388,32 @@ public interface JournalFolderLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.journal.model.JournalFolder> getJournalFolders(
 		int start, int end);
+
+	/**
+	* Returns all the journal folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal folders
+	* @param companyId the primary key of the company
+	* @return all the matching journal folders, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.journal.model.JournalFolder> getJournalFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of journal folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal folders
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of journal folders
+	* @param end the upper bound of the range of journal folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching journal folders, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.journal.model.JournalFolder> getJournalFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of journal folders.

--- a/portal-service/src/com/liferay/portlet/journal/service/JournalFolderLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/journal/service/JournalFolderLocalServiceUtil.java
@@ -279,18 +279,6 @@ public class JournalFolderLocalServiceUtil {
 	}
 
 	/**
-	* Returns the journal folder with the matching UUID and company.
-	*
-	* @param uuid the journal folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
-	*/
-	public static com.liferay.portlet.journal.model.JournalFolder fetchJournalFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchJournalFolderByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the journal folder matching the UUID and group.
 	*
 	* @param uuid the journal folder's UUID
@@ -454,20 +442,6 @@ public class JournalFolderLocalServiceUtil {
 	}
 
 	/**
-	* Returns the journal folder with the matching UUID and company.
-	*
-	* @param uuid the journal folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal folder
-	* @throws PortalException if a matching journal folder could not be found
-	*/
-	public static com.liferay.portlet.journal.model.JournalFolder getJournalFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getJournalFolderByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the journal folder matching the UUID and group.
 	*
 	* @param uuid the journal folder's UUID
@@ -495,6 +469,36 @@ public class JournalFolderLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.journal.model.JournalFolder> getJournalFolders(
 		int start, int end) {
 		return getService().getJournalFolders(start, end);
+	}
+
+	/**
+	* Returns all the journal folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal folders
+	* @param companyId the primary key of the company
+	* @return all the matching journal folders, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.journal.model.JournalFolder> getJournalFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getJournalFoldersByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of journal folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal folders
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of journal folders
+	* @param end the upper bound of the range of journal folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching journal folders, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.journal.model.JournalFolder> getJournalFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getJournalFoldersByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/journal/service/JournalFolderLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/service/JournalFolderLocalServiceWrapper.java
@@ -310,20 +310,6 @@ public class JournalFolderLocalServiceWrapper
 	}
 
 	/**
-	* Returns the journal folder with the matching UUID and company.
-	*
-	* @param uuid the journal folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
-	*/
-	@Override
-	public com.liferay.portlet.journal.model.JournalFolder fetchJournalFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _journalFolderLocalService.fetchJournalFolderByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the journal folder matching the UUID and group.
 	*
 	* @param uuid the journal folder's UUID
@@ -522,22 +508,6 @@ public class JournalFolderLocalServiceWrapper
 	}
 
 	/**
-	* Returns the journal folder with the matching UUID and company.
-	*
-	* @param uuid the journal folder's UUID
-	* @param companyId the primary key of the company
-	* @return the matching journal folder
-	* @throws PortalException if a matching journal folder could not be found
-	*/
-	@Override
-	public com.liferay.portlet.journal.model.JournalFolder getJournalFolderByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _journalFolderLocalService.getJournalFolderByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the journal folder matching the UUID and group.
 	*
 	* @param uuid the journal folder's UUID
@@ -568,6 +538,38 @@ public class JournalFolderLocalServiceWrapper
 	public java.util.List<com.liferay.portlet.journal.model.JournalFolder> getJournalFolders(
 		int start, int end) {
 		return _journalFolderLocalService.getJournalFolders(start, end);
+	}
+
+	/**
+	* Returns all the journal folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal folders
+	* @param companyId the primary key of the company
+	* @return all the matching journal folders, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.journal.model.JournalFolder> getJournalFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _journalFolderLocalService.getJournalFoldersByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of journal folders that match the UUID and company.
+	*
+	* @param uuid the UUID of the journal folders
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of journal folders
+	* @param end the upper bound of the range of journal folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching journal folders, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.journal.model.JournalFolder> getJournalFoldersByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _journalFolderLocalService.getJournalFoldersByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBBanLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBBanLocalService.java
@@ -187,17 +187,6 @@ public interface MBBanLocalService extends BaseLocalService,
 	public com.liferay.portlet.messageboards.model.MBBan fetchMBBan(long banId);
 
 	/**
-	* Returns the message boards ban with the matching UUID and company.
-	*
-	* @param uuid the message boards ban's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards ban, or <code>null</code> if a matching message boards ban could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBBan fetchMBBanByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the message boards ban matching the UUID and group.
 	*
 	* @param uuid the message boards ban's UUID
@@ -241,19 +230,6 @@ public interface MBBanLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the message boards ban with the matching UUID and company.
-	*
-	* @param uuid the message boards ban's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards ban
-	* @throws PortalException if a matching message boards ban could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBBan getMBBanByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the message boards ban matching the UUID and group.
 	*
 	* @param uuid the message boards ban's UUID
@@ -280,6 +256,32 @@ public interface MBBanLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.messageboards.model.MBBan> getMBBans(
 		int start, int end);
+
+	/**
+	* Returns all the message boards bans that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards bans
+	* @param companyId the primary key of the company
+	* @return all the matching message boards bans, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBBan> getMBBansByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of message boards bans that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards bans
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards bans
+	* @param end the upper bound of the range of message boards bans (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards bans, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBBan> getMBBansByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of message boards bans.

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBBanLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBBanLocalServiceUtil.java
@@ -217,18 +217,6 @@ public class MBBanLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards ban with the matching UUID and company.
-	*
-	* @param uuid the message boards ban's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards ban, or <code>null</code> if a matching message boards ban could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBBan fetchMBBanByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMBBanByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards ban matching the UUID and group.
 	*
 	* @param uuid the message boards ban's UUID
@@ -280,20 +268,6 @@ public class MBBanLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards ban with the matching UUID and company.
-	*
-	* @param uuid the message boards ban's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards ban
-	* @throws PortalException if a matching message boards ban could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBBan getMBBanByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMBBanByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards ban matching the UUID and group.
 	*
 	* @param uuid the message boards ban's UUID
@@ -321,6 +295,36 @@ public class MBBanLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.messageboards.model.MBBan> getMBBans(
 		int start, int end) {
 		return getService().getMBBans(start, end);
+	}
+
+	/**
+	* Returns all the message boards bans that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards bans
+	* @param companyId the primary key of the company
+	* @return all the matching message boards bans, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBBan> getMBBansByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMBBansByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of message boards bans that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards bans
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards bans
+	* @param end the upper bound of the range of message boards bans (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards bans, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBBan> getMBBansByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMBBansByUuidAndCompanyId(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBBanLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBBanLocalServiceWrapper.java
@@ -225,19 +225,6 @@ public class MBBanLocalServiceWrapper implements MBBanLocalService,
 	}
 
 	/**
-	* Returns the message boards ban with the matching UUID and company.
-	*
-	* @param uuid the message boards ban's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards ban, or <code>null</code> if a matching message boards ban could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBBan fetchMBBanByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mbBanLocalService.fetchMBBanByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards ban matching the UUID and group.
 	*
 	* @param uuid the message boards ban's UUID
@@ -296,21 +283,6 @@ public class MBBanLocalServiceWrapper implements MBBanLocalService,
 	}
 
 	/**
-	* Returns the message boards ban with the matching UUID and company.
-	*
-	* @param uuid the message boards ban's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards ban
-	* @throws PortalException if a matching message boards ban could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBBan getMBBanByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mbBanLocalService.getMBBanByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards ban matching the UUID and group.
 	*
 	* @param uuid the message boards ban's UUID
@@ -340,6 +312,37 @@ public class MBBanLocalServiceWrapper implements MBBanLocalService,
 	public java.util.List<com.liferay.portlet.messageboards.model.MBBan> getMBBans(
 		int start, int end) {
 		return _mbBanLocalService.getMBBans(start, end);
+	}
+
+	/**
+	* Returns all the message boards bans that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards bans
+	* @param companyId the primary key of the company
+	* @return all the matching message boards bans, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBBan> getMBBansByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mbBanLocalService.getMBBansByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of message boards bans that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards bans
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards bans
+	* @param end the upper bound of the range of message boards bans (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards bans, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBBan> getMBBansByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mbBanLocalService.getMBBansByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalService.java
@@ -222,17 +222,6 @@ public interface MBCategoryLocalService extends BaseLocalService,
 		long categoryId);
 
 	/**
-	* Returns the message boards category with the matching UUID and company.
-	*
-	* @param uuid the message boards category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBCategory fetchMBCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the message boards category matching the UUID and group.
 	*
 	* @param uuid the message boards category's UUID
@@ -351,6 +340,32 @@ public interface MBCategoryLocalService extends BaseLocalService,
 		int start, int end);
 
 	/**
+	* Returns all the message boards categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards categories
+	* @param companyId the primary key of the company
+	* @return all the matching message boards categories, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBCategory> getMBCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of message boards categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards categories
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards categories
+	* @param end the upper bound of the range of message boards categories (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards categories, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBCategory> getMBCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
+
+	/**
 	* Returns the number of message boards categories.
 	*
 	* @return the number of message boards categories
@@ -368,19 +383,6 @@ public interface MBCategoryLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.messageboards.model.MBCategory getMBCategory(
 		long categoryId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
-	* Returns the message boards category with the matching UUID and company.
-	*
-	* @param uuid the message boards category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards category
-	* @throws PortalException if a matching message boards category could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBCategory getMBCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalServiceUtil.java
@@ -265,18 +265,6 @@ public class MBCategoryLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards category with the matching UUID and company.
-	*
-	* @param uuid the message boards category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBCategory fetchMBCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMBCategoryByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards category matching the UUID and group.
 	*
 	* @param uuid the message boards category's UUID
@@ -432,6 +420,36 @@ public class MBCategoryLocalServiceUtil {
 	}
 
 	/**
+	* Returns all the message boards categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards categories
+	* @param companyId the primary key of the company
+	* @return all the matching message boards categories, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBCategory> getMBCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMBCategoriesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of message boards categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards categories
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards categories
+	* @param end the upper bound of the range of message boards categories (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards categories, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBCategory> getMBCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMBCategoriesByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of message boards categories.
 	*
 	* @return the number of message boards categories
@@ -451,20 +469,6 @@ public class MBCategoryLocalServiceUtil {
 		long categoryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().getMBCategory(categoryId);
-	}
-
-	/**
-	* Returns the message boards category with the matching UUID and company.
-	*
-	* @param uuid the message boards category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards category
-	* @throws PortalException if a matching message boards category could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBCategory getMBCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMBCategoryByUuidAndCompanyId(uuid, companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalServiceWrapper.java
@@ -278,20 +278,6 @@ public class MBCategoryLocalServiceWrapper implements MBCategoryLocalService,
 	}
 
 	/**
-	* Returns the message boards category with the matching UUID and company.
-	*
-	* @param uuid the message boards category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBCategory fetchMBCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mbCategoryLocalService.fetchMBCategoryByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message boards category matching the UUID and group.
 	*
 	* @param uuid the message boards category's UUID
@@ -476,6 +462,38 @@ public class MBCategoryLocalServiceWrapper implements MBCategoryLocalService,
 	}
 
 	/**
+	* Returns all the message boards categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards categories
+	* @param companyId the primary key of the company
+	* @return all the matching message boards categories, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBCategory> getMBCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mbCategoryLocalService.getMBCategoriesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of message boards categories that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards categories
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards categories
+	* @param end the upper bound of the range of message boards categories (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards categories, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBCategory> getMBCategoriesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mbCategoryLocalService.getMBCategoriesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
+	}
+
+	/**
 	* Returns the number of message boards categories.
 	*
 	* @return the number of message boards categories
@@ -497,22 +515,6 @@ public class MBCategoryLocalServiceWrapper implements MBCategoryLocalService,
 		long categoryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _mbCategoryLocalService.getMBCategory(categoryId);
-	}
-
-	/**
-	* Returns the message boards category with the matching UUID and company.
-	*
-	* @param uuid the message boards category's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards category
-	* @throws PortalException if a matching message boards category could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBCategory getMBCategoryByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mbCategoryLocalService.getMBCategoryByUuidAndCompanyId(uuid,
-			companyId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBDiscussionLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBDiscussionLocalService.java
@@ -190,17 +190,6 @@ public interface MBDiscussionLocalService extends BaseLocalService,
 		long discussionId);
 
 	/**
-	* Returns the message boards discussion with the matching UUID and company.
-	*
-	* @param uuid the message boards discussion's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards discussion, or <code>null</code> if a matching message boards discussion could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBDiscussion fetchMBDiscussionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the message boards discussion matching the UUID and group.
 	*
 	* @param uuid the message boards discussion's UUID
@@ -248,19 +237,6 @@ public interface MBDiscussionLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the message boards discussion with the matching UUID and company.
-	*
-	* @param uuid the message boards discussion's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards discussion
-	* @throws PortalException if a matching message boards discussion could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBDiscussion getMBDiscussionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the message boards discussion matching the UUID and group.
 	*
 	* @param uuid the message boards discussion's UUID
@@ -287,6 +263,32 @@ public interface MBDiscussionLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.messageboards.model.MBDiscussion> getMBDiscussions(
 		int start, int end);
+
+	/**
+	* Returns all the message boards discussions that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards discussions
+	* @param companyId the primary key of the company
+	* @return all the matching message boards discussions, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBDiscussion> getMBDiscussionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of message boards discussions that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards discussions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards discussions
+	* @param end the upper bound of the range of message boards discussions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards discussions, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBDiscussion> getMBDiscussionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of message boards discussions.

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBDiscussionLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBDiscussionLocalServiceUtil.java
@@ -213,18 +213,6 @@ public class MBDiscussionLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards discussion with the matching UUID and company.
-	*
-	* @param uuid the message boards discussion's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards discussion, or <code>null</code> if a matching message boards discussion could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBDiscussion fetchMBDiscussionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMBDiscussionByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards discussion matching the UUID and group.
 	*
 	* @param uuid the message boards discussion's UUID
@@ -280,20 +268,6 @@ public class MBDiscussionLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards discussion with the matching UUID and company.
-	*
-	* @param uuid the message boards discussion's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards discussion
-	* @throws PortalException if a matching message boards discussion could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBDiscussion getMBDiscussionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMBDiscussionByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards discussion matching the UUID and group.
 	*
 	* @param uuid the message boards discussion's UUID
@@ -321,6 +295,36 @@ public class MBDiscussionLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.messageboards.model.MBDiscussion> getMBDiscussions(
 		int start, int end) {
 		return getService().getMBDiscussions(start, end);
+	}
+
+	/**
+	* Returns all the message boards discussions that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards discussions
+	* @param companyId the primary key of the company
+	* @return all the matching message boards discussions, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBDiscussion> getMBDiscussionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMBDiscussionsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of message boards discussions that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards discussions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards discussions
+	* @param end the upper bound of the range of message boards discussions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards discussions, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBDiscussion> getMBDiscussionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMBDiscussionsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBDiscussionLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBDiscussionLocalServiceWrapper.java
@@ -220,20 +220,6 @@ public class MBDiscussionLocalServiceWrapper implements MBDiscussionLocalService
 	}
 
 	/**
-	* Returns the message boards discussion with the matching UUID and company.
-	*
-	* @param uuid the message boards discussion's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards discussion, or <code>null</code> if a matching message boards discussion could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBDiscussion fetchMBDiscussionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mbDiscussionLocalService.fetchMBDiscussionByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message boards discussion matching the UUID and group.
 	*
 	* @param uuid the message boards discussion's UUID
@@ -297,22 +283,6 @@ public class MBDiscussionLocalServiceWrapper implements MBDiscussionLocalService
 	}
 
 	/**
-	* Returns the message boards discussion with the matching UUID and company.
-	*
-	* @param uuid the message boards discussion's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards discussion
-	* @throws PortalException if a matching message boards discussion could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBDiscussion getMBDiscussionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mbDiscussionLocalService.getMBDiscussionByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message boards discussion matching the UUID and group.
 	*
 	* @param uuid the message boards discussion's UUID
@@ -343,6 +313,38 @@ public class MBDiscussionLocalServiceWrapper implements MBDiscussionLocalService
 	public java.util.List<com.liferay.portlet.messageboards.model.MBDiscussion> getMBDiscussions(
 		int start, int end) {
 		return _mbDiscussionLocalService.getMBDiscussions(start, end);
+	}
+
+	/**
+	* Returns all the message boards discussions that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards discussions
+	* @param companyId the primary key of the company
+	* @return all the matching message boards discussions, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBDiscussion> getMBDiscussionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mbDiscussionLocalService.getMBDiscussionsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of message boards discussions that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards discussions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards discussions
+	* @param end the upper bound of the range of message boards discussions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards discussions, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBDiscussion> getMBDiscussionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mbDiscussionLocalService.getMBDiscussionsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMailingListLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMailingListLocalService.java
@@ -189,17 +189,6 @@ public interface MBMailingListLocalService extends BaseLocalService,
 		long mailingListId);
 
 	/**
-	* Returns the message boards mailing list with the matching UUID and company.
-	*
-	* @param uuid the message boards mailing list's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards mailing list, or <code>null</code> if a matching message boards mailing list could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBMailingList fetchMBMailingListByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the message boards mailing list matching the UUID and group.
 	*
 	* @param uuid the message boards mailing list's UUID
@@ -242,19 +231,6 @@ public interface MBMailingListLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the message boards mailing list with the matching UUID and company.
-	*
-	* @param uuid the message boards mailing list's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards mailing list
-	* @throws PortalException if a matching message boards mailing list could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBMailingList getMBMailingListByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the message boards mailing list matching the UUID and group.
 	*
 	* @param uuid the message boards mailing list's UUID
@@ -281,6 +257,32 @@ public interface MBMailingListLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.messageboards.model.MBMailingList> getMBMailingLists(
 		int start, int end);
+
+	/**
+	* Returns all the message boards mailing lists that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards mailing lists
+	* @param companyId the primary key of the company
+	* @return all the matching message boards mailing lists, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBMailingList> getMBMailingListsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of message boards mailing lists that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards mailing lists
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards mailing lists
+	* @param end the upper bound of the range of message boards mailing lists (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards mailing lists, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBMailingList> getMBMailingListsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of message boards mailing lists.

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMailingListLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMailingListLocalServiceUtil.java
@@ -215,18 +215,6 @@ public class MBMailingListLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards mailing list with the matching UUID and company.
-	*
-	* @param uuid the message boards mailing list's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards mailing list, or <code>null</code> if a matching message boards mailing list could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBMailingList fetchMBMailingListByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMBMailingListByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards mailing list matching the UUID and group.
 	*
 	* @param uuid the message boards mailing list's UUID
@@ -276,20 +264,6 @@ public class MBMailingListLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards mailing list with the matching UUID and company.
-	*
-	* @param uuid the message boards mailing list's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards mailing list
-	* @throws PortalException if a matching message boards mailing list could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBMailingList getMBMailingListByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMBMailingListByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards mailing list matching the UUID and group.
 	*
 	* @param uuid the message boards mailing list's UUID
@@ -317,6 +291,36 @@ public class MBMailingListLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.messageboards.model.MBMailingList> getMBMailingLists(
 		int start, int end) {
 		return getService().getMBMailingLists(start, end);
+	}
+
+	/**
+	* Returns all the message boards mailing lists that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards mailing lists
+	* @param companyId the primary key of the company
+	* @return all the matching message boards mailing lists, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBMailingList> getMBMailingListsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMBMailingListsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of message boards mailing lists that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards mailing lists
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards mailing lists
+	* @param end the upper bound of the range of message boards mailing lists (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards mailing lists, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBMailingList> getMBMailingListsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMBMailingListsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMailingListLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMailingListLocalServiceWrapper.java
@@ -224,20 +224,6 @@ public class MBMailingListLocalServiceWrapper
 	}
 
 	/**
-	* Returns the message boards mailing list with the matching UUID and company.
-	*
-	* @param uuid the message boards mailing list's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards mailing list, or <code>null</code> if a matching message boards mailing list could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBMailingList fetchMBMailingListByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mbMailingListLocalService.fetchMBMailingListByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message boards mailing list matching the UUID and group.
 	*
 	* @param uuid the message boards mailing list's UUID
@@ -295,22 +281,6 @@ public class MBMailingListLocalServiceWrapper
 	}
 
 	/**
-	* Returns the message boards mailing list with the matching UUID and company.
-	*
-	* @param uuid the message boards mailing list's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards mailing list
-	* @throws PortalException if a matching message boards mailing list could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBMailingList getMBMailingListByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mbMailingListLocalService.getMBMailingListByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message boards mailing list matching the UUID and group.
 	*
 	* @param uuid the message boards mailing list's UUID
@@ -341,6 +311,38 @@ public class MBMailingListLocalServiceWrapper
 	public java.util.List<com.liferay.portlet.messageboards.model.MBMailingList> getMBMailingLists(
 		int start, int end) {
 		return _mbMailingListLocalService.getMBMailingLists(start, end);
+	}
+
+	/**
+	* Returns all the message boards mailing lists that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards mailing lists
+	* @param companyId the primary key of the company
+	* @return all the matching message boards mailing lists, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBMailingList> getMBMailingListsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mbMailingListLocalService.getMBMailingListsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of message boards mailing lists that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards mailing lists
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards mailing lists
+	* @param end the upper bound of the range of message boards mailing lists (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards mailing lists, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBMailingList> getMBMailingListsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mbMailingListLocalService.getMBMailingListsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalService.java
@@ -259,17 +259,6 @@ public interface MBMessageLocalService extends BaseLocalService,
 		long messageId);
 
 	/**
-	* Returns the message-boards message with the matching UUID and company.
-	*
-	* @param uuid the message-boards message's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBMessage fetchMBMessageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the message-boards message matching the UUID and group.
 	*
 	* @param uuid the message-boards message's UUID
@@ -379,19 +368,6 @@ public interface MBMessageLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the message-boards message with the matching UUID and company.
-	*
-	* @param uuid the message-boards message's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message-boards message
-	* @throws PortalException if a matching message-boards message could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBMessage getMBMessageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the message-boards message matching the UUID and group.
 	*
 	* @param uuid the message-boards message's UUID
@@ -418,6 +394,32 @@ public interface MBMessageLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.messageboards.model.MBMessage> getMBMessages(
 		int start, int end);
+
+	/**
+	* Returns all the message-boards messages that match the UUID and company.
+	*
+	* @param uuid the UUID of the message-boards messages
+	* @param companyId the primary key of the company
+	* @return all the matching message-boards messages, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBMessage> getMBMessagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of message-boards messages that match the UUID and company.
+	*
+	* @param uuid the UUID of the message-boards messages
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message-boards messages
+	* @param end the upper bound of the range of message-boards messages (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message-boards messages, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBMessage> getMBMessagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of message-boards messages.

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceUtil.java
@@ -319,18 +319,6 @@ public class MBMessageLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message-boards message with the matching UUID and company.
-	*
-	* @param uuid the message-boards message's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBMessage fetchMBMessageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMBMessageByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message-boards message matching the UUID and group.
 	*
 	* @param uuid the message-boards message's UUID
@@ -475,20 +463,6 @@ public class MBMessageLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message-boards message with the matching UUID and company.
-	*
-	* @param uuid the message-boards message's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message-boards message
-	* @throws PortalException if a matching message-boards message could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBMessage getMBMessageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMBMessageByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message-boards message matching the UUID and group.
 	*
 	* @param uuid the message-boards message's UUID
@@ -516,6 +490,36 @@ public class MBMessageLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.messageboards.model.MBMessage> getMBMessages(
 		int start, int end) {
 		return getService().getMBMessages(start, end);
+	}
+
+	/**
+	* Returns all the message-boards messages that match the UUID and company.
+	*
+	* @param uuid the UUID of the message-boards messages
+	* @param companyId the primary key of the company
+	* @return all the matching message-boards messages, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBMessage> getMBMessagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMBMessagesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of message-boards messages that match the UUID and company.
+	*
+	* @param uuid the UUID of the message-boards messages
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message-boards messages
+	* @param end the upper bound of the range of message-boards messages (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message-boards messages, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBMessage> getMBMessagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMBMessagesByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceWrapper.java
@@ -333,20 +333,6 @@ public class MBMessageLocalServiceWrapper implements MBMessageLocalService,
 	}
 
 	/**
-	* Returns the message-boards message with the matching UUID and company.
-	*
-	* @param uuid the message-boards message's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBMessage fetchMBMessageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mbMessageLocalService.fetchMBMessageByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message-boards message matching the UUID and group.
 	*
 	* @param uuid the message-boards message's UUID
@@ -516,22 +502,6 @@ public class MBMessageLocalServiceWrapper implements MBMessageLocalService,
 	}
 
 	/**
-	* Returns the message-boards message with the matching UUID and company.
-	*
-	* @param uuid the message-boards message's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message-boards message
-	* @throws PortalException if a matching message-boards message could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBMessage getMBMessageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mbMessageLocalService.getMBMessageByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message-boards message matching the UUID and group.
 	*
 	* @param uuid the message-boards message's UUID
@@ -561,6 +531,38 @@ public class MBMessageLocalServiceWrapper implements MBMessageLocalService,
 	public java.util.List<com.liferay.portlet.messageboards.model.MBMessage> getMBMessages(
 		int start, int end) {
 		return _mbMessageLocalService.getMBMessages(start, end);
+	}
+
+	/**
+	* Returns all the message-boards messages that match the UUID and company.
+	*
+	* @param uuid the UUID of the message-boards messages
+	* @param companyId the primary key of the company
+	* @return all the matching message-boards messages, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBMessage> getMBMessagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mbMessageLocalService.getMBMessagesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of message-boards messages that match the UUID and company.
+	*
+	* @param uuid the UUID of the message-boards messages
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message-boards messages
+	* @param end the upper bound of the range of message-boards messages (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message-boards messages, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBMessage> getMBMessagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mbMessageLocalService.getMBMessagesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadFlagLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadFlagLocalService.java
@@ -184,17 +184,6 @@ public interface MBThreadFlagLocalService extends BaseLocalService,
 		long threadFlagId);
 
 	/**
-	* Returns the message boards thread flag with the matching UUID and company.
-	*
-	* @param uuid the message boards thread flag's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread flag, or <code>null</code> if a matching message boards thread flag could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBThreadFlag fetchMBThreadFlagByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the message boards thread flag matching the UUID and group.
 	*
 	* @param uuid the message boards thread flag's UUID
@@ -232,19 +221,6 @@ public interface MBThreadFlagLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the message boards thread flag with the matching UUID and company.
-	*
-	* @param uuid the message boards thread flag's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread flag
-	* @throws PortalException if a matching message boards thread flag could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBThreadFlag getMBThreadFlagByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the message boards thread flag matching the UUID and group.
 	*
 	* @param uuid the message boards thread flag's UUID
@@ -271,6 +247,32 @@ public interface MBThreadFlagLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.messageboards.model.MBThreadFlag> getMBThreadFlags(
 		int start, int end);
+
+	/**
+	* Returns all the message boards thread flags that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards thread flags
+	* @param companyId the primary key of the company
+	* @return all the matching message boards thread flags, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBThreadFlag> getMBThreadFlagsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of message boards thread flags that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards thread flags
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards thread flags
+	* @param end the upper bound of the range of message boards thread flags (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards thread flags, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBThreadFlag> getMBThreadFlagsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of message boards thread flags.

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadFlagLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadFlagLocalServiceUtil.java
@@ -205,18 +205,6 @@ public class MBThreadFlagLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards thread flag with the matching UUID and company.
-	*
-	* @param uuid the message boards thread flag's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread flag, or <code>null</code> if a matching message boards thread flag could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBThreadFlag fetchMBThreadFlagByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMBThreadFlagByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards thread flag matching the UUID and group.
 	*
 	* @param uuid the message boards thread flag's UUID
@@ -260,20 +248,6 @@ public class MBThreadFlagLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards thread flag with the matching UUID and company.
-	*
-	* @param uuid the message boards thread flag's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread flag
-	* @throws PortalException if a matching message boards thread flag could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBThreadFlag getMBThreadFlagByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMBThreadFlagByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards thread flag matching the UUID and group.
 	*
 	* @param uuid the message boards thread flag's UUID
@@ -301,6 +275,36 @@ public class MBThreadFlagLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.messageboards.model.MBThreadFlag> getMBThreadFlags(
 		int start, int end) {
 		return getService().getMBThreadFlags(start, end);
+	}
+
+	/**
+	* Returns all the message boards thread flags that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards thread flags
+	* @param companyId the primary key of the company
+	* @return all the matching message boards thread flags, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBThreadFlag> getMBThreadFlagsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMBThreadFlagsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of message boards thread flags that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards thread flags
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards thread flags
+	* @param end the upper bound of the range of message boards thread flags (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards thread flags, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBThreadFlag> getMBThreadFlagsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMBThreadFlagsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadFlagLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadFlagLocalServiceWrapper.java
@@ -215,20 +215,6 @@ public class MBThreadFlagLocalServiceWrapper implements MBThreadFlagLocalService
 	}
 
 	/**
-	* Returns the message boards thread flag with the matching UUID and company.
-	*
-	* @param uuid the message boards thread flag's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread flag, or <code>null</code> if a matching message boards thread flag could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBThreadFlag fetchMBThreadFlagByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mbThreadFlagLocalService.fetchMBThreadFlagByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message boards thread flag matching the UUID and group.
 	*
 	* @param uuid the message boards thread flag's UUID
@@ -278,22 +264,6 @@ public class MBThreadFlagLocalServiceWrapper implements MBThreadFlagLocalService
 	}
 
 	/**
-	* Returns the message boards thread flag with the matching UUID and company.
-	*
-	* @param uuid the message boards thread flag's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread flag
-	* @throws PortalException if a matching message boards thread flag could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBThreadFlag getMBThreadFlagByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mbThreadFlagLocalService.getMBThreadFlagByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message boards thread flag matching the UUID and group.
 	*
 	* @param uuid the message boards thread flag's UUID
@@ -324,6 +294,38 @@ public class MBThreadFlagLocalServiceWrapper implements MBThreadFlagLocalService
 	public java.util.List<com.liferay.portlet.messageboards.model.MBThreadFlag> getMBThreadFlags(
 		int start, int end) {
 		return _mbThreadFlagLocalService.getMBThreadFlags(start, end);
+	}
+
+	/**
+	* Returns all the message boards thread flags that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards thread flags
+	* @param companyId the primary key of the company
+	* @return all the matching message boards thread flags, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBThreadFlag> getMBThreadFlagsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mbThreadFlagLocalService.getMBThreadFlagsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of message boards thread flags that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards thread flags
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards thread flags
+	* @param end the upper bound of the range of message boards thread flags (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards thread flags, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBThreadFlag> getMBThreadFlagsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mbThreadFlagLocalService.getMBThreadFlagsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadLocalService.java
@@ -189,17 +189,6 @@ public interface MBThreadLocalService extends BaseLocalService,
 		long threadId);
 
 	/**
-	* Returns the message boards thread with the matching UUID and company.
-	*
-	* @param uuid the message boards thread's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread, or <code>null</code> if a matching message boards thread could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBThread fetchMBThreadByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the message boards thread matching the UUID and group.
 	*
 	* @param uuid the message boards thread's UUID
@@ -355,19 +344,6 @@ public interface MBThreadLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the message boards thread with the matching UUID and company.
-	*
-	* @param uuid the message boards thread's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread
-	* @throws PortalException if a matching message boards thread could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.messageboards.model.MBThread getMBThreadByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the message boards thread matching the UUID and group.
 	*
 	* @param uuid the message boards thread's UUID
@@ -394,6 +370,32 @@ public interface MBThreadLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.messageboards.model.MBThread> getMBThreads(
 		int start, int end);
+
+	/**
+	* Returns all the message boards threads that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards threads
+	* @param companyId the primary key of the company
+	* @return all the matching message boards threads, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBThread> getMBThreadsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of message boards threads that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards threads
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards threads
+	* @param end the upper bound of the range of message boards threads (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards threads, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.messageboards.model.MBThread> getMBThreadsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of message boards threads.

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadLocalServiceUtil.java
@@ -210,18 +210,6 @@ public class MBThreadLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards thread with the matching UUID and company.
-	*
-	* @param uuid the message boards thread's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread, or <code>null</code> if a matching message boards thread could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBThread fetchMBThreadByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMBThreadByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards thread matching the UUID and group.
 	*
 	* @param uuid the message boards thread's UUID
@@ -417,20 +405,6 @@ public class MBThreadLocalServiceUtil {
 	}
 
 	/**
-	* Returns the message boards thread with the matching UUID and company.
-	*
-	* @param uuid the message boards thread's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread
-	* @throws PortalException if a matching message boards thread could not be found
-	*/
-	public static com.liferay.portlet.messageboards.model.MBThread getMBThreadByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMBThreadByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the message boards thread matching the UUID and group.
 	*
 	* @param uuid the message boards thread's UUID
@@ -458,6 +432,36 @@ public class MBThreadLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.messageboards.model.MBThread> getMBThreads(
 		int start, int end) {
 		return getService().getMBThreads(start, end);
+	}
+
+	/**
+	* Returns all the message boards threads that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards threads
+	* @param companyId the primary key of the company
+	* @return all the matching message boards threads, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBThread> getMBThreadsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMBThreadsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of message boards threads that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards threads
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards threads
+	* @param end the upper bound of the range of message boards threads (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards threads, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.messageboards.model.MBThread> getMBThreadsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMBThreadsByUuidAndCompanyId(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBThreadLocalServiceWrapper.java
@@ -221,20 +221,6 @@ public class MBThreadLocalServiceWrapper implements MBThreadLocalService,
 	}
 
 	/**
-	* Returns the message boards thread with the matching UUID and company.
-	*
-	* @param uuid the message boards thread's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread, or <code>null</code> if a matching message boards thread could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBThread fetchMBThreadByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mbThreadLocalService.fetchMBThreadByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message boards thread matching the UUID and group.
 	*
 	* @param uuid the message boards thread's UUID
@@ -451,22 +437,6 @@ public class MBThreadLocalServiceWrapper implements MBThreadLocalService,
 	}
 
 	/**
-	* Returns the message boards thread with the matching UUID and company.
-	*
-	* @param uuid the message boards thread's UUID
-	* @param companyId the primary key of the company
-	* @return the matching message boards thread
-	* @throws PortalException if a matching message boards thread could not be found
-	*/
-	@Override
-	public com.liferay.portlet.messageboards.model.MBThread getMBThreadByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mbThreadLocalService.getMBThreadByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the message boards thread matching the UUID and group.
 	*
 	* @param uuid the message boards thread's UUID
@@ -496,6 +466,38 @@ public class MBThreadLocalServiceWrapper implements MBThreadLocalService,
 	public java.util.List<com.liferay.portlet.messageboards.model.MBThread> getMBThreads(
 		int start, int end) {
 		return _mbThreadLocalService.getMBThreads(start, end);
+	}
+
+	/**
+	* Returns all the message boards threads that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards threads
+	* @param companyId the primary key of the company
+	* @return all the matching message boards threads, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBThread> getMBThreadsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mbThreadLocalService.getMBThreadsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of message boards threads that match the UUID and company.
+	*
+	* @param uuid the UUID of the message boards threads
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of message boards threads
+	* @param end the upper bound of the range of message boards threads (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching message boards threads, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.messageboards.model.MBThread> getMBThreadsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mbThreadLocalService.getMBThreadsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRActionLocalService.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRActionLocalService.java
@@ -196,17 +196,6 @@ public interface MDRActionLocalService extends BaseLocalService,
 		long actionId);
 
 	/**
-	* Returns the m d r action with the matching UUID and company.
-	*
-	* @param uuid the m d r action's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r action, or <code>null</code> if a matching m d r action could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.mobiledevicerules.model.MDRAction fetchMDRActionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the m d r action matching the UUID and group.
 	*
 	* @param uuid the m d r action's UUID
@@ -260,19 +249,6 @@ public interface MDRActionLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the m d r action with the matching UUID and company.
-	*
-	* @param uuid the m d r action's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r action
-	* @throws PortalException if a matching m d r action could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.mobiledevicerules.model.MDRAction getMDRActionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the m d r action matching the UUID and group.
 	*
 	* @param uuid the m d r action's UUID
@@ -299,6 +275,32 @@ public interface MDRActionLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRAction> getMDRActions(
 		int start, int end);
+
+	/**
+	* Returns all the m d r actions that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r actions
+	* @param companyId the primary key of the company
+	* @return all the matching m d r actions, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRAction> getMDRActionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of m d r actions that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r actions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r actions
+	* @param end the upper bound of the range of m d r actions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r actions, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRAction> getMDRActionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of m d r actions.

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRActionLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRActionLocalServiceUtil.java
@@ -222,18 +222,6 @@ public class MDRActionLocalServiceUtil {
 	}
 
 	/**
-	* Returns the m d r action with the matching UUID and company.
-	*
-	* @param uuid the m d r action's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r action, or <code>null</code> if a matching m d r action could not be found
-	*/
-	public static com.liferay.portlet.mobiledevicerules.model.MDRAction fetchMDRActionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMDRActionByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the m d r action matching the UUID and group.
 	*
 	* @param uuid the m d r action's UUID
@@ -297,20 +285,6 @@ public class MDRActionLocalServiceUtil {
 	}
 
 	/**
-	* Returns the m d r action with the matching UUID and company.
-	*
-	* @param uuid the m d r action's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r action
-	* @throws PortalException if a matching m d r action could not be found
-	*/
-	public static com.liferay.portlet.mobiledevicerules.model.MDRAction getMDRActionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMDRActionByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the m d r action matching the UUID and group.
 	*
 	* @param uuid the m d r action's UUID
@@ -338,6 +312,36 @@ public class MDRActionLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRAction> getMDRActions(
 		int start, int end) {
 		return getService().getMDRActions(start, end);
+	}
+
+	/**
+	* Returns all the m d r actions that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r actions
+	* @param companyId the primary key of the company
+	* @return all the matching m d r actions, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRAction> getMDRActionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMDRActionsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of m d r actions that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r actions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r actions
+	* @param end the upper bound of the range of m d r actions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r actions, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRAction> getMDRActionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMDRActionsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRActionLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRActionLocalServiceWrapper.java
@@ -231,20 +231,6 @@ public class MDRActionLocalServiceWrapper implements MDRActionLocalService,
 	}
 
 	/**
-	* Returns the m d r action with the matching UUID and company.
-	*
-	* @param uuid the m d r action's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r action, or <code>null</code> if a matching m d r action could not be found
-	*/
-	@Override
-	public com.liferay.portlet.mobiledevicerules.model.MDRAction fetchMDRActionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mdrActionLocalService.fetchMDRActionByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the m d r action matching the UUID and group.
 	*
 	* @param uuid the m d r action's UUID
@@ -318,22 +304,6 @@ public class MDRActionLocalServiceWrapper implements MDRActionLocalService,
 	}
 
 	/**
-	* Returns the m d r action with the matching UUID and company.
-	*
-	* @param uuid the m d r action's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r action
-	* @throws PortalException if a matching m d r action could not be found
-	*/
-	@Override
-	public com.liferay.portlet.mobiledevicerules.model.MDRAction getMDRActionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mdrActionLocalService.getMDRActionByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the m d r action matching the UUID and group.
 	*
 	* @param uuid the m d r action's UUID
@@ -363,6 +333,38 @@ public class MDRActionLocalServiceWrapper implements MDRActionLocalService,
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRAction> getMDRActions(
 		int start, int end) {
 		return _mdrActionLocalService.getMDRActions(start, end);
+	}
+
+	/**
+	* Returns all the m d r actions that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r actions
+	* @param companyId the primary key of the company
+	* @return all the matching m d r actions, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRAction> getMDRActionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mdrActionLocalService.getMDRActionsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of m d r actions that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r actions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r actions
+	* @param end the upper bound of the range of m d r actions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r actions, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRAction> getMDRActionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mdrActionLocalService.getMDRActionsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupInstanceLocalService.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupInstanceLocalService.java
@@ -190,17 +190,6 @@ public interface MDRRuleGroupInstanceLocalService extends BaseLocalService,
 		long ruleGroupInstanceId);
 
 	/**
-	* Returns the m d r rule group instance with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group instance's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group instance, or <code>null</code> if a matching m d r rule group instance could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance fetchMDRRuleGroupInstanceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the m d r rule group instance matching the UUID and group.
 	*
 	* @param uuid the m d r rule group instance's UUID
@@ -246,19 +235,6 @@ public interface MDRRuleGroupInstanceLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the m d r rule group instance with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group instance's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group instance
-	* @throws PortalException if a matching m d r rule group instance could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance getMDRRuleGroupInstanceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the m d r rule group instance matching the UUID and group.
 	*
 	* @param uuid the m d r rule group instance's UUID
@@ -285,6 +261,32 @@ public interface MDRRuleGroupInstanceLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance> getMDRRuleGroupInstances(
 		int start, int end);
+
+	/**
+	* Returns all the m d r rule group instances that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule group instances
+	* @param companyId the primary key of the company
+	* @return all the matching m d r rule group instances, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance> getMDRRuleGroupInstancesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of m d r rule group instances that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule group instances
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r rule group instances
+	* @param end the upper bound of the range of m d r rule group instances (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r rule group instances, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance> getMDRRuleGroupInstancesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of m d r rule group instances.

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupInstanceLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupInstanceLocalServiceUtil.java
@@ -217,19 +217,6 @@ public class MDRRuleGroupInstanceLocalServiceUtil {
 	}
 
 	/**
-	* Returns the m d r rule group instance with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group instance's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group instance, or <code>null</code> if a matching m d r rule group instance could not be found
-	*/
-	public static com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance fetchMDRRuleGroupInstanceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService()
-				   .fetchMDRRuleGroupInstanceByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the m d r rule group instance matching the UUID and group.
 	*
 	* @param uuid the m d r rule group instance's UUID
@@ -285,21 +272,6 @@ public class MDRRuleGroupInstanceLocalServiceUtil {
 	}
 
 	/**
-	* Returns the m d r rule group instance with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group instance's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group instance
-	* @throws PortalException if a matching m d r rule group instance could not be found
-	*/
-	public static com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance getMDRRuleGroupInstanceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .getMDRRuleGroupInstanceByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the m d r rule group instance matching the UUID and group.
 	*
 	* @param uuid the m d r rule group instance's UUID
@@ -328,6 +300,37 @@ public class MDRRuleGroupInstanceLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance> getMDRRuleGroupInstances(
 		int start, int end) {
 		return getService().getMDRRuleGroupInstances(start, end);
+	}
+
+	/**
+	* Returns all the m d r rule group instances that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule group instances
+	* @param companyId the primary key of the company
+	* @return all the matching m d r rule group instances, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance> getMDRRuleGroupInstancesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService()
+				   .getMDRRuleGroupInstancesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of m d r rule group instances that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule group instances
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r rule group instances
+	* @param end the upper bound of the range of m d r rule group instances (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r rule group instances, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance> getMDRRuleGroupInstancesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMDRRuleGroupInstancesByUuidAndCompanyId(uuid, companyId,
+			start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupInstanceLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupInstanceLocalServiceWrapper.java
@@ -228,20 +228,6 @@ public class MDRRuleGroupInstanceLocalServiceWrapper
 	}
 
 	/**
-	* Returns the m d r rule group instance with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group instance's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group instance, or <code>null</code> if a matching m d r rule group instance could not be found
-	*/
-	@Override
-	public com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance fetchMDRRuleGroupInstanceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mdrRuleGroupInstanceLocalService.fetchMDRRuleGroupInstanceByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the m d r rule group instance matching the UUID and group.
 	*
 	* @param uuid the m d r rule group instance's UUID
@@ -304,22 +290,6 @@ public class MDRRuleGroupInstanceLocalServiceWrapper
 	}
 
 	/**
-	* Returns the m d r rule group instance with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group instance's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group instance
-	* @throws PortalException if a matching m d r rule group instance could not be found
-	*/
-	@Override
-	public com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance getMDRRuleGroupInstanceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mdrRuleGroupInstanceLocalService.getMDRRuleGroupInstanceByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the m d r rule group instance matching the UUID and group.
 	*
 	* @param uuid the m d r rule group instance's UUID
@@ -351,6 +321,38 @@ public class MDRRuleGroupInstanceLocalServiceWrapper
 		int start, int end) {
 		return _mdrRuleGroupInstanceLocalService.getMDRRuleGroupInstances(start,
 			end);
+	}
+
+	/**
+	* Returns all the m d r rule group instances that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule group instances
+	* @param companyId the primary key of the company
+	* @return all the matching m d r rule group instances, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance> getMDRRuleGroupInstancesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mdrRuleGroupInstanceLocalService.getMDRRuleGroupInstancesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of m d r rule group instances that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule group instances
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r rule group instances
+	* @param end the upper bound of the range of m d r rule group instances (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r rule group instances, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance> getMDRRuleGroupInstancesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mdrRuleGroupInstanceLocalService.getMDRRuleGroupInstancesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalService.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalService.java
@@ -193,17 +193,6 @@ public interface MDRRuleGroupLocalService extends BaseLocalService,
 		long ruleGroupId);
 
 	/**
-	* Returns the m d r rule group with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group, or <code>null</code> if a matching m d r rule group could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup fetchMDRRuleGroupByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the m d r rule group matching the UUID and group.
 	*
 	* @param uuid the m d r rule group's UUID
@@ -245,19 +234,6 @@ public interface MDRRuleGroupLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the m d r rule group with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group
-	* @throws PortalException if a matching m d r rule group could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup getMDRRuleGroupByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the m d r rule group matching the UUID and group.
 	*
 	* @param uuid the m d r rule group's UUID
@@ -284,6 +260,32 @@ public interface MDRRuleGroupLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> getMDRRuleGroups(
 		int start, int end);
+
+	/**
+	* Returns all the m d r rule groups that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule groups
+	* @param companyId the primary key of the company
+	* @return all the matching m d r rule groups, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> getMDRRuleGroupsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of m d r rule groups that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule groups
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r rule groups
+	* @param end the upper bound of the range of m d r rule groups (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r rule groups, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> getMDRRuleGroupsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of m d r rule groups.

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceUtil.java
@@ -218,18 +218,6 @@ public class MDRRuleGroupLocalServiceUtil {
 	}
 
 	/**
-	* Returns the m d r rule group with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group, or <code>null</code> if a matching m d r rule group could not be found
-	*/
-	public static com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup fetchMDRRuleGroupByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMDRRuleGroupByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the m d r rule group matching the UUID and group.
 	*
 	* @param uuid the m d r rule group's UUID
@@ -278,20 +266,6 @@ public class MDRRuleGroupLocalServiceUtil {
 	}
 
 	/**
-	* Returns the m d r rule group with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group
-	* @throws PortalException if a matching m d r rule group could not be found
-	*/
-	public static com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup getMDRRuleGroupByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMDRRuleGroupByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the m d r rule group matching the UUID and group.
 	*
 	* @param uuid the m d r rule group's UUID
@@ -319,6 +293,36 @@ public class MDRRuleGroupLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> getMDRRuleGroups(
 		int start, int end) {
 		return getService().getMDRRuleGroups(start, end);
+	}
+
+	/**
+	* Returns all the m d r rule groups that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule groups
+	* @param companyId the primary key of the company
+	* @return all the matching m d r rule groups, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> getMDRRuleGroupsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMDRRuleGroupsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of m d r rule groups that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule groups
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r rule groups
+	* @param end the upper bound of the range of m d r rule groups (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r rule groups, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> getMDRRuleGroupsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMDRRuleGroupsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceWrapper.java
@@ -230,20 +230,6 @@ public class MDRRuleGroupLocalServiceWrapper implements MDRRuleGroupLocalService
 	}
 
 	/**
-	* Returns the m d r rule group with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group, or <code>null</code> if a matching m d r rule group could not be found
-	*/
-	@Override
-	public com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup fetchMDRRuleGroupByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mdrRuleGroupLocalService.fetchMDRRuleGroupByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the m d r rule group matching the UUID and group.
 	*
 	* @param uuid the m d r rule group's UUID
@@ -299,22 +285,6 @@ public class MDRRuleGroupLocalServiceWrapper implements MDRRuleGroupLocalService
 	}
 
 	/**
-	* Returns the m d r rule group with the matching UUID and company.
-	*
-	* @param uuid the m d r rule group's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule group
-	* @throws PortalException if a matching m d r rule group could not be found
-	*/
-	@Override
-	public com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup getMDRRuleGroupByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mdrRuleGroupLocalService.getMDRRuleGroupByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the m d r rule group matching the UUID and group.
 	*
 	* @param uuid the m d r rule group's UUID
@@ -345,6 +315,38 @@ public class MDRRuleGroupLocalServiceWrapper implements MDRRuleGroupLocalService
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> getMDRRuleGroups(
 		int start, int end) {
 		return _mdrRuleGroupLocalService.getMDRRuleGroups(start, end);
+	}
+
+	/**
+	* Returns all the m d r rule groups that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule groups
+	* @param companyId the primary key of the company
+	* @return all the matching m d r rule groups, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> getMDRRuleGroupsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mdrRuleGroupLocalService.getMDRRuleGroupsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of m d r rule groups that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rule groups
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r rule groups
+	* @param end the upper bound of the range of m d r rule groups (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r rule groups, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> getMDRRuleGroupsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mdrRuleGroupLocalService.getMDRRuleGroupsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleLocalService.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleLocalService.java
@@ -203,17 +203,6 @@ public interface MDRRuleLocalService extends BaseLocalService,
 		long ruleId);
 
 	/**
-	* Returns the m d r rule with the matching UUID and company.
-	*
-	* @param uuid the m d r rule's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule, or <code>null</code> if a matching m d r rule could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.mobiledevicerules.model.MDRRule fetchMDRRuleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the m d r rule matching the UUID and group.
 	*
 	* @param uuid the m d r rule's UUID
@@ -254,19 +243,6 @@ public interface MDRRuleLocalService extends BaseLocalService,
 		long ruleId) throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the m d r rule with the matching UUID and company.
-	*
-	* @param uuid the m d r rule's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule
-	* @throws PortalException if a matching m d r rule could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.mobiledevicerules.model.MDRRule getMDRRuleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the m d r rule matching the UUID and group.
 	*
 	* @param uuid the m d r rule's UUID
@@ -293,6 +269,32 @@ public interface MDRRuleLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRule> getMDRRules(
 		int start, int end);
+
+	/**
+	* Returns all the m d r rules that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rules
+	* @param companyId the primary key of the company
+	* @return all the matching m d r rules, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRule> getMDRRulesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of m d r rules that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rules
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r rules
+	* @param end the upper bound of the range of m d r rules (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r rules, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRule> getMDRRulesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of m d r rules.

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleLocalServiceUtil.java
@@ -232,18 +232,6 @@ public class MDRRuleLocalServiceUtil {
 	}
 
 	/**
-	* Returns the m d r rule with the matching UUID and company.
-	*
-	* @param uuid the m d r rule's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule, or <code>null</code> if a matching m d r rule could not be found
-	*/
-	public static com.liferay.portlet.mobiledevicerules.model.MDRRule fetchMDRRuleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchMDRRuleByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the m d r rule matching the UUID and group.
 	*
 	* @param uuid the m d r rule's UUID
@@ -291,20 +279,6 @@ public class MDRRuleLocalServiceUtil {
 	}
 
 	/**
-	* Returns the m d r rule with the matching UUID and company.
-	*
-	* @param uuid the m d r rule's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule
-	* @throws PortalException if a matching m d r rule could not be found
-	*/
-	public static com.liferay.portlet.mobiledevicerules.model.MDRRule getMDRRuleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getMDRRuleByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the m d r rule matching the UUID and group.
 	*
 	* @param uuid the m d r rule's UUID
@@ -332,6 +306,36 @@ public class MDRRuleLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRule> getMDRRules(
 		int start, int end) {
 		return getService().getMDRRules(start, end);
+	}
+
+	/**
+	* Returns all the m d r rules that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rules
+	* @param companyId the primary key of the company
+	* @return all the matching m d r rules, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRule> getMDRRulesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getMDRRulesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of m d r rules that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rules
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r rules
+	* @param end the upper bound of the range of m d r rules (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r rules, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRule> getMDRRulesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getMDRRulesByUuidAndCompanyId(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleLocalServiceWrapper.java
@@ -240,20 +240,6 @@ public class MDRRuleLocalServiceWrapper implements MDRRuleLocalService,
 	}
 
 	/**
-	* Returns the m d r rule with the matching UUID and company.
-	*
-	* @param uuid the m d r rule's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule, or <code>null</code> if a matching m d r rule could not be found
-	*/
-	@Override
-	public com.liferay.portlet.mobiledevicerules.model.MDRRule fetchMDRRuleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _mdrRuleLocalService.fetchMDRRuleByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the m d r rule matching the UUID and group.
 	*
 	* @param uuid the m d r rule's UUID
@@ -307,21 +293,6 @@ public class MDRRuleLocalServiceWrapper implements MDRRuleLocalService,
 	}
 
 	/**
-	* Returns the m d r rule with the matching UUID and company.
-	*
-	* @param uuid the m d r rule's UUID
-	* @param companyId the primary key of the company
-	* @return the matching m d r rule
-	* @throws PortalException if a matching m d r rule could not be found
-	*/
-	@Override
-	public com.liferay.portlet.mobiledevicerules.model.MDRRule getMDRRuleByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _mdrRuleLocalService.getMDRRuleByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the m d r rule matching the UUID and group.
 	*
 	* @param uuid the m d r rule's UUID
@@ -351,6 +322,38 @@ public class MDRRuleLocalServiceWrapper implements MDRRuleLocalService,
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRule> getMDRRules(
 		int start, int end) {
 		return _mdrRuleLocalService.getMDRRules(start, end);
+	}
+
+	/**
+	* Returns all the m d r rules that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rules
+	* @param companyId the primary key of the company
+	* @return all the matching m d r rules, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRule> getMDRRulesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _mdrRuleLocalService.getMDRRulesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of m d r rules that match the UUID and company.
+	*
+	* @param uuid the UUID of the m d r rules
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of m d r rules
+	* @param end the upper bound of the range of m d r rules (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching m d r rules, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRule> getMDRRulesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _mdrRuleLocalService.getMDRRulesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/polls/service/PollsChoiceLocalService.java
+++ b/portal-service/src/com/liferay/portlet/polls/service/PollsChoiceLocalService.java
@@ -171,17 +171,6 @@ public interface PollsChoiceLocalService extends BaseLocalService,
 		long choiceId);
 
 	/**
-	* Returns the polls choice with the matching UUID and company.
-	*
-	* @param uuid the polls choice's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls choice, or <code>null</code> if a matching polls choice could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.polls.model.PollsChoice fetchPollsChoiceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the polls choice matching the UUID and group.
 	*
 	* @param uuid the polls choice's UUID
@@ -236,19 +225,6 @@ public interface PollsChoiceLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the polls choice with the matching UUID and company.
-	*
-	* @param uuid the polls choice's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls choice
-	* @throws PortalException if a matching polls choice could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.polls.model.PollsChoice getPollsChoiceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the polls choice matching the UUID and group.
 	*
 	* @param uuid the polls choice's UUID
@@ -275,6 +251,32 @@ public interface PollsChoiceLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.polls.model.PollsChoice> getPollsChoices(
 		int start, int end);
+
+	/**
+	* Returns all the polls choices that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls choices
+	* @param companyId the primary key of the company
+	* @return all the matching polls choices, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.polls.model.PollsChoice> getPollsChoicesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of polls choices that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls choices
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of polls choices
+	* @param end the upper bound of the range of polls choices (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching polls choices, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.polls.model.PollsChoice> getPollsChoicesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of polls choices.

--- a/portal-service/src/com/liferay/portlet/polls/service/PollsChoiceLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/polls/service/PollsChoiceLocalServiceUtil.java
@@ -189,18 +189,6 @@ public class PollsChoiceLocalServiceUtil {
 	}
 
 	/**
-	* Returns the polls choice with the matching UUID and company.
-	*
-	* @param uuid the polls choice's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls choice, or <code>null</code> if a matching polls choice could not be found
-	*/
-	public static com.liferay.portlet.polls.model.PollsChoice fetchPollsChoiceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchPollsChoiceByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the polls choice matching the UUID and group.
 	*
 	* @param uuid the polls choice's UUID
@@ -265,20 +253,6 @@ public class PollsChoiceLocalServiceUtil {
 	}
 
 	/**
-	* Returns the polls choice with the matching UUID and company.
-	*
-	* @param uuid the polls choice's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls choice
-	* @throws PortalException if a matching polls choice could not be found
-	*/
-	public static com.liferay.portlet.polls.model.PollsChoice getPollsChoiceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getPollsChoiceByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the polls choice matching the UUID and group.
 	*
 	* @param uuid the polls choice's UUID
@@ -306,6 +280,36 @@ public class PollsChoiceLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.polls.model.PollsChoice> getPollsChoices(
 		int start, int end) {
 		return getService().getPollsChoices(start, end);
+	}
+
+	/**
+	* Returns all the polls choices that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls choices
+	* @param companyId the primary key of the company
+	* @return all the matching polls choices, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.polls.model.PollsChoice> getPollsChoicesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getPollsChoicesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of polls choices that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls choices
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of polls choices
+	* @param end the upper bound of the range of polls choices (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching polls choices, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.polls.model.PollsChoice> getPollsChoicesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getPollsChoicesByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/polls/service/PollsChoiceLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/polls/service/PollsChoiceLocalServiceWrapper.java
@@ -194,20 +194,6 @@ public class PollsChoiceLocalServiceWrapper implements PollsChoiceLocalService,
 	}
 
 	/**
-	* Returns the polls choice with the matching UUID and company.
-	*
-	* @param uuid the polls choice's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls choice, or <code>null</code> if a matching polls choice could not be found
-	*/
-	@Override
-	public com.liferay.portlet.polls.model.PollsChoice fetchPollsChoiceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _pollsChoiceLocalService.fetchPollsChoiceByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the polls choice matching the UUID and group.
 	*
 	* @param uuid the polls choice's UUID
@@ -281,22 +267,6 @@ public class PollsChoiceLocalServiceWrapper implements PollsChoiceLocalService,
 	}
 
 	/**
-	* Returns the polls choice with the matching UUID and company.
-	*
-	* @param uuid the polls choice's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls choice
-	* @throws PortalException if a matching polls choice could not be found
-	*/
-	@Override
-	public com.liferay.portlet.polls.model.PollsChoice getPollsChoiceByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _pollsChoiceLocalService.getPollsChoiceByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the polls choice matching the UUID and group.
 	*
 	* @param uuid the polls choice's UUID
@@ -327,6 +297,38 @@ public class PollsChoiceLocalServiceWrapper implements PollsChoiceLocalService,
 	public java.util.List<com.liferay.portlet.polls.model.PollsChoice> getPollsChoices(
 		int start, int end) {
 		return _pollsChoiceLocalService.getPollsChoices(start, end);
+	}
+
+	/**
+	* Returns all the polls choices that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls choices
+	* @param companyId the primary key of the company
+	* @return all the matching polls choices, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.polls.model.PollsChoice> getPollsChoicesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _pollsChoiceLocalService.getPollsChoicesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of polls choices that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls choices
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of polls choices
+	* @param end the upper bound of the range of polls choices (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching polls choices, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.polls.model.PollsChoice> getPollsChoicesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _pollsChoiceLocalService.getPollsChoicesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/polls/service/PollsQuestionLocalService.java
+++ b/portal-service/src/com/liferay/portlet/polls/service/PollsQuestionLocalService.java
@@ -207,17 +207,6 @@ public interface PollsQuestionLocalService extends BaseLocalService,
 		long questionId);
 
 	/**
-	* Returns the polls question with the matching UUID and company.
-	*
-	* @param uuid the polls question's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls question, or <code>null</code> if a matching polls question could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.polls.model.PollsQuestion fetchPollsQuestionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the polls question matching the UUID and group.
 	*
 	* @param uuid the polls question's UUID
@@ -261,19 +250,6 @@ public interface PollsQuestionLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the polls question with the matching UUID and company.
-	*
-	* @param uuid the polls question's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls question
-	* @throws PortalException if a matching polls question could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.polls.model.PollsQuestion getPollsQuestionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the polls question matching the UUID and group.
 	*
 	* @param uuid the polls question's UUID
@@ -300,6 +276,32 @@ public interface PollsQuestionLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.polls.model.PollsQuestion> getPollsQuestions(
 		int start, int end);
+
+	/**
+	* Returns all the polls questions that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls questions
+	* @param companyId the primary key of the company
+	* @return all the matching polls questions, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.polls.model.PollsQuestion> getPollsQuestionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of polls questions that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls questions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of polls questions
+	* @param end the upper bound of the range of polls questions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching polls questions, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.polls.model.PollsQuestion> getPollsQuestionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of polls questions.

--- a/portal-service/src/com/liferay/portlet/polls/service/PollsQuestionLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/polls/service/PollsQuestionLocalServiceUtil.java
@@ -244,18 +244,6 @@ public class PollsQuestionLocalServiceUtil {
 	}
 
 	/**
-	* Returns the polls question with the matching UUID and company.
-	*
-	* @param uuid the polls question's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls question, or <code>null</code> if a matching polls question could not be found
-	*/
-	public static com.liferay.portlet.polls.model.PollsQuestion fetchPollsQuestionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchPollsQuestionByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the polls question matching the UUID and group.
 	*
 	* @param uuid the polls question's UUID
@@ -305,20 +293,6 @@ public class PollsQuestionLocalServiceUtil {
 	}
 
 	/**
-	* Returns the polls question with the matching UUID and company.
-	*
-	* @param uuid the polls question's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls question
-	* @throws PortalException if a matching polls question could not be found
-	*/
-	public static com.liferay.portlet.polls.model.PollsQuestion getPollsQuestionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getPollsQuestionByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the polls question matching the UUID and group.
 	*
 	* @param uuid the polls question's UUID
@@ -346,6 +320,36 @@ public class PollsQuestionLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.polls.model.PollsQuestion> getPollsQuestions(
 		int start, int end) {
 		return getService().getPollsQuestions(start, end);
+	}
+
+	/**
+	* Returns all the polls questions that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls questions
+	* @param companyId the primary key of the company
+	* @return all the matching polls questions, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.polls.model.PollsQuestion> getPollsQuestionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getPollsQuestionsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of polls questions that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls questions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of polls questions
+	* @param end the upper bound of the range of polls questions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching polls questions, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.polls.model.PollsQuestion> getPollsQuestionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getPollsQuestionsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/polls/service/PollsQuestionLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/polls/service/PollsQuestionLocalServiceWrapper.java
@@ -255,20 +255,6 @@ public class PollsQuestionLocalServiceWrapper
 	}
 
 	/**
-	* Returns the polls question with the matching UUID and company.
-	*
-	* @param uuid the polls question's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls question, or <code>null</code> if a matching polls question could not be found
-	*/
-	@Override
-	public com.liferay.portlet.polls.model.PollsQuestion fetchPollsQuestionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _pollsQuestionLocalService.fetchPollsQuestionByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the polls question matching the UUID and group.
 	*
 	* @param uuid the polls question's UUID
@@ -325,22 +311,6 @@ public class PollsQuestionLocalServiceWrapper
 	}
 
 	/**
-	* Returns the polls question with the matching UUID and company.
-	*
-	* @param uuid the polls question's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls question
-	* @throws PortalException if a matching polls question could not be found
-	*/
-	@Override
-	public com.liferay.portlet.polls.model.PollsQuestion getPollsQuestionByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _pollsQuestionLocalService.getPollsQuestionByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the polls question matching the UUID and group.
 	*
 	* @param uuid the polls question's UUID
@@ -371,6 +341,38 @@ public class PollsQuestionLocalServiceWrapper
 	public java.util.List<com.liferay.portlet.polls.model.PollsQuestion> getPollsQuestions(
 		int start, int end) {
 		return _pollsQuestionLocalService.getPollsQuestions(start, end);
+	}
+
+	/**
+	* Returns all the polls questions that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls questions
+	* @param companyId the primary key of the company
+	* @return all the matching polls questions, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.polls.model.PollsQuestion> getPollsQuestionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _pollsQuestionLocalService.getPollsQuestionsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of polls questions that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls questions
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of polls questions
+	* @param end the upper bound of the range of polls questions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching polls questions, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.polls.model.PollsQuestion> getPollsQuestionsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _pollsQuestionLocalService.getPollsQuestionsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/polls/service/PollsVoteLocalService.java
+++ b/portal-service/src/com/liferay/portlet/polls/service/PollsVoteLocalService.java
@@ -170,17 +170,6 @@ public interface PollsVoteLocalService extends BaseLocalService,
 	public com.liferay.portlet.polls.model.PollsVote fetchPollsVote(long voteId);
 
 	/**
-	* Returns the polls vote with the matching UUID and company.
-	*
-	* @param uuid the polls vote's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls vote, or <code>null</code> if a matching polls vote could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.polls.model.PollsVote fetchPollsVoteByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the polls vote matching the UUID and group.
 	*
 	* @param uuid the polls vote's UUID
@@ -230,19 +219,6 @@ public interface PollsVoteLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the polls vote with the matching UUID and company.
-	*
-	* @param uuid the polls vote's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls vote
-	* @throws PortalException if a matching polls vote could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.polls.model.PollsVote getPollsVoteByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the polls vote matching the UUID and group.
 	*
 	* @param uuid the polls vote's UUID
@@ -269,6 +245,32 @@ public interface PollsVoteLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.polls.model.PollsVote> getPollsVotes(
 		int start, int end);
+
+	/**
+	* Returns all the polls votes that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls votes
+	* @param companyId the primary key of the company
+	* @return all the matching polls votes, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.polls.model.PollsVote> getPollsVotesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of polls votes that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls votes
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of polls votes
+	* @param end the upper bound of the range of polls votes (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching polls votes, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.polls.model.PollsVote> getPollsVotesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of polls votes.

--- a/portal-service/src/com/liferay/portlet/polls/service/PollsVoteLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/polls/service/PollsVoteLocalServiceUtil.java
@@ -186,18 +186,6 @@ public class PollsVoteLocalServiceUtil {
 	}
 
 	/**
-	* Returns the polls vote with the matching UUID and company.
-	*
-	* @param uuid the polls vote's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls vote, or <code>null</code> if a matching polls vote could not be found
-	*/
-	public static com.liferay.portlet.polls.model.PollsVote fetchPollsVoteByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchPollsVoteByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the polls vote matching the UUID and group.
 	*
 	* @param uuid the polls vote's UUID
@@ -255,20 +243,6 @@ public class PollsVoteLocalServiceUtil {
 	}
 
 	/**
-	* Returns the polls vote with the matching UUID and company.
-	*
-	* @param uuid the polls vote's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls vote
-	* @throws PortalException if a matching polls vote could not be found
-	*/
-	public static com.liferay.portlet.polls.model.PollsVote getPollsVoteByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getPollsVoteByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the polls vote matching the UUID and group.
 	*
 	* @param uuid the polls vote's UUID
@@ -296,6 +270,36 @@ public class PollsVoteLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.polls.model.PollsVote> getPollsVotes(
 		int start, int end) {
 		return getService().getPollsVotes(start, end);
+	}
+
+	/**
+	* Returns all the polls votes that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls votes
+	* @param companyId the primary key of the company
+	* @return all the matching polls votes, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.polls.model.PollsVote> getPollsVotesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getPollsVotesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of polls votes that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls votes
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of polls votes
+	* @param end the upper bound of the range of polls votes (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching polls votes, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.polls.model.PollsVote> getPollsVotesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getPollsVotesByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/polls/service/PollsVoteLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/polls/service/PollsVoteLocalServiceWrapper.java
@@ -191,20 +191,6 @@ public class PollsVoteLocalServiceWrapper implements PollsVoteLocalService,
 	}
 
 	/**
-	* Returns the polls vote with the matching UUID and company.
-	*
-	* @param uuid the polls vote's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls vote, or <code>null</code> if a matching polls vote could not be found
-	*/
-	@Override
-	public com.liferay.portlet.polls.model.PollsVote fetchPollsVoteByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _pollsVoteLocalService.fetchPollsVoteByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the polls vote matching the UUID and group.
 	*
 	* @param uuid the polls vote's UUID
@@ -271,22 +257,6 @@ public class PollsVoteLocalServiceWrapper implements PollsVoteLocalService,
 	}
 
 	/**
-	* Returns the polls vote with the matching UUID and company.
-	*
-	* @param uuid the polls vote's UUID
-	* @param companyId the primary key of the company
-	* @return the matching polls vote
-	* @throws PortalException if a matching polls vote could not be found
-	*/
-	@Override
-	public com.liferay.portlet.polls.model.PollsVote getPollsVoteByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _pollsVoteLocalService.getPollsVoteByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the polls vote matching the UUID and group.
 	*
 	* @param uuid the polls vote's UUID
@@ -316,6 +286,38 @@ public class PollsVoteLocalServiceWrapper implements PollsVoteLocalService,
 	public java.util.List<com.liferay.portlet.polls.model.PollsVote> getPollsVotes(
 		int start, int end) {
 		return _pollsVoteLocalService.getPollsVotes(start, end);
+	}
+
+	/**
+	* Returns all the polls votes that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls votes
+	* @param companyId the primary key of the company
+	* @return all the matching polls votes, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.polls.model.PollsVote> getPollsVotesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _pollsVoteLocalService.getPollsVotesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of polls votes that match the UUID and company.
+	*
+	* @param uuid the UUID of the polls votes
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of polls votes
+	* @param end the upper bound of the range of polls votes (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching polls votes, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.polls.model.PollsVote> getPollsVotesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _pollsVoteLocalService.getPollsVotesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/social/service/SocialRequestLocalService.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialRequestLocalService.java
@@ -229,17 +229,6 @@ public interface SocialRequestLocalService extends BaseLocalService,
 		long requestId);
 
 	/**
-	* Returns the social request with the matching UUID and company.
-	*
-	* @param uuid the social request's UUID
-	* @param companyId the primary key of the company
-	* @return the matching social request, or <code>null</code> if a matching social request could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.social.model.SocialRequest fetchSocialRequestByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the social request matching the UUID and group.
 	*
 	* @param uuid the social request's UUID
@@ -345,19 +334,6 @@ public interface SocialRequestLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the social request with the matching UUID and company.
-	*
-	* @param uuid the social request's UUID
-	* @param companyId the primary key of the company
-	* @return the matching social request
-	* @throws PortalException if a matching social request could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.social.model.SocialRequest getSocialRequestByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the social request matching the UUID and group.
 	*
 	* @param uuid the social request's UUID
@@ -384,6 +360,32 @@ public interface SocialRequestLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.social.model.SocialRequest> getSocialRequests(
 		int start, int end);
+
+	/**
+	* Returns all the social requests that match the UUID and company.
+	*
+	* @param uuid the UUID of the social requests
+	* @param companyId the primary key of the company
+	* @return all the matching social requests, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.social.model.SocialRequest> getSocialRequestsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of social requests that match the UUID and company.
+	*
+	* @param uuid the UUID of the social requests
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of social requests
+	* @param end the upper bound of the range of social requests (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching social requests, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.social.model.SocialRequest> getSocialRequestsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of social requests.

--- a/portal-service/src/com/liferay/portlet/social/service/SocialRequestLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialRequestLocalServiceUtil.java
@@ -256,18 +256,6 @@ public class SocialRequestLocalServiceUtil {
 	}
 
 	/**
-	* Returns the social request with the matching UUID and company.
-	*
-	* @param uuid the social request's UUID
-	* @param companyId the primary key of the company
-	* @return the matching social request, or <code>null</code> if a matching social request could not be found
-	*/
-	public static com.liferay.portlet.social.model.SocialRequest fetchSocialRequestByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchSocialRequestByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the social request matching the UUID and group.
 	*
 	* @param uuid the social request's UUID
@@ -384,20 +372,6 @@ public class SocialRequestLocalServiceUtil {
 	}
 
 	/**
-	* Returns the social request with the matching UUID and company.
-	*
-	* @param uuid the social request's UUID
-	* @param companyId the primary key of the company
-	* @return the matching social request
-	* @throws PortalException if a matching social request could not be found
-	*/
-	public static com.liferay.portlet.social.model.SocialRequest getSocialRequestByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getSocialRequestByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the social request matching the UUID and group.
 	*
 	* @param uuid the social request's UUID
@@ -425,6 +399,36 @@ public class SocialRequestLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.social.model.SocialRequest> getSocialRequests(
 		int start, int end) {
 		return getService().getSocialRequests(start, end);
+	}
+
+	/**
+	* Returns all the social requests that match the UUID and company.
+	*
+	* @param uuid the UUID of the social requests
+	* @param companyId the primary key of the company
+	* @return all the matching social requests, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.social.model.SocialRequest> getSocialRequestsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getSocialRequestsByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of social requests that match the UUID and company.
+	*
+	* @param uuid the UUID of the social requests
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of social requests
+	* @param end the upper bound of the range of social requests (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching social requests, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.social.model.SocialRequest> getSocialRequestsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getSocialRequestsByUuidAndCompanyId(uuid, companyId, start,
+			end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/social/service/SocialRequestLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialRequestLocalServiceWrapper.java
@@ -267,20 +267,6 @@ public class SocialRequestLocalServiceWrapper
 	}
 
 	/**
-	* Returns the social request with the matching UUID and company.
-	*
-	* @param uuid the social request's UUID
-	* @param companyId the primary key of the company
-	* @return the matching social request, or <code>null</code> if a matching social request could not be found
-	*/
-	@Override
-	public com.liferay.portlet.social.model.SocialRequest fetchSocialRequestByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _socialRequestLocalService.fetchSocialRequestByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the social request matching the UUID and group.
 	*
 	* @param uuid the social request's UUID
@@ -408,22 +394,6 @@ public class SocialRequestLocalServiceWrapper
 	}
 
 	/**
-	* Returns the social request with the matching UUID and company.
-	*
-	* @param uuid the social request's UUID
-	* @param companyId the primary key of the company
-	* @return the matching social request
-	* @throws PortalException if a matching social request could not be found
-	*/
-	@Override
-	public com.liferay.portlet.social.model.SocialRequest getSocialRequestByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _socialRequestLocalService.getSocialRequestByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the social request matching the UUID and group.
 	*
 	* @param uuid the social request's UUID
@@ -454,6 +424,38 @@ public class SocialRequestLocalServiceWrapper
 	public java.util.List<com.liferay.portlet.social.model.SocialRequest> getSocialRequests(
 		int start, int end) {
 		return _socialRequestLocalService.getSocialRequests(start, end);
+	}
+
+	/**
+	* Returns all the social requests that match the UUID and company.
+	*
+	* @param uuid the UUID of the social requests
+	* @param companyId the primary key of the company
+	* @return all the matching social requests, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.social.model.SocialRequest> getSocialRequestsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _socialRequestLocalService.getSocialRequestsByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of social requests that match the UUID and company.
+	*
+	* @param uuid the UUID of the social requests
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of social requests
+	* @param end the upper bound of the range of social requests (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching social requests, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.social.model.SocialRequest> getSocialRequestsByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _socialRequestLocalService.getSocialRequestsByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/wiki/service/WikiNodeLocalService.java
+++ b/portal-service/src/com/liferay/portlet/wiki/service/WikiNodeLocalService.java
@@ -207,17 +207,6 @@ public interface WikiNodeLocalService extends BaseLocalService,
 	public com.liferay.portlet.wiki.model.WikiNode fetchWikiNode(long nodeId);
 
 	/**
-	* Returns the wiki node with the matching UUID and company.
-	*
-	* @param uuid the wiki node's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.wiki.model.WikiNode fetchWikiNodeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the wiki node matching the UUID and group.
 	*
 	* @param uuid the wiki node's UUID
@@ -309,19 +298,6 @@ public interface WikiNodeLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the wiki node with the matching UUID and company.
-	*
-	* @param uuid the wiki node's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki node
-	* @throws PortalException if a matching wiki node could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.wiki.model.WikiNode getWikiNodeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the wiki node matching the UUID and group.
 	*
 	* @param uuid the wiki node's UUID
@@ -348,6 +324,32 @@ public interface WikiNodeLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.wiki.model.WikiNode> getWikiNodes(
 		int start, int end);
+
+	/**
+	* Returns all the wiki nodes that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki nodes
+	* @param companyId the primary key of the company
+	* @return all the matching wiki nodes, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.wiki.model.WikiNode> getWikiNodesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of wiki nodes that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki nodes
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of wiki nodes
+	* @param end the upper bound of the range of wiki nodes (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching wiki nodes, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.wiki.model.WikiNode> getWikiNodesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of wiki nodes.

--- a/portal-service/src/com/liferay/portlet/wiki/service/WikiNodeLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/wiki/service/WikiNodeLocalServiceUtil.java
@@ -244,18 +244,6 @@ public class WikiNodeLocalServiceUtil {
 	}
 
 	/**
-	* Returns the wiki node with the matching UUID and company.
-	*
-	* @param uuid the wiki node's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
-	*/
-	public static com.liferay.portlet.wiki.model.WikiNode fetchWikiNodeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchWikiNodeByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the wiki node matching the UUID and group.
 	*
 	* @param uuid the wiki node's UUID
@@ -365,20 +353,6 @@ public class WikiNodeLocalServiceUtil {
 	}
 
 	/**
-	* Returns the wiki node with the matching UUID and company.
-	*
-	* @param uuid the wiki node's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki node
-	* @throws PortalException if a matching wiki node could not be found
-	*/
-	public static com.liferay.portlet.wiki.model.WikiNode getWikiNodeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getWikiNodeByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the wiki node matching the UUID and group.
 	*
 	* @param uuid the wiki node's UUID
@@ -406,6 +380,36 @@ public class WikiNodeLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.wiki.model.WikiNode> getWikiNodes(
 		int start, int end) {
 		return getService().getWikiNodes(start, end);
+	}
+
+	/**
+	* Returns all the wiki nodes that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki nodes
+	* @param companyId the primary key of the company
+	* @return all the matching wiki nodes, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.wiki.model.WikiNode> getWikiNodesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getWikiNodesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of wiki nodes that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki nodes
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of wiki nodes
+	* @param end the upper bound of the range of wiki nodes (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching wiki nodes, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.wiki.model.WikiNode> getWikiNodesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getWikiNodesByUuidAndCompanyId(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/wiki/service/WikiNodeLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/wiki/service/WikiNodeLocalServiceWrapper.java
@@ -259,20 +259,6 @@ public class WikiNodeLocalServiceWrapper implements WikiNodeLocalService,
 	}
 
 	/**
-	* Returns the wiki node with the matching UUID and company.
-	*
-	* @param uuid the wiki node's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
-	*/
-	@Override
-	public com.liferay.portlet.wiki.model.WikiNode fetchWikiNodeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _wikiNodeLocalService.fetchWikiNodeByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the wiki node matching the UUID and group.
 	*
 	* @param uuid the wiki node's UUID
@@ -401,22 +387,6 @@ public class WikiNodeLocalServiceWrapper implements WikiNodeLocalService,
 	}
 
 	/**
-	* Returns the wiki node with the matching UUID and company.
-	*
-	* @param uuid the wiki node's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki node
-	* @throws PortalException if a matching wiki node could not be found
-	*/
-	@Override
-	public com.liferay.portlet.wiki.model.WikiNode getWikiNodeByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _wikiNodeLocalService.getWikiNodeByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the wiki node matching the UUID and group.
 	*
 	* @param uuid the wiki node's UUID
@@ -446,6 +416,38 @@ public class WikiNodeLocalServiceWrapper implements WikiNodeLocalService,
 	public java.util.List<com.liferay.portlet.wiki.model.WikiNode> getWikiNodes(
 		int start, int end) {
 		return _wikiNodeLocalService.getWikiNodes(start, end);
+	}
+
+	/**
+	* Returns all the wiki nodes that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki nodes
+	* @param companyId the primary key of the company
+	* @return all the matching wiki nodes, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.wiki.model.WikiNode> getWikiNodesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _wikiNodeLocalService.getWikiNodesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of wiki nodes that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki nodes
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of wiki nodes
+	* @param end the upper bound of the range of wiki nodes (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching wiki nodes, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.wiki.model.WikiNode> getWikiNodesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _wikiNodeLocalService.getWikiNodesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/wiki/service/WikiPageLocalService.java
+++ b/portal-service/src/com/liferay/portlet/wiki/service/WikiPageLocalService.java
@@ -278,17 +278,6 @@ public interface WikiPageLocalService extends BaseLocalService,
 	public com.liferay.portlet.wiki.model.WikiPage fetchWikiPage(long pageId);
 
 	/**
-	* Returns the wiki page with the matching UUID and company.
-	*
-	* @param uuid the wiki page's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.wiki.model.WikiPage fetchWikiPageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId);
-
-	/**
 	* Returns the wiki page matching the UUID and group.
 	*
 	* @param uuid the wiki page's UUID
@@ -523,19 +512,6 @@ public interface WikiPageLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**
-	* Returns the wiki page with the matching UUID and company.
-	*
-	* @param uuid the wiki page's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki page
-	* @throws PortalException if a matching wiki page could not be found
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portlet.wiki.model.WikiPage getWikiPageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException;
-
-	/**
 	* Returns the wiki page matching the UUID and group.
 	*
 	* @param uuid the wiki page's UUID
@@ -562,6 +538,32 @@ public interface WikiPageLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.wiki.model.WikiPage> getWikiPages(
 		int start, int end);
+
+	/**
+	* Returns all the wiki pages that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki pages
+	* @param companyId the primary key of the company
+	* @return all the matching wiki pages, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.wiki.model.WikiPage> getWikiPagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId);
+
+	/**
+	* Returns a range of wiki pages that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki pages
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of wiki pages
+	* @param end the upper bound of the range of wiki pages (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching wiki pages, or an empty list if no matches were found
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.wiki.model.WikiPage> getWikiPagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator);
 
 	/**
 	* Returns the number of wiki pages.

--- a/portal-service/src/com/liferay/portlet/wiki/service/WikiPageLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/wiki/service/WikiPageLocalServiceUtil.java
@@ -364,18 +364,6 @@ public class WikiPageLocalServiceUtil {
 	}
 
 	/**
-	* Returns the wiki page with the matching UUID and company.
-	*
-	* @param uuid the wiki page's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	*/
-	public static com.liferay.portlet.wiki.model.WikiPage fetchWikiPageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return getService().fetchWikiPageByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the wiki page matching the UUID and group.
 	*
 	* @param uuid the wiki page's UUID
@@ -674,20 +662,6 @@ public class WikiPageLocalServiceUtil {
 	}
 
 	/**
-	* Returns the wiki page with the matching UUID and company.
-	*
-	* @param uuid the wiki page's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki page
-	* @throws PortalException if a matching wiki page could not be found
-	*/
-	public static com.liferay.portlet.wiki.model.WikiPage getWikiPageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getWikiPageByUuidAndCompanyId(uuid, companyId);
-	}
-
-	/**
 	* Returns the wiki page matching the UUID and group.
 	*
 	* @param uuid the wiki page's UUID
@@ -715,6 +689,36 @@ public class WikiPageLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.wiki.model.WikiPage> getWikiPages(
 		int start, int end) {
 		return getService().getWikiPages(start, end);
+	}
+
+	/**
+	* Returns all the wiki pages that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki pages
+	* @param companyId the primary key of the company
+	* @return all the matching wiki pages, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.wiki.model.WikiPage> getWikiPagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return getService().getWikiPagesByUuidAndCompanyId(uuid, companyId);
+	}
+
+	/**
+	* Returns a range of wiki pages that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki pages
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of wiki pages
+	* @param end the upper bound of the range of wiki pages (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching wiki pages, or an empty list if no matches were found
+	*/
+	public static java.util.List<com.liferay.portlet.wiki.model.WikiPage> getWikiPagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return getService()
+				   .getWikiPagesByUuidAndCompanyId(uuid, companyId, start, end,
+			orderByComparator);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/wiki/service/WikiPageLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/wiki/service/WikiPageLocalServiceWrapper.java
@@ -384,20 +384,6 @@ public class WikiPageLocalServiceWrapper implements WikiPageLocalService,
 	}
 
 	/**
-	* Returns the wiki page with the matching UUID and company.
-	*
-	* @param uuid the wiki page's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki page, or <code>null</code> if a matching wiki page could not be found
-	*/
-	@Override
-	public com.liferay.portlet.wiki.model.WikiPage fetchWikiPageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId) {
-		return _wikiPageLocalService.fetchWikiPageByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the wiki page matching the UUID and group.
 	*
 	* @param uuid the wiki page's UUID
@@ -743,22 +729,6 @@ public class WikiPageLocalServiceWrapper implements WikiPageLocalService,
 	}
 
 	/**
-	* Returns the wiki page with the matching UUID and company.
-	*
-	* @param uuid the wiki page's UUID
-	* @param companyId the primary key of the company
-	* @return the matching wiki page
-	* @throws PortalException if a matching wiki page could not be found
-	*/
-	@Override
-	public com.liferay.portlet.wiki.model.WikiPage getWikiPageByUuidAndCompanyId(
-		java.lang.String uuid, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _wikiPageLocalService.getWikiPageByUuidAndCompanyId(uuid,
-			companyId);
-	}
-
-	/**
 	* Returns the wiki page matching the UUID and group.
 	*
 	* @param uuid the wiki page's UUID
@@ -788,6 +758,38 @@ public class WikiPageLocalServiceWrapper implements WikiPageLocalService,
 	public java.util.List<com.liferay.portlet.wiki.model.WikiPage> getWikiPages(
 		int start, int end) {
 		return _wikiPageLocalService.getWikiPages(start, end);
+	}
+
+	/**
+	* Returns all the wiki pages that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki pages
+	* @param companyId the primary key of the company
+	* @return all the matching wiki pages, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.wiki.model.WikiPage> getWikiPagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId) {
+		return _wikiPageLocalService.getWikiPagesByUuidAndCompanyId(uuid,
+			companyId);
+	}
+
+	/**
+	* Returns a range of wiki pages that match the UUID and company.
+	*
+	* @param uuid the UUID of the wiki pages
+	* @param companyId the primary key of the company
+	* @param start the lower bound of the range of wiki pages
+	* @param end the upper bound of the range of wiki pages (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return all the matching wiki pages, or an empty list if no matches were found
+	*/
+	@Override
+	public java.util.List<com.liferay.portlet.wiki.model.WikiPage> getWikiPagesByUuidAndCompanyId(
+		java.lang.String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator) {
+		return _wikiPageLocalService.getWikiPagesByUuidAndCompanyId(uuid,
+			companyId, start, end, orderByComparator);
 	}
 
 	/**


### PR DESCRIPTION
Hey Julio,

We have been working on a feature for staging but I've came across a part affecting the web contents, so I'm sending the pull request to you first.

A while ago I've created a method in the *ServiceBaseImpl classes called get/fetchXYByUuidAndCompanyId. The original purpose of this was to be able to fetch the entities like UserGroup or Organization easily during the staging process. But initially I was generated these methods based on if an entity has a uuid and a companyId. By doing so the service builder generated getters and fetchers for JournalArticle/JournalFolder/BookmarksEntry/etc as well. The problem with this is that the get/fetch method is returning a single value only. This is fine if the entity is not in a group but for the journal article we might have multiple articles with the same UUID in the same Company. For a UserGroup this won't happen, but for a JournalArticle it can happen. Since the implementation was missing any OrderByComparator we couldn't know if that's going to return a proper article.

So I've made a fix that makes this smarter. Now for entities like UserGroup it is generating the get/fetch methods as previously, but for grouped entities like JournalArticle it generates a methods which returns lists instead of a single value.

Now here comes your part actually, this was just the introduction :) As I generated the new methods, I was replacing the occurrences to the proper ones, and I've realized that we have duplicated logic for querying an article's layout, and I've reorganized the calls and pulled them into one single place to the JournalUtil, so now every place calls the same method, with the unified logic. Can you please review it? If you think it's good, you can push it to Brian, and I'll add some explanation for him as well.

Thanks,

Máté

cc: @danielkocsis
