### PR TITLE
LPS-48727 Refactoring calls in StagedModelDataHandlerUtil

### DIFF
--- a/portal-impl/test/portal-test.properties
+++ b/portal-impl/test/portal-test.properties
@@ -27,3 +27,5 @@ module.framework.base.dir=../bundles/osgi
 
 journal.transformer.regex.pattern.0=beta.sample.com
 journal.transformer.regex.replacement.0=production.sample.com
+
+scheduler.enabled=false

--- a/portal-service/src/com/liferay/portal/kernel/lar/ExportImportPathUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/ExportImportPathUtil.java
@@ -63,6 +63,13 @@ public class ExportImportPathUtil {
 	 */
 	public static final String PATH_PREFIX_SERVICE = "service";
 
+	public static String getCompanyModelPath(
+		long companyId, String className, long classPK) {
+
+		return getModelPath(
+			PATH_PREFIX_COMPANY, companyId, className, classPK, null);
+	}
+
 	/**
 	 * Returns the expando-specific path for the entity path. The entity path
 	 * must include an XML file.

--- a/portal-test-internal/src/com/liferay/portal/lar/BaseStagedModelDataHandlerTestCase.java
+++ b/portal-test-internal/src/com/liferay/portal/lar/BaseStagedModelDataHandlerTestCase.java
@@ -299,6 +299,8 @@ public abstract class BaseStagedModelDataHandlerTestCase {
 
 		portletDataContext.setImportDataRootElement(rootElement);
 
+		portletDataContext.setSourceCompanyId(stagingGroup.getCompanyId());
+
 		Group sourceCompanyGroup = GroupLocalServiceUtil.getCompanyGroup(
 			stagingGroup.getCompanyId());
 


### PR DESCRIPTION
Hey Julio,

This is quite a small change, but I'd like to give you some background details.

I've started to work on some refactoring for the StagedModelDataHandlers beneficial for the different component owners. I've been working on to make the import process automatically import the referenced entities - such as JournalFolder or DDMStructure for the JournalArticle - so the developer of the SMDH won't have to do it, this will remove lots of unnecessary code pieces, making the SMDH thinner and easier.

I already have a working prototype with fully green tests, but to push this properly I need some shuffling around with the different helper methods, some refactoring and stuff. This is the first batch in the series there will be more to come.

Thanks,

Máté
