### PR TITLE
LPS-50580 Uploaded documents links in Social Office Activities portlet returns user to the home page if the site was originally an upgraded 6.1 EE GA2 site

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradePortletPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradePortletPreferences.java
@@ -58,7 +58,8 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 			sb.append("PortletPreferences.portletId, Layout.typeSettings ");
 			sb.append("from PortletPreferences inner join Layout on ");
 			sb.append("PortletPreferences.plid = Layout.plid where ");
-			sb.append("preferences like '%<portlet-preferences />%'");
+			sb.append("preferences like '%<portlet-preferences />%' ");
+			sb.append("or preferences = ''");
 
 			String sql = sb.toString();
 


### PR DESCRIPTION
Hey Sergio,

Could you please check this pull request?

The fix deletes empty (blank string in preferences DB column) portlet preferences which are corrupting the navigation between layouts.
These preferences are generated in 6.1.20 when creating an SO Page, and are retained after upgrading from 6.1.20 to 6.2 but practically they have no use.

Best regards,
István