### PR TITLE
[TECHNICAL-SUPPORT] LPS-53762 Hide permission view when Web Content Structure's default values are edited

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -10184,7 +10184,7 @@
     # Input a list of sections that will be included as part of the article form
     # when defining the default values of a structure.
     #
-    journal.article.form.default.values=content,small-image,categorization,display-page,related-assets,permissions,custom-fields
+    journal.article.form.default.values=content,small-image,categorization,display-page,related-assets,custom-fields
 
     #
     # Input a list of sections that will be included as part of the article form

--- a/portal-web/docroot/html/portlet/journal/article_toolbar.jsp
+++ b/portal-web/docroot/html/portlet/journal/article_toolbar.jsp
@@ -30,7 +30,7 @@ long classNameId = BeanParamUtil.getLong(article, request, "classNameId");
 			<aui:button data-title='<%= LanguageUtil.get(request, "in-order-to-preview-your-changes,-the-web-content-is-saved-as-a-draft") %>' icon="icon-search" name="basicPreviewButton" value="basic-preview" />
 		</c:if>
 
-		<c:if test="<%= JournalArticlePermission.contains(permissionChecker, article, ActionKeys.PERMISSIONS) %>">
+		<c:if test="<%= JournalArticlePermission.contains(permissionChecker, article, ActionKeys.PERMISSIONS) && (classNameId == JournalArticleConstants.CLASSNAME_ID_DEFAULT) %>">
 			<aui:button icon="icon-lock" name="articlePermissionsButton" value="permissions" />
 		</c:if>
 


### PR DESCRIPTION
Hey Julio,

one of our customer has reported the problem, that the permissions are not inherited to the articles from the default article.

I don't think it should work, even copying an article doesn't copy the permissions.

As the permission view could be misleading, I decided to remove it. 
Furthermore it seems weird to me to be able to add e.g. **Add Discussion** permission to a default article.

Could you please review my changes?

Thanks,
Tamás