### PR TITLE
LPS-51116

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/action/EditGroupAction.java
+++ b/portal-impl/src/com/liferay/portlet/sites/action/EditGroupAction.java
@@ -709,9 +709,7 @@ public class EditGroupAction extends PortletAction {
 		typeSettingsProperties.setProperty("true-robots.txt", privateRobots);
 
 		boolean trashEnabled = ParamUtil.getBoolean(
-			actionRequest, "trashEnabled",
-			GetterUtil.getBoolean(
-				typeSettingsProperties.getProperty("trashEnabled"), true));
+			actionRequest, "trashEnabled", false);
 
 		typeSettingsProperties.setProperty(
 			"trashEnabled", String.valueOf(trashEnabled));


### PR DESCRIPTION
This is an update for [LPS-51116](https://issues.liferay.com/browse/LPS-51116).<br><br>

Hey Chema!  This issue is showing up in many places around portal now that there are no hidden inputs for the aui:input checkbox.  The server is often assuming that there will be some sort of data for each input, and therefore either defaults to true for a "false" (missing) checkbox field or simply doesn't update the database at all, as is the case with [LPS-51034](https://issues.liferay.com/browse/LPS-51034).  There, it simply [enters properties into the database](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L1110-L1131), overwriting what's there and leaving what wasn't submitted.

Any thoughts on a fix for this?  Seems like it needs to be on a case-by-case basis for each action.
