### PR TITLE
LPS-58442 Add aria-label for screen readers

### DIFF
--- a/modules/frontend/frontend-taglib/src/META-INF/resources/add_menu/page.jsp
+++ b/modules/frontend/frontend-taglib/src/META-INF/resources/add_menu/page.jsp
@@ -27,7 +27,7 @@ List<AddMenuItem> addMenuItems = (List<AddMenuItem>)request.getAttribute("lifera
 		AddMenuItem addMenuItem = addMenuItems.get(0);
 		%>
 
-		<a class="btn btn-action btn-bottom-right btn-primary" data-placement="left" data-toggle="tooltip" href="<%= HtmlUtil.escapeAttribute(addMenuItem.getUrl()) %>" title="<%= HtmlUtil.escapeAttribute(addMenuItem.getLabel()) %>">
+		<a aria-label="<%= HtmlUtil.escapeAttribute(addMenuItem.getLabel()) %>" class="btn btn-action btn-bottom-right btn-primary" data-placement="left" data-toggle="tooltip" href="<%= HtmlUtil.escapeAttribute(addMenuItem.getUrl()) %>" title="<%= HtmlUtil.escapeAttribute(addMenuItem.getLabel()) %>">
 			<span class="icon-plus"></span>
 		</a>
 
@@ -41,19 +41,19 @@ List<AddMenuItem> addMenuItems = (List<AddMenuItem>)request.getAttribute("lifera
 	</c:when>
 	<c:otherwise>
 		<div class="btn-action-secondary btn-bottom-right dropdown">
-			<button aria-expanded="false" class="btn btn-primary" data-toggle="dropdown" type="button">
+			<button aria-expanded="false" aria-label="<%= LanguageUtil.get(request, "add") %>" class="btn btn-primary" data-toggle="dropdown" type="button">
 				<span class="icon-plus"></span>
 			</button>
 
-			<ul class="dropdown-menu dropdown-menu-left-side-bottom">
+			<ul class="dropdown-menu dropdown-menu-left-side-bottom" role="menu">
 
 				<%
 				for (int i = 0; i < addMenuItems.size(); i++) {
 					AddMenuItem addMenuItem = addMenuItems.get(i);
 				%>
 
-					<li>
-						<a href="<%= HtmlUtil.escapeAttribute(addMenuItem.getUrl()) %>"><%= HtmlUtil.escape(addMenuItem.getLabel()) %></a>
+					<li role="presentation">
+						<a href="<%= HtmlUtil.escapeAttribute(addMenuItem.getUrl()) %>" role="menuitem"><%= HtmlUtil.escape(addMenuItem.getLabel()) %></a>
 					</li>
 
 				<%

--- a/modules/frontend/frontend-taglib/src/META-INF/resources/liferay-frontend.tld
+++ b/modules/frontend/frontend-taglib/src/META-INF/resources/liferay-frontend.tld
@@ -10,25 +10,30 @@
 	<short-name>frontend</short-name>
 	<uri>http://liferay.com/tld/frontend</uri>
 	<tag>
+		<description>Creates an add menu that contains a list of url menu items.</description>
 		<name>add-menu</name>
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.AddMenuTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<description>List of url menu items.</description>
 			<name>addMenuItems</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 	</tag>
 	<tag>
+		<description>Creates a menu item.</description>
 		<name>add-menu-item</name>
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.AddMenuItemTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<description>A title for the menu item.</description>
 			<name>title</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>A URL to the action to execute.</description>
 			<name>url</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>


### PR DESCRIPTION
Hola Julio, 

he comprobado la accesibilidad del boton "+". Desde el teclado es perfectamente accesible, pero había ciertos casos en los que el lector de pantallas no decía nada. Solo he tenido que añadir aria-labels. 
Cualquier cosa que veas me dices. 

cc/ @jbalsas