### PR TITLE
LPS-51344

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetEntryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetEntryPersistenceImpl.java
@@ -3763,6 +3763,7 @@ public class AssetEntryPersistenceImpl extends BasePersistenceImpl<AssetEntry>
 	public AssetEntry create(long entryId) {
 		AssetEntry assetEntry = new AssetEntryImpl();
 
+		assetEntry.setListable(true);
 		assetEntry.setNew(true);
 		assetEntry.setPrimaryKey(entryId);
 

--- a/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherImpl.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherImpl.java
@@ -751,7 +751,6 @@ public class AssetPublisherImpl implements AssetPublisher {
 
 		assetEntryQuery.setAnyTagIds(anyAssetTagIds);
 
-		assetEntryQuery.setListable(true);
 		assetEntryQuery.setNotAllCategoryIds(notAllAssetCategoryIds);
 
 		for (String assetTagName : notAllAssetTagNames) {

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/AssetEntryQueryTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/AssetEntryQueryTest.java
@@ -575,7 +575,6 @@ public class AssetEntryQueryTest {
 		}
 
 		assetEntryQuery.setGroupIds(new long[] {groupId});
-		assetEntryQuery.setListable(true);
 
 		return assetEntryQuery;
 	}
@@ -589,7 +588,6 @@ public class AssetEntryQueryTest {
 		assetEntryQuery.setAndOperator(andOperator);
 		assetEntryQuery.setDescription(description);
 		assetEntryQuery.setGroupIds(new long[] {groupId});
-		assetEntryQuery.setListable(true);
 		assetEntryQuery.setTitle(title);
 		assetEntryQuery.setUserName(userName);
 
@@ -643,7 +641,6 @@ public class AssetEntryQueryTest {
 
 		assetEntryQuery.setGroupIds(new long[] {groupId});
 		assetEntryQuery.setKeywords(keywords);
-		assetEntryQuery.setListable(true);
 
 		return assetEntryQuery;
 	}

--- a/portal-service/src/com/liferay/portlet/asset/service/persistence/AssetEntryQuery.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/persistence/AssetEntryQuery.java
@@ -707,7 +707,7 @@ public class AssetEntryQuery {
 	private String _keywords;
 	private Layout _layout;
 	private long _linkedAssetEntryId = 0;
-	private boolean _listable;
+	private boolean _listable = true;
 	private long[] _notAllCategoryIds = new long[0];
 	private long[] _notAllTagIds = new long[0];
 	private long[][] _notAllTagIdsArray = new long[0][];


### PR DESCRIPTION
Hey Julio, this relates to the email thread we had the other day... I think this is necessary for the fix because i did some testing and found a regression with filtering by the tags navigation portlet; some entries were not being found by the AssetEntryQuery because listable was not being set to true in the query. so because this is a new field, i think it makes sense to always set listable to true for every asset by default (then update to false when necessary), and always search for listable assets. i think that doing this will prevent us from affecting the previous behavior. let me know if you have questions. thanks!