### PR TITLE
LPS-53391 Fix wrong preference name

### DIFF
--- a/modules/apps/journal/journal-content-web/src/com/liferay/journal/content/web/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/com/liferay/journal/content/web/context/JournalContentDisplayContext.java
@@ -128,16 +128,12 @@ public class JournalContentDisplayContext {
 			return _articleGroupId;
 		}
 
-		_articleGroupId = ParamUtil.getLong(_request, "articleGroupId");
+		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
+			WebKeys.THEME_DISPLAY);
 
-		if (_articleGroupId <= 0) {
-			ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-			_articleGroupId = GetterUtil.getLong(
-				_portletPreferences.getValue(
-					"groupId", String.valueOf(themeDisplay.getScopeGroupId())));
-		}
+		_articleGroupId = PrefsParamUtil.getLong(
+			_portletPreferences, _request, "groupId",
+			themeDisplay.getScopeGroupId());
 
 		return _articleGroupId;
 	}

--- a/modules/apps/journal/journal-content-web/src/com/liferay/journal/content/web/portlet/JournalContentPortlet.java
+++ b/modules/apps/journal/journal-content-web/src/com/liferay/journal/content/web/portlet/JournalContentPortlet.java
@@ -92,8 +92,7 @@ public class JournalContentPortlet extends MVCPortlet {
 		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		long articleGroupId = ParamUtil.getLong(
-			renderRequest, "articleGroupId");
+		long articleGroupId = ParamUtil.getLong(renderRequest, "groupId");
 
 		if (articleGroupId <= 0) {
 			articleGroupId = GetterUtil.getLong(

--- a/modules/apps/journal/journal-content-web/src/com/liferay/journal/content/web/portlet/action/JournalContentConfigurationAction.java
+++ b/modules/apps/journal/journal-content-web/src/com/liferay/journal/content/web/portlet/action/JournalContentConfigurationAction.java
@@ -63,8 +63,7 @@ public class JournalContentConfigurationAction
 
 		long articleGroupId = getArticleGroupId(actionRequest);
 
-		setPreference(
-			actionRequest, "articleGroupId", String.valueOf(articleGroupId));
+		setPreference(actionRequest, "groupId", String.valueOf(articleGroupId));
 
 		super.processAction(portletConfig, actionRequest, actionResponse);
 	}


### PR DESCRIPTION
The preference name was changed only partially from groupId to articleGroupId, causing the export/import logic (at least) to fail. Moving back to groupId.

@ealonso