### PR TITLE
LPS-55979 Selecting the "Navigation" display template for RSS breaks other button functionality

### DIFF
--- a/modules/apps/rss/rss-web/src/com/liferay/rss/web/configuration/RSSPortletInstanceConfiguration.java
+++ b/modules/apps/rss/rss-web/src/com/liferay/rss/web/configuration/RSSPortletInstanceConfiguration.java
@@ -63,7 +63,7 @@ public interface RSSPortletInstanceConfiguration {
 	public String[] titles();
 
 	@Meta.AD(
-		deflt = "http://www.liferay.com/community/blogs/-/blogs_stream/community/rss|http://partners.userland.com/nytRss/technology.xml",
+		deflt = "http://partners.userland.com/nytRss/technology.xml",
 		required = false
 	)
 	public String[] urls();


### PR DESCRIPTION
The real problem lies in the RSS feeds that are obtained. When there is a corrupt feed, ie. with truncated html elements, the javascript that is being when rendering the tab container for the template throws an error. The error in the RSS feed happens because it is generated in an old version of LR portal.

Until the javascript is fixed, we remove the feed that is causing the error