### PR TITLE
LPS-52683 Switch component markup

### DIFF
--- a/portal-web/docroot/html/taglib/aui/input/init-ext.jspf
+++ b/portal-web/docroot/html/taglib/aui/input/init-ext.jspf
@@ -37,7 +37,7 @@ else if (Validator.isNotNull(title)) {
 	title = LanguageUtil.get(request, title);
 }
 
-boolean checkboxField = baseType.equals("checkbox") || baseType.equals("boolean");
+boolean checkboxField = baseType.equals("checkbox") || baseType.equals("boolean") || type.equals("switch");
 boolean radioField = baseType.equals("radio");
 
 boolean showForLabel = true;
@@ -63,6 +63,10 @@ String fieldCssClass = AUIUtil.buildCss(AUIUtil.FIELD_PREFIX, disabled, first, l
 
 if (baseType.equals("email") || baseType.equals("password") || baseType.equals("text") || baseType.equals("textarea")) {
 	fieldCssClass += " form-control";
+}
+
+if (type.equals("switch")) {
+	fieldCssClass += " switch";
 }
 
 boolean useInputWrapper = true;

--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -40,7 +40,7 @@
 boolean choiceField = checkboxField || radioField;
 %>
 
-<c:if test='<%= !type.equals("assetCategories") && !type.equals("hidden") && Validator.isNotNull(label) %>'>
+<c:if test='<%= !type.equals("assetCategories") && !type.equals("hidden") && !type.equals("switch") && Validator.isNotNull(label) %>'>
 	<label <%= labelTag %>>
 		<c:if test='<%= !choiceField && !inlineLabel.equals("right") %>'>
 				<%= labelContent %>
@@ -93,7 +93,7 @@ boolean choiceField = checkboxField || radioField;
 			placeholder="<%= placeholder %>"
 		/>
 	</c:when>
-	<c:when test='<%= type.equals("checkbox") %>'>
+	<c:when test='<%= type.equals("checkbox") || type.equals("switch") %>'>
 
 		<%
 		String valueString = null;
@@ -121,6 +121,41 @@ boolean choiceField = checkboxField || radioField;
 		%>
 
 		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" name="<%= namespace + name %>" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> onClick="<%= onClick %>" <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(locale, title) + "\"" : StringPool.BLANK %> type="checkbox" <%= Validator.isNotNull(valueString) ? ("value=\"" + HtmlUtil.escapeAttribute(valueString)) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+
+		<c:if test='<%= type.equals("switch") %>'>
+			<%
+			String iconOn = (String)dynamicAttributes.get("iconOn");
+			String iconOff = (String)dynamicAttributes.get("iconOff");
+			String labelOn = (String)dynamicAttributes.get("labelOn");
+			String labelOff = (String)dynamicAttributes.get("labelOff");
+			String buttonIconOn = (String)dynamicAttributes.get("buttonIconOn");
+			String buttonIconOff = (String)dynamicAttributes.get("buttonIconOff");
+			%>
+
+			<label <%= labelTag %>>
+				<span class="label-on"><%= (Validator.isNotNull(labelOn) ? labelOn : "&nbsp") %></span>
+
+				<c:if test="<%= Validator.isNotNull(labelOff) %>">
+					<span class="label-off"><%= labelOff %></span>
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(buttonIconOn) %>">
+					<span class="button-icon <%= Validator.isNotNull(buttonIconOff) ? "button-icon-on" : StringPool.BLANK %> switch-icon <%= buttonIconOn %>"></span>
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(buttonIconOff) %>">
+					<span class="button-icon button-icon-off switch-icon <%= buttonIconOff %>"></span>
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(iconOn) %>">
+					<span class="switch-icon switch-icon-on <%= iconOn %>"></span>
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(iconOff) %>">
+					<span class="switch-icon switch-icon-off <%= iconOff %>"></span>
+				</c:if>
+			</label>
+		</c:if>
 	</c:when>
 	<c:when test='<%= type.equals("radio") %>'>
 
@@ -268,7 +303,7 @@ boolean choiceField = checkboxField || radioField;
 	</div>
 </c:if>
 
-<c:if test='<%= !type.equals("assetCategories") && !type.equals("hidden") && Validator.isNotNull(label) %>'>
+<c:if test='<%= !type.equals("assetCategories") && !type.equals("hidden") && !type.equals("switch") && Validator.isNotNull(label) %>'>
 	<c:if test='<%= choiceField || inlineLabel.equals("right") %>'>
 			<%= labelContent %>
 		</label>

--- a/portal-web/docroot/html/themes/_styled/css/application.css
+++ b/portal-web/docroot/html/themes/_styled/css/application.css
@@ -269,6 +269,106 @@
 	padding: 1px;
 }
 
+/* ---------- Switches ---------- */
+
+input.switch {
+	font-size: 62.5%;
+	margin-left: -999em;
+
+	&:empty ~ label {
+		cursor: pointer;
+		float: left;
+		font-size: 1.2rem;
+		line-height: 2.6rem;
+		position: relative;
+		text-indent: 5rem;
+
+		&:after, &:before {
+			background-color: #DDD;
+			bottom: 0;
+			content: ' ';
+			display: block;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 4.4rem;
+		}
+
+		&:after {
+			background-color: #FFF;
+			bottom: 0.4rem;
+			left: 0.4rem;
+			top: 0.4rem;
+			width: 1.8rem;
+		}
+
+		.switch-icon {
+			color: #FFF;
+			font-size: 1.4rem;
+			left: 0.4rem;
+			line-height: 1.8rem;
+			position: absolute;
+			text-align: center;
+			text-indent: 0;
+			top: 0.4rem;
+			width: 1.8rem;
+			z-index: 1;
+
+			&.button-icon-on {
+				display: block;
+			}
+
+			&.button-icon-off {
+				display: none;
+			}
+		}
+
+		.button-icon {
+			color: #DDD;
+		}
+
+		.switch-icon-on {
+			left: 0.2rem;
+		}
+
+		.switch-icon-off {
+			left: 2.4rem;
+		}
+
+		.label-off {
+			left: 0;
+			position: absolute;
+			top: 0;
+		}
+	}
+
+	&:checked ~ label {
+		&:after {
+			left: 2.2rem;
+		}
+
+		&:before {
+			background-color: #1E9C38;
+		}
+
+		.button-icon {
+			left: 2.2rem;
+
+			&.button-icon-on {
+				display: none;
+			}
+
+			&.button-icon-off {
+				display: block;
+			}
+		}
+	}
+
+	&:disabled ~ label {
+		cursor: auto;
+	}
+}
+
 /* ---------- Miscellaneous ---------- */
 
 .hsv-palette {

--- a/portal-web/docroot/html/themes/_styled/css/extras.css
+++ b/portal-web/docroot/html/themes/_styled/css/extras.css
@@ -589,3 +589,37 @@ body:first-of-type {
 		@include border-radius(0);
 	}
 }
+
+/* ---------- Switches ---------- */
+
+input.switch {
+	&:focus ~ label:before {
+		@include box-shadow(0 0 3px #00F);
+	}
+
+	&:empty ~ label {
+		@include user-select(none);
+
+		&:after, &:before, .label-on, .label-off, .switch-icon {
+			@include transition(all 100ms ease-in);
+		}
+
+		.label-on, .switch-icon-on {
+			@include opacity(0);
+		}
+	}
+
+	&:checked ~ label {
+		.label-on, .switch-icon-on {
+			@include opacity(1);
+		}
+
+		.label-off, .switch-icon-off {
+			@include opacity(0);
+		}
+	}
+
+	&:disabled ~ label {
+		@include opacity(0.4);
+	}
+}

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
@@ -678,6 +678,38 @@ select:focus {
 	}
 }
 
+/* ---------- Switches ---------- */
+
+input.switch {
+	&:empty ~ label {
+		&:before {
+			background-color: #868B96;
+		}
+
+		.label-on, .label-off {
+			font-weight: 500;
+		}
+
+		.label-on {
+			color: #34ADAB;
+		}
+
+		.button-icon {
+			color: #868B96;
+		}
+	}
+
+	&:checked ~ label {
+		&:before {
+			background-color: #34ADAB;
+		}
+
+		.button-icon {
+			color: #34ADAB;
+		}
+	}
+}
+
 /* ---------- Hidden accessible ---------- */
 
 #banner h2, #banner h3, .site-breadcrumbs h1 {


### PR DESCRIPTION
Hey, @juliocamarero 

This adds a new `aui:input` type __switch__ as a special case of __checkbox__.

You can apply [this ADT](https://issues.liferay.com/secure/attachment/121602/switch_gallery_adt.txt) to an AssetPublisher to see all the expected use cases together. (Needs to be sent to @natecavanaugh)

This is how it should look like in *_styled* and *classic* themes:

![screen shot 2015-01-16 at 09 26 41](https://cloud.githubusercontent.com/assets/905006/5773351/d2882e64-9d61-11e4-8dcb-a2f872f33f21.png)
![screen shot 2015-01-16 at 09 26 06](https://cloud.githubusercontent.com/assets/905006/5773344/bc6db860-9d61-11e4-856b-68807e1a32e8.png)

/cc @ipeychev