### PR TITLE
LPS-48386-simpler-fix

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
@@ -147,7 +147,7 @@ public class DynamicCSSUtil {
 		if (cacheResourceURL != null) {
 			cacheResourceURLConnection = cacheResourceURL.openConnection();
 
-			if (PropsValues.THEME_CSS_FAST_LOAD_CHECK_MODIFIED_DATE) {
+			if (!themeCssFastLoad) {
 				URL resourceURL = servletContext.getResource(resourcePath);
 
 				if (resourceURL != null) {

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1782,8 +1782,6 @@ public class PropsValues {
 
 	public static boolean THEME_CSS_FAST_LOAD = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.THEME_CSS_FAST_LOAD));
 
-	public static boolean THEME_CSS_FAST_LOAD_CHECK_MODIFIED_DATE = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.THEME_CSS_FAST_LOAD_CHECK_MODIFIED_DATE));
-
 	public static boolean THEME_CSS_FAST_LOAD_CHECK_REQUEST_PARAMETER = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.THEME_CSS_FAST_LOAD_CHECK_REQUEST_PARAMETER));
 
 	public static boolean THEME_IMAGES_FAST_LOAD = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.THEME_IMAGES_FAST_LOAD));

--- a/portal-impl/src/portal-developer.properties
+++ b/portal-impl/src/portal-developer.properties
@@ -1,5 +1,4 @@
 theme.css.fast.load=false
-theme.css.fast.load.check.modified.date=true
 theme.css.fast.load.check.request.parameter=true
 theme.images.fast.load=false
 theme.images.fast.load.check.request.parameter=true

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -651,12 +651,6 @@
     theme.css.fast.load=true
 
     #
-    # Set this property to true to check the modified date of the CSS file in
-    # order to parse it when it is more recent than the cached CSS file.
-    #
-    theme.css.fast.load.check.modified.date=false
-
-    #
     # Set this property to false to ignore the URL parameter "css_fast_load".
     # See the property "theme.css.fast.load".
     #

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2541,8 +2541,6 @@ public interface PropsKeys {
 
 	public static final String THEME_CSS_FAST_LOAD = "theme.css.fast.load";
 
-	public static final String THEME_CSS_FAST_LOAD_CHECK_MODIFIED_DATE = "theme.css.fast.load.check.modified.date";
-
 	public static final String THEME_CSS_FAST_LOAD_CHECK_REQUEST_PARAMETER = "theme.css.fast.load.check.request.parameter";
 
 	public static final String THEME_IMAGES_FAST_LOAD = "theme.images.fast.load";


### PR DESCRIPTION
After a conversation with Nate, we should infer if we need the comparison of dates from the themeCssFastLoad value.

Taking in account the original issue, the date comparison for plugins only could fail if the developer assumes an slow load but there is a mechanism to avoid it in production.

cc/ @natecavanaugh
