### PR TITLE
LPS-55924 Avoid equal comparisons for CLOBs and checking null values for Oracle

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradePortletPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradePortletPreferences.java
@@ -59,7 +59,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 			sb.append("from PortletPreferences inner join Layout on ");
 			sb.append("PortletPreferences.plid = Layout.plid where ");
 			sb.append("preferences like '%<portlet-preferences />%' or ");
-			sb.append("preferences like ''");
+			sb.append("preferences like '' or preferences is null");
 
 			String sql = sb.toString();
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradePortletPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradePortletPreferences.java
@@ -59,7 +59,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 			sb.append("from PortletPreferences inner join Layout on ");
 			sb.append("PortletPreferences.plid = Layout.plid where ");
 			sb.append("preferences like '%<portlet-preferences />%' or ");
-			sb.append("preferences = ''");
+			sb.append("preferences like ''");
 
 			String sql = sb.toString();
 


### PR DESCRIPTION
Hey @juliocamarero,

This pul request contains two commits:
1. This kind of comparisons: _clob_field = ''_ cause an exception in Oracle (see [LPS-55924](https://issues.liferay.com/browse/LPS-55924)) so I have modified it to use the valid equivalent.
2. Empty strings doesn't make sense in Oracle (Oracle uses NULL values for that) so I have added the _IS NULL_ comparisons (ANSI standard). I guess that is ok since we can remove preferences for embedded portlets set as NULL due to they will be regenerated first time those portlet are loaded (see your [comment] (https://issues.liferay.com/browse/LPS-34984?focusedCommentId=363677&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-363677))

SQL syntax has been agreed with @migue.

Thanks.
PS: @IstvanD