### PR TITLE
[TECH-SUPPORT] LPS-56609 If index.search.highlight.enabled=false is set, web contents are always displayed in default language when searched

### DIFF
--- a/modules/apps/journal/journal-service/src/com/liferay/journal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/com/liferay/journal/search/JournalArticleIndexer.java
@@ -517,11 +517,14 @@ public class JournalArticleIndexer
 		String localizedTitleName = DocumentImpl.getLocalizedName(
 			locale, Field.TITLE);
 
-		if ((snippetLocale == null) ||
+		if ((snippetLocale == null) &&
 			(document.getField(localizedTitleName) == null)) {
 
 			snippetLocale = LocaleUtil.fromLanguageId(
 				document.get("defaultLanguageId"));
+		}
+		else {
+			snippetLocale = locale;
 		}
 
 		String title = document.get(


### PR DESCRIPTION
Hi Julio,

Altough this is a search related issue, it's specific to WCM.

Please see @istvansajtos's explanation here:
https://github.com/laszlocsontos/liferay-portal/pull/78

Thanks for reviewing!

Cheers,
László