### PR TITLE
[TECHICAL-SUPPORT] LPS-52587 Asset Publisher scoped to several sites: cannot select all of the categories

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1858,6 +1858,23 @@ public class PortalImpl implements Portal {
 	}
 
 	@Override
+	public long[] getCurrentAndAncestorSiteGroupIds(long[] groupIds)
+		throws PortalException {
+
+		List<Group> groups = getCurrentAndAncestorSiteGroups(groupIds);
+
+		long[] currentAndAncestorSiteGroupIds = new long[groups.size()];
+
+		for (int i = 0; i < groups.size(); i++) {
+			Group group = groups.get(i);
+
+			currentAndAncestorSiteGroupIds[i] = group.getGroupId();
+		}
+
+		return currentAndAncestorSiteGroupIds;
+	}
+
+	@Override
 	public List<Group> getCurrentAndAncestorSiteGroups(long groupId)
 		throws PortalException {
 
@@ -1870,6 +1887,19 @@ public class PortalImpl implements Portal {
 		}
 
 		groups.addAll(doGetAncestorSiteGroups(groupId, false));
+
+		return new ArrayList<Group>(groups);
+	}
+
+	@Override
+	public List<Group> getCurrentAndAncestorSiteGroups(long[] groupIds)
+		throws PortalException {
+
+		Set<Group> groups = new LinkedHashSet<Group>();
+
+		for (int i = 0; i < groupIds.length; i++) {
+			groups.addAll(getCurrentAndAncestorSiteGroups(groupIds[i]));
+		}
 
 		return new ArrayList<Group>(groups);
 	}

--- a/portal-service/src/com/liferay/portal/util/Portal.java
+++ b/portal-service/src/com/liferay/portal/util/Portal.java
@@ -537,7 +537,13 @@ public interface Portal {
 	public long[] getCurrentAndAncestorSiteGroupIds(long groupId)
 		throws PortalException;
 
+	public long[] getCurrentAndAncestorSiteGroupIds(long[] groupIds)
+		throws PortalException;
+
 	public List<Group> getCurrentAndAncestorSiteGroups(long groupId)
+		throws PortalException;
+
+	public List<Group> getCurrentAndAncestorSiteGroups(long[] groupIds)
 		throws PortalException;
 
 	public String getCurrentCompleteURL(HttpServletRequest request);

--- a/portal-service/src/com/liferay/portal/util/PortalUtil.java
+++ b/portal-service/src/com/liferay/portal/util/PortalUtil.java
@@ -711,10 +711,22 @@ public class PortalUtil {
 		return getPortal().getCurrentAndAncestorSiteGroupIds(groupId);
 	}
 
+	public static long[] getCurrentAndAncestorSiteGroupIds(long[] groupIds)
+		throws PortalException {
+
+		return getPortal().getCurrentAndAncestorSiteGroupIds(groupIds);
+	}
+
 	public static List<Group> getCurrentAndAncestorSiteGroups(long groupId)
 		throws PortalException {
 
 		return getPortal().getCurrentAndAncestorSiteGroups(groupId);
+	}
+
+	public static List<Group> getCurrentAndAncestorSiteGroups(long[] groupIds)
+		throws PortalException {
+
+		return getPortal().getCurrentAndAncestorSiteGroups(groupIds);
 	}
 
 	public static String getCurrentCompleteURL(HttpServletRequest request) {

--- a/portal-web/docroot/html/portlet/asset_publisher/edit_query_rule.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/edit_query_rule.jsp
@@ -70,6 +70,7 @@ if (queryLogicIndex >= 0) {
 	<div class="categories-selector field <%= Validator.equals(queryName, "assetCategories") ? StringPool.BLANK : "hide" %>">
 		<liferay-ui:asset-categories-selector
 			curCategoryIds='<%= Validator.equals(queryName, "assetCategories") ? queryValues : null %>'
+			groupIds="<%= categorizableGroupIds %>"
 			hiddenInput='<%= "queryCategoryIds" + index %>'
 		/>
 	</div>

--- a/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
@@ -22,12 +22,18 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_asset_
 String className = (String)request.getAttribute("liferay-ui:asset-categories-selector:className");
 long classPK = GetterUtil.getLong((String)request.getAttribute("liferay-ui:asset-categories-selector:classPK"));
 long classTypePK = GetterUtil.getLong((String)request.getAttribute("liferay-ui:asset-categories-selector:classTypePK"));
+long[] groupIds = (long[])request.getAttribute("liferay-ui:asset-categories-selector:groupIds");
 String hiddenInput = (String)request.getAttribute("liferay-ui:asset-categories-selector:hiddenInput");
 String curCategoryIds = GetterUtil.getString((String)request.getAttribute("liferay-ui:asset-categories-selector:curCategoryIds"), "");
 String curCategoryNames = StringPool.BLANK;
 int maxEntries = GetterUtil.getInteger(PropsUtil.get(PropsKeys.ASSET_CATEGORIES_SELECTOR_MAX_ENTRIES));
 
-long[] groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(scopeGroupId);
+if (ArrayUtil.isEmpty(groupIds)) {
+	groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(scopeGroupId);
+}
+else {
+	groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds);
+}
 
 List<AssetVocabulary> vocabularies = AssetVocabularyServiceUtil.getGroupVocabularies(groupIds);
 

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -436,6 +436,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>groupIds</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>hiddenInput</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/com/liferay/taglib/ui/AssetCategoriesSelectorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/AssetCategoriesSelectorTag.java
@@ -45,6 +45,10 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 		_curCategoryIds = curCategoryIds;
 	}
 
+	public void setGroupIds(long[] groupIds) {
+		_groupIds = groupIds;
+	}
+
 	public void setHiddenInput(String hiddenInput) {
 		_hiddenInput = hiddenInput;
 	}
@@ -56,6 +60,7 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 		_classTypePK = AssetCategoryConstants.ALL_CLASS_TYPE_PK;
 		_contentCallback = null;
 		_curCategoryIds = null;
+		_groupIds = null;
 		_hiddenInput = "assetCategoryIds";
 	}
 
@@ -81,6 +86,8 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 			"liferay-ui:asset-categories-selector:curCategoryIds",
 			_curCategoryIds);
 		request.setAttribute(
+			"liferay-ui:asset-categories-selector:groupIds", _groupIds);
+		request.setAttribute(
 			"liferay-ui:asset-categories-selector:hiddenInput", _hiddenInput);
 	}
 
@@ -92,6 +99,7 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 	private long _classTypePK = AssetCategoryConstants.ALL_CLASS_TYPE_PK;
 	private String _contentCallback;
 	private String _curCategoryIds;
+	private long[] _groupIds;
 	private String _hiddenInput = "assetCategoryIds";
 
 }


### PR DESCRIPTION
Hi Julio,

this fix will allow users to select categories from all of the scope groups.

It leads to some interesting questions though:

When we configure the AP to **"Contains all of the following Categories"**, if we add a new entry using the AP, the categories will be automatically added to the entry.

As from now on we can select categories from other Sites as well, what should happen?

I think only those categories should be added to the entry, where the groupId is the same as the new entry's groupId (ancestor's are considered.)

Actually this is what happens without any modifications:

Event though the add entry URL's will contain all the VocabularyId/CategoryId pairs as parameter ( See: **AssetUtil.java getAddPortletURL** method) only those vocabularies will be considered which are in the entry's (or it's ancestors) group . (**asset_categories_selector/page.jsp**).

**Tags are working differently:**

If we select a tag from another Site, the tag is copied to the actual Site where the AP is.
(**AssetTagLocalServiceImpl checkTags**)

It looks a bit weird to me, shouldn't we use global tags if we want to use the same tag in different Sites?
Actually global tags are copied to the Sites as well, so I'm not sure whether it's a bug or not.

However, this will result a different behavior, if we use the  **"Contains all of the following Tags"** filter, the new entries will really contain all the selected tags (actually the copied tags).




Similar inconsistency exists between **categories and tags navigation**.

The **Categories navigation portlet** displays only the categories from the current Site and it's ancestors.
However, as the tags are copied the **Tags's navigation portlet** will display tags which were copied from other Sites as well.

I tend to think that in both cases, the way the categories are working is the expected.

What do you think?

Thanks,
Tamás