### PR TITLE
LPS-49911 REGRESSION: Pages of type "Link to another page in the current site" does not work as expected

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/LayoutAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LayoutAction.java
@@ -180,22 +180,19 @@ public class LayoutAction extends Action {
 			return null;
 		}
 
-		long plid = 0;
-
-		Layout layout = themeDisplay.getLayout();
-
-		if (layout != null) {
-			plid = layout.getPlid();
-		}
-		else {
-			plid = ParamUtil.getLong(request, "p_l_id");
-		}
+		long plid = ParamUtil.getLong(request, "p_l_id");
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("p_l_id is " + plid);
 		}
 
 		if (plid > 0) {
+			Layout layout = themeDisplay.getLayout();
+
+			if (layout != null) {
+				plid = layout.getPlid();
+			}
+
 			ActionForward actionForward = processLayout(
 				actionMapping, request, response, plid);
 


### PR DESCRIPTION
Regression caused by LPS-46493.

For pages of type "Link to Page" the plid value is zero, but after LPS-46493 changes, plid is always setted with "layout.getPlid()".

Because this change, for that kind of pages, "processLayout" is executed instead "forwardLayout"
