### PR TITLE
[TECHNICAL-SUPPORT] LPS-57885 Nested non-localizable boolean field value does not persist in translations

### DIFF
--- a/modules/apps/journal/journal-service/src/com/liferay/journal/transformer/LocaleTransformerListener.java
+++ b/modules/apps/journal/journal-service/src/com/liferay/journal/transformer/LocaleTransformerListener.java
@@ -89,18 +89,20 @@ public class LocaleTransformerListener extends BaseTransformerListener {
 		String defaultLanguageId = LocaleUtil.toLanguageId(
 			LocaleUtil.getSiteDefault());
 
-		String[] availableLanguageIds = StringUtil.split(
-			rootElement.attributeValue("available-locales", defaultLanguageId));
-
 		String articleDefaultLanguageId = rootElement.attributeValue(
 			"default-locale", defaultLanguageId);
 
+		String[] availableLanguageIds = StringUtil.split(
+			rootElement.attributeValue(
+				"available-locales", articleDefaultLanguageId));
+
 		if (!ArrayUtil.contains(availableLanguageIds, languageId, true)) {
 			filterByLanguage(
-				rootElement, articleDefaultLanguageId, defaultLanguageId);
+				rootElement, articleDefaultLanguageId,
+				articleDefaultLanguageId);
 		}
 		else {
-			filterByLanguage(rootElement, languageId, defaultLanguageId);
+			filterByLanguage(rootElement, languageId, articleDefaultLanguageId);
 		}
 	}
 


### PR DESCRIPTION
Hi Julio,

the filtering logic keeps only the values for the actual locale, extending it with the value for the default locale and deletes the other ones.

However, it uses the Site's default language, which is wrong, as it is possible to change the article's default  language.

Could you please review my changes?

Thanks,
Tamás