### PR TITLE
[TECHNICAL-SUPPORT] LPS-54559 IFrame portlet - preference name changes aren't handled by the upgradeprocess

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_1_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_1_0.java
@@ -25,6 +25,7 @@ import com.liferay.portal.upgrade.v6_1_0.UpgradeCountry;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeDocumentLibrary;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeExpando;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeGroup;
+import com.liferay.portal.upgrade.v6_1_0.UpgradeIFrame;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeImageGallery;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeJournal;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeLayout;
@@ -66,6 +67,7 @@ public class UpgradeProcess_6_1_0 extends UpgradeProcess {
 		upgrade(UpgradeExpando.class);
 		upgrade(UpgradeGroup.class);
 		upgrade(UpgradeImageGallery.class);
+		upgrade(UpgradeIFrame.class);
 		upgrade(UpgradeJournal.class);
 		upgrade(UpgradeLayout.class);
 		upgrade(UpgradeLock.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeIFrame.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeIFrame.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v6_1_0;
+
+import com.liferay.portal.kernel.upgrade.BaseUpgradePortletPreferences;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portlet.PortletPreferencesFactoryUtil;
+
+import javax.portlet.PortletPreferences;
+
+/**
+ * @author Tamas Molnar
+ */
+public class UpgradeIFrame extends BaseUpgradePortletPreferences {
+
+	@Override
+	protected String[] getPortletIds() {
+		return new String[] {"48_INSTANCE_%"};
+	}
+
+	protected void upgradePassword(PortletPreferences portletPreferences)
+		throws Exception {
+
+		String password = GetterUtil.getString(
+			portletPreferences.getValue("password", null));
+
+		if (Validator.isNotNull(password)) {
+			portletPreferences.setValue("formPassword", password);
+		}
+
+		portletPreferences.reset("password");
+	}
+
+	@Override
+	protected String upgradePreferences(
+			long companyId, long ownerId, int ownerType, long plid,
+			String portletId, String xml)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			PortletPreferencesFactoryUtil.fromXML(
+				companyId, ownerId, ownerType, plid, portletId, xml);
+
+		upgradePassword(portletPreferences);
+		upgradeUserName(portletPreferences);
+
+		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+	}
+
+	protected void upgradeUserName(PortletPreferences portletPreferences)
+		throws Exception {
+
+		String userName = GetterUtil.getString(
+			portletPreferences.getValue("userName", null));
+
+		if (Validator.isNull(userName)) {
+			userName = GetterUtil.getString(
+				portletPreferences.getValue("user-name", null));
+		}
+
+		if (Validator.isNotNull(userName)) {
+			portletPreferences.setValue("formUserName", userName);
+		}
+
+		portletPreferences.reset("userName");
+		portletPreferences.reset("user-name");
+	}
+
+}


### PR DESCRIPTION
Hi Julio,

LPS-14468 changed two preference names in the IFrame portlet which currently aren't handled by the upgrade process.

I put some fallback logic for the **user-name** preference, as the upgrade process converts is to CamelCase anyway.

I think it's worth trying to find the value with **user-name** and **userName** as well, so the order of the upgrade processes doesn't matter.

Thanks,
Tamás