### PR TITLE
LPS-48386 return the cached resource when the check-modified-date condit...

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
@@ -139,16 +139,6 @@ public class DynamicCSSUtil {
 
 		boolean themeCssFastLoad = _isThemeCssFastLoad(request, themeDisplay);
 
-		URLConnection resourceURLConnection = null;
-
-		if (PropsValues.THEME_CSS_FAST_LOAD_CHECK_MODIFIED_DATE) {
-			URL resourceURL = servletContext.getResource(resourcePath);
-
-			if (resourceURL != null) {
-				resourceURLConnection = resourceURL.openConnection();
-			}
-		}
-
 		URLConnection cacheResourceURLConnection = null;
 
 		URL cacheResourceURL = _getCacheResourceURL(
@@ -156,13 +146,24 @@ public class DynamicCSSUtil {
 
 		if (cacheResourceURL != null) {
 			cacheResourceURLConnection = cacheResourceURL.openConnection();
+
+			if (PropsValues.THEME_CSS_FAST_LOAD_CHECK_MODIFIED_DATE) {
+				URL resourceURL = servletContext.getResource(resourcePath);
+
+				if (resourceURL != null) {
+					URLConnection resourceURLConnection =
+						resourceURL.openConnection();
+
+					if (cacheResourceURLConnection.getLastModified() <
+							resourceURLConnection.getLastModified()) {
+						cacheResourceURLConnection = null;
+					}
+				}
+			}
 		}
 
 		if ((themeCssFastLoad || !content.contains(_CSS_IMPORT_BEGIN)) &&
-			(cacheResourceURLConnection != null) &&
-			(resourceURLConnection != null) &&
-			(cacheResourceURLConnection.getLastModified() >=
-				resourceURLConnection.getLastModified())) {
+			(cacheResourceURLConnection != null)) {
 
 			parsedContent = StringUtil.read(
 				cacheResourceURLConnection.getInputStream());


### PR DESCRIPTION
Taking a look into the original description of the issue, the condition fails in some cases and the resource is ever parsed, so the propouse of this property is bypass this condition an use the cached resource.

We need to add a commit similar to this. Please, let me know if you have any doubt. Thanks Julio!
