### PR TITLE
Lps 55098 pr 3437 update

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-browser-web/src/META-INF/resources/init.jsp
@@ -29,6 +29,7 @@ page import="com.liferay.asset.browser.web.search.AssetBrowserSearch" %><%@
 page import="com.liferay.asset.browser.web.search.AssetBrowserSearchTerms" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.search.Hits" %><%@
+page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.HttpUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@

--- a/modules/apps/asset/asset-browser-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/META-INF/resources/view.jsp
@@ -23,6 +23,14 @@ long refererAssetEntryId = ParamUtil.getLong(request, "refererAssetEntryId");
 String typeSelection = ParamUtil.getString(request, "typeSelection");
 long subtypeSelectionId = ParamUtil.getLong(request, "subtypeSelectionId");
 String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectAsset");
+boolean isListableSearch = ParamUtil.getBoolean(request, "isListableSearch", true);
+boolean isListable = ParamUtil.getBoolean(request, "isListable", true);
+
+Boolean listable = null;
+
+if (isListableSearch) {
+	listable = GetterUtil.getBoolean(isListable);
+}
 
 PortletURL portletURL = renderResponse.createRenderURL();
 
@@ -67,11 +75,11 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 					<c:when test="<%= AssetBrowserWebConfigurationValues.SEARCH_WITH_DATABASE %>">
 
 						<%
-						int assetEntriesTotal = AssetEntryLocalServiceUtil.getEntriesCount(selectedGroupIds, new long[] {assetRendererFactory.getClassNameId()}, searchTerms.getKeywords(), searchTerms.getUserName(), searchTerms.getTitle(), searchTerms.getDescription(), searchTerms.isAdvancedSearch(), searchTerms.isAndOperator());
+						int assetEntriesTotal = AssetEntryLocalServiceUtil.getEntriesCount(selectedGroupIds, new long[] {assetRendererFactory.getClassNameId()}, searchTerms.getKeywords(), searchTerms.getUserName(), searchTerms.getTitle(), searchTerms.getDescription(), listable, searchTerms.isAdvancedSearch(), searchTerms.isAndOperator());
 
 						searchContainer.setTotal(assetEntriesTotal);
 
-						List<AssetEntry> assetEntries = AssetEntryLocalServiceUtil.getEntries(selectedGroupIds, new long[] {assetRendererFactory.getClassNameId()}, searchTerms.getKeywords(), searchTerms.getUserName(), searchTerms.getTitle(), searchTerms.getDescription(), searchTerms.isAdvancedSearch(), searchTerms.isAndOperator(), searchContainer.getStart(), searchContainer.getEnd(), "modifiedDate", "title", "DESC", "ASC");
+						List<AssetEntry> assetEntries = AssetEntryLocalServiceUtil.getEntries(selectedGroupIds, new long[] {assetRendererFactory.getClassNameId()}, searchTerms.getKeywords(), searchTerms.getUserName(), searchTerms.getTitle(), searchTerms.getDescription(), listable, searchTerms.isAdvancedSearch(), searchTerms.isAndOperator(), searchContainer.getStart(), searchContainer.getEnd(), "modifiedDate", "title", "DESC", "ASC");
 
 						searchContainer.setResults(assetEntries);
 						%>

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -194,14 +194,15 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 	@Override
 	public List<AssetEntry> getEntries(
 		long[] groupIds, long[] classNameIds, String keywords, String userName,
-		String title, String description, boolean advancedSearch,
-		boolean andOperator, int start, int end, String orderByCol1,
-		String orderByCol2, String orderByType1, String orderByType2) {
+		String title, String description, Boolean listable,
+		boolean advancedSearch, boolean andOperator, int start, int end,
+		String orderByCol1, String orderByCol2, String orderByType1,
+		String orderByType2) {
 
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery(
 			groupIds, classNameIds, keywords, userName, title, description,
-			advancedSearch, andOperator, start, end, orderByCol1, orderByCol2,
-			orderByType1, orderByType2);
+			listable, advancedSearch, andOperator, start, end,
+			orderByCol1, orderByCol2, orderByType1, orderByType2);
 
 		return getEntries(assetEntryQuery);
 	}
@@ -214,13 +215,13 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 	@Override
 	public int getEntriesCount(
 		long[] groupIds, long[] classNameIds, String keywords, String userName,
-		String title, String description, boolean advancedSearch,
-		boolean andOperator) {
+		String title, String description, Boolean listable,
+		boolean advancedSearch, boolean andOperator) {
 
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery(
 			groupIds, classNameIds, keywords, userName, title, description,
-			advancedSearch, andOperator, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			null, null, null, null);
+			listable, advancedSearch, andOperator, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null, null, null, null);
 
 		return getEntriesCount(assetEntryQuery);
 	}
@@ -903,9 +904,10 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 	protected AssetEntryQuery getAssetEntryQuery(
 		long[] groupIds, long[] classNameIds, String keywords, String userName,
-		String title, String description, boolean advancedSearch,
-		boolean andOperator, int start, int end, String orderByCol1,
-		String orderByCol2, String orderByType1, String orderByType2) {
+		String title, String description, Boolean listable,
+		boolean advancedSearch, boolean andOperator, int start, int end,
+		String orderByCol1, String orderByCol2, String orderByType1,
+		String orderByType2) {
 
 		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
 
@@ -922,6 +924,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		assetEntryQuery.setClassNameIds(classNameIds);
 		assetEntryQuery.setEnd(end);
 		assetEntryQuery.setGroupIds(groupIds);
+		assetEntryQuery.setListable(listable);
 		assetEntryQuery.setOrderByCol1(orderByCol1);
 		assetEntryQuery.setOrderByCol2(orderByCol2);
 		assetEntryQuery.setOrderByType1(orderByType1);

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -201,8 +201,8 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery(
 			groupIds, classNameIds, keywords, userName, title, description,
-			listable, advancedSearch, andOperator, start, end,
-			orderByCol1, orderByCol2, orderByType1, orderByType2);
+			listable, advancedSearch, andOperator, start, end, orderByCol1,
+			orderByCol2, orderByType1, orderByType2);
 
 		return getEntries(assetEntryQuery);
 	}

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetEntryLocalService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetEntryLocalService.java
@@ -346,10 +346,10 @@ public interface AssetEntryLocalService extends BaseLocalService,
 	public java.util.List<com.liferay.portlet.asset.model.AssetEntry> getEntries(
 		long[] groupIds, long[] classNameIds, java.lang.String keywords,
 		java.lang.String userName, java.lang.String title,
-		java.lang.String description, boolean advancedSearch,
-		boolean andOperator, int start, int end, java.lang.String orderByCol1,
-		java.lang.String orderByCol2, java.lang.String orderByType1,
-		java.lang.String orderByType2);
+		java.lang.String description, java.lang.Boolean listable,
+		boolean advancedSearch, boolean andOperator, int start, int end,
+		java.lang.String orderByCol1, java.lang.String orderByCol2,
+		java.lang.String orderByType1, java.lang.String orderByType2);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getEntriesCount(
@@ -359,7 +359,7 @@ public interface AssetEntryLocalService extends BaseLocalService,
 	public int getEntriesCount(long[] groupIds, long[] classNameIds,
 		java.lang.String keywords, java.lang.String userName,
 		java.lang.String title, java.lang.String description,
-		boolean advancedSearch, boolean andOperator);
+		java.lang.Boolean listable, boolean advancedSearch, boolean andOperator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.asset.model.AssetEntry getEntry(

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetEntryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetEntryLocalServiceUtil.java
@@ -440,14 +440,14 @@ public class AssetEntryLocalServiceUtil {
 	public static java.util.List<com.liferay.portlet.asset.model.AssetEntry> getEntries(
 		long[] groupIds, long[] classNameIds, java.lang.String keywords,
 		java.lang.String userName, java.lang.String title,
-		java.lang.String description, boolean advancedSearch,
-		boolean andOperator, int start, int end, java.lang.String orderByCol1,
-		java.lang.String orderByCol2, java.lang.String orderByType1,
-		java.lang.String orderByType2) {
+		java.lang.String description, java.lang.Boolean listable,
+		boolean advancedSearch, boolean andOperator, int start, int end,
+		java.lang.String orderByCol1, java.lang.String orderByCol2,
+		java.lang.String orderByType1, java.lang.String orderByType2) {
 		return getService()
 				   .getEntries(groupIds, classNameIds, keywords, userName,
-			title, description, advancedSearch, andOperator, start, end,
-			orderByCol1, orderByCol2, orderByType1, orderByType2);
+			title, description, listable, advancedSearch, andOperator, start,
+			end, orderByCol1, orderByCol2, orderByType1, orderByType2);
 	}
 
 	public static int getEntriesCount(
@@ -458,10 +458,10 @@ public class AssetEntryLocalServiceUtil {
 	public static int getEntriesCount(long[] groupIds, long[] classNameIds,
 		java.lang.String keywords, java.lang.String userName,
 		java.lang.String title, java.lang.String description,
-		boolean advancedSearch, boolean andOperator) {
+		java.lang.Boolean listable, boolean advancedSearch, boolean andOperator) {
 		return getService()
 				   .getEntriesCount(groupIds, classNameIds, keywords, userName,
-			title, description, advancedSearch, andOperator);
+			title, description, listable, advancedSearch, andOperator);
 	}
 
 	public static com.liferay.portlet.asset.model.AssetEntry getEntry(

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetEntryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetEntryLocalServiceWrapper.java
@@ -494,12 +494,12 @@ public class AssetEntryLocalServiceWrapper implements AssetEntryLocalService,
 	public java.util.List<com.liferay.portlet.asset.model.AssetEntry> getEntries(
 		long[] groupIds, long[] classNameIds, java.lang.String keywords,
 		java.lang.String userName, java.lang.String title,
-		java.lang.String description, boolean advancedSearch,
-		boolean andOperator, int start, int end, java.lang.String orderByCol1,
-		java.lang.String orderByCol2, java.lang.String orderByType1,
-		java.lang.String orderByType2) {
+		java.lang.String description, java.lang.Boolean listable,
+		boolean advancedSearch, boolean andOperator, int start, int end,
+		java.lang.String orderByCol1, java.lang.String orderByCol2,
+		java.lang.String orderByType1, java.lang.String orderByType2) {
 		return _assetEntryLocalService.getEntries(groupIds, classNameIds,
-			keywords, userName, title, description, advancedSearch,
+			keywords, userName, title, description, listable, advancedSearch,
 			andOperator, start, end, orderByCol1, orderByCol2, orderByType1,
 			orderByType2);
 	}
@@ -514,9 +514,10 @@ public class AssetEntryLocalServiceWrapper implements AssetEntryLocalService,
 	public int getEntriesCount(long[] groupIds, long[] classNameIds,
 		java.lang.String keywords, java.lang.String userName,
 		java.lang.String title, java.lang.String description,
-		boolean advancedSearch, boolean andOperator) {
+		java.lang.Boolean listable, boolean advancedSearch, boolean andOperator) {
 		return _assetEntryLocalService.getEntriesCount(groupIds, classNameIds,
-			keywords, userName, title, description, advancedSearch, andOperator);
+			keywords, userName, title, description, listable, advancedSearch,
+			andOperator);
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portlet/asset/service/persistence/AssetEntryQuery.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/persistence/AssetEntryQuery.java
@@ -458,7 +458,7 @@ public class AssetEntryQuery {
 		_toString = null;
 	}
 
-	public void setListable(boolean listable) {
+	public void setListable(Boolean listable) {
 		_listable = listable;
 	}
 
@@ -703,7 +703,7 @@ public class AssetEntryQuery {
 	private String _keywords;
 	private Layout _layout;
 	private long _linkedAssetEntryId = 0;
-	private boolean _listable = true;
+	private Boolean _listable = true;
 	private long[] _notAllCategoryIds = new long[0];
 	private long[] _notAllTagIds = new long[0];
 	private long[][] _notAllTagIdsArray = new long[0][];


### PR DESCRIPTION
@juliocamarero before re-sending this to brian i wanted to see if i was moving in the right direction.

he asked me to make the service API take a Boolean so that we could set it to null explicitly instead of just taking in a true/false parameter and processing it for the Boolean; it looks like this makes the API change a bit more flexible.

In order to make this available in the asset-browser module I need to be able to get a "Boolean" from the request parameters but i could only see a way to get a "boolean". Since we should be able to set listable to null I thought we could use two "boolean" variables from the request; one to see if we want to set it to null and the other to specify the non-null value.

is there a better way to get a "Boolean" from request parameters that allows the default to be "true" but still has the possibility of being set to "null" or "false"?

pr chain:
https://github.com/brianchandotcom/liferay-portal/pull/26879
https://github.com/brianchandotcom/liferay-portal/pull/26937
https://github.com/brianchandotcom/liferay-portal/pull/26955

Please let me know if you would like me to change anything else.

Thanks!
-Andrew