### PR TITLE
LPS-44761 We should show only web content on the current site

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/search/ArticleDisplayTerms.java
+++ b/portal-impl/src/com/liferay/portlet/journal/search/ArticleDisplayTerms.java
@@ -186,44 +186,6 @@ public class ArticleDisplayTerms extends DisplayTerms {
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (Validator.isNotNull(ddmStructureKey) &&
-			!ddmStructureKey.equals("0")) {
-
-			DDMStructure ddmStructure = null;
-
-			try {
-				ddmStructure = DDMStructureLocalServiceUtil.fetchStructure(
-					themeDisplay.getSiteGroupId(),
-					PortalUtil.getClassNameId(JournalArticle.class),
-					ddmStructureKey);
-			}
-			catch (SystemException se) {
-			}
-
-			if (ddmStructure != null) {
-				return 0;
-			}
-		}
-
-		if (Validator.isNotNull(ddmTemplateKey) &&
-			!ddmTemplateKey.equals("0")) {
-
-			DDMTemplate ddmTemplate = null;
-
-			try {
-				ddmTemplate = DDMTemplateLocalServiceUtil.fetchTemplate(
-					themeDisplay.getSiteGroupId(),
-					PortalUtil.getClassNameId(JournalArticle.class),
-					ddmTemplateKey);
-			}
-			catch (SystemException se) {
-			}
-
-			if (ddmTemplate != null) {
-				return 0;
-			}
-		}
-
 		return themeDisplay.getScopeGroupId();
 	}
 


### PR DESCRIPTION
Hi guys,

The way of filtering by Structure will work is the following:

If I filter by a global structure in the global scope --> Only the articles in the global scope using this structure will be shown
If I filter by a global structure in a site --> Only the articles from this site using this structure will be shown
If I filter by a site structure in its site --> Only the articles from the site using this structure will be shown
If I filter by a site structure in a subscope --> Only the articles from this scope will be shown

So, we only filter by structure the articles in the current scope.

Cheers,
Eudaldo.
