### PR TITLE
LPS-58574

### DIFF
--- a/.gradle/caches/modules-2/files-2.1/javax.annotation/jsr250-api/1.0/828184cb963d953865b5941e416999e376b1c82a/jsr250-api-1.0.pom
+++ b/.gradle/caches/modules-2/files-2.1/javax.annotation/jsr250-api/1.0/828184cb963d953865b5941e416999e376b1c82a/jsr250-api-1.0.pom
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                        http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>javax.annotation</groupId>
+  <artifactId>jsr250-api</artifactId>
+  <version>1.0</version>
+  <name>JSR-250 Common Annotations for the JavaTM Platform</name>
+  <description>JSR-250 Reference Implementation by Glassfish</description>
+  <url>http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html</url>
+
+  <licenses>
+    <license>
+      <name>COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0</name>
+      <url>https://glassfish.dev.java.net/public/CDDLv1.0.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <dependencies/>
+
+  <distributionManagement>
+    <downloadUrl>http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html</downloadUrl>
+  </distributionManagement>
+</project>

--- a/.gradle/caches/modules-2/files-2.1/javax.portlet/portlet-api/2.0/1f98c5cd33539ad7e9a32eec18c632d51a5cefb3/portlet-api-2.0.pom
+++ b/.gradle/caches/modules-2/files-2.1/javax.portlet/portlet-api/2.0/1f98c5cd33539ad7e9a32eec18c632d51a5cefb3/portlet-api-2.0.pom
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2006 The Apache Software Foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- 
+  A basic Maven 2 build for the JSR-286 sources.
+  Use 'mv package' to create the jar in the target directory or
+  'mvn install' to package the jar and install it in
+  your local Maven repository.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+ 
+  <groupId>javax.portlet</groupId>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>portlet-api</artifactId>
+  <version>2.0</version>
+  <packaging>jar</packaging>
+  <name>Java Portlet Specification V2.0</name> 
+  <description>The Java Portlet API version 2.0 developed by the Java Community Process JSR-286 Expert Group.</description>
+  <url>http://www.jcp.org/en/jsr/detail?id=286</url>
+  <distributionManagement>
+    <repository>
+      <id></id>
+      <url></url>
+    </repository>
+    <downloadUrl>http://jcp.org/aboutJava/communityprocess/final/jsr286/index.html</downloadUrl>
+  </distributionManagement>
+  
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.4</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+	<plugins>
+		<plugin>
+			<!-- Make sure compilation is done with java 1.5 
+				since the source has annotations -->
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-compiler-plugin</artifactId>
+			<configuration>
+				<source>1.5</source>
+				<target>1.5</target>
+			</configuration>
+		</plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <doctitle>${pom.name}</doctitle>
+            <windowtitle>${pom.name}</windowtitle>
+            <splitindex>true</splitindex>
+            <bottom>&nbsp;</bottom>
+          </configuration>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+		<plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+                <archive>
+                    <manifestEntries>
+                        <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                        <Bundle-SymbolicName>javax.portlet</Bundle-SymbolicName>
+                        <Bundle-Name>JSR 286</Bundle-Name>
+                        <Bundle-DocURL>http://www.jcp.org/en/jsr/detail?id=286</Bundle-DocURL>
+                        <Export-Package>
+                            javax.portlet;version="2.0.0",
+                            javax.portlet.filter;version="2.0.0"
+                        </Export-Package>
+                        <Import-Package>
+                            org.w3c.dom,
+                            javax.xml.namespace,
+                            javax.servlet.http; version="2.4.0"
+                        </Import-Package>
+                    </manifestEntries>
+                </archive>
+            </configuration>
+        </plugin>
+	</plugins>
+
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh-external</artifactId>
+        <version>1.0-alpha-5</version>
+      </extension>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ftp</artifactId>
+        <version>1.0-alpha-6</version>
+      </extension>
+    </extensions>
+
+  </build>
+  
+</project>
+
+

--- a/modules/apps/asset/asset-categories-service/bnd.bnd
+++ b/modules/apps/asset/asset-categories-service/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Asset Categories Service
+Bundle-SymbolicName: com.liferay.asset.categories.service
+Bundle-Version: 1.0.0
+Include-Resource: classes

--- a/modules/apps/asset/asset-categories-service/build.gradle
+++ b/modules/apps/asset/asset-categories-service/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
+}
+
+liferay {
+	deployDir = file("${liferayHome}/osgi/modules")
+}

--- a/modules/apps/asset/asset-categories-service/build.xml
+++ b/modules/apps/asset/asset-categories-service/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../build-module.xml" />
+</project>

--- a/modules/apps/asset/asset-categories-service/src/com/liferay/asset/categories/service/permission/AssetCategoryPermissionUpdateHandler.java
+++ b/modules/apps/asset/asset-categories-service/src/com/liferay/asset/categories/service/permission/AssetCategoryPermissionUpdateHandler.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.categories.service.permission;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.security.permission.PermissionUpdateHandler;
+import com.liferay.portlet.asset.model.AssetCategory;
+import com.liferay.portlet.asset.service.AssetCategoryLocalService;
+
+import java.util.Date;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Gergely Mathe
+ */
+@Component(
+	property = {
+		"model.class.name=com.liferay.portlet.asset.model.AssetCategory"
+	},
+	service = PermissionUpdateHandler.class
+)
+public class AssetCategoryPermissionUpdateHandler
+	implements PermissionUpdateHandler {
+
+	@Override
+	public void updatedPermission(String primKey) {
+		AssetCategory assetCategory =
+			_assetCategoryLocalService.fetchAssetCategory(
+				GetterUtil.getLong(primKey));
+
+		if (assetCategory == null) {
+			return;
+		}
+
+		assetCategory.setModifiedDate(new Date());
+
+		_assetCategoryLocalService.updateAssetCategory(assetCategory);
+	}
+
+	@Reference
+	protected void setAssetCategoryLocalService(
+		AssetCategoryLocalService assetCategoryLocalService) {
+
+		_assetCategoryLocalService = assetCategoryLocalService;
+	}
+
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+}

--- a/modules/apps/asset/asset-categories-service/src/com/liferay/asset/categories/service/permission/AssetVocabularyPermissionUpdateHandler.java
+++ b/modules/apps/asset/asset-categories-service/src/com/liferay/asset/categories/service/permission/AssetVocabularyPermissionUpdateHandler.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.categories.service.permission;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.security.permission.PermissionUpdateHandler;
+import com.liferay.portlet.asset.model.AssetVocabulary;
+import com.liferay.portlet.asset.service.AssetVocabularyLocalService;
+
+import java.util.Date;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Gergely Mathe
+ */
+@Component(
+	property = {
+		"model.class.name=com.liferay.portlet.asset.model.AssetVocabulary"
+	},
+	service = PermissionUpdateHandler.class
+)
+public class AssetVocabularyPermissionUpdateHandler
+	implements PermissionUpdateHandler {
+
+	@Override
+	public void updatedPermission(String primKey) {
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.fetchAssetVocabulary(
+				GetterUtil.getLong(primKey));
+
+		if (assetVocabulary == null) {
+			return;
+		}
+
+		assetVocabulary.setModifiedDate(new Date());
+
+		_assetVocabularyLocalService.updateAssetVocabulary(assetVocabulary);
+	}
+
+	@Reference
+	protected void setAssetVocabularyLocalService(
+		AssetVocabularyLocalService assetVocabularyLocalService) {
+
+		_assetVocabularyLocalService = assetVocabularyLocalService;
+	}
+
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+}

--- a/modules/apps/asset/asset-tags-service/bnd.bnd
+++ b/modules/apps/asset/asset-tags-service/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Asset Tags Service
+Bundle-SymbolicName: com.liferay.asset.tags.service
+Bundle-Version: 1.0.0
+Include-Resource: classes

--- a/modules/apps/asset/asset-tags-service/build.gradle
+++ b/modules/apps/asset/asset-tags-service/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
+}
+
+liferay {
+	deployDir = file("${liferayHome}/osgi/modules")
+}

--- a/modules/apps/asset/asset-tags-service/build.xml
+++ b/modules/apps/asset/asset-tags-service/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../build-module.xml" />
+</project>

--- a/modules/apps/asset/asset-tags-service/src/com/liferay/asset/categories/service/permission/AssetTagPermissionUpdateHandler.java
+++ b/modules/apps/asset/asset-tags-service/src/com/liferay/asset/categories/service/permission/AssetTagPermissionUpdateHandler.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.categories.service.permission;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.security.permission.PermissionUpdateHandler;
+import com.liferay.portlet.asset.model.AssetTag;
+import com.liferay.portlet.asset.service.AssetTagLocalService;
+
+import java.util.Date;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Gergely Mathe
+ */
+@Component(
+	property = {"model.class.name=com.liferay.portlet.asset.model.AssetTag"},
+	service = PermissionUpdateHandler.class
+)
+public class AssetTagPermissionUpdateHandler
+	implements PermissionUpdateHandler {
+
+	@Override
+	public void updatedPermission(String primKey) {
+		AssetTag assetTag = _assetTagLocalService.fetchAssetTag(
+			GetterUtil.getLong(primKey));
+
+		if (assetTag == null) {
+			return;
+		}
+
+		assetTag.setModifiedDate(new Date());
+
+		_assetTagLocalService.updateAssetTag(assetTag);
+	}
+
+	@Reference
+	protected void setAssetTagLocalService(
+		AssetTagLocalService assetTagLocalService) {
+
+		_assetTagLocalService = assetTagLocalService;
+	}
+
+	private AssetTagLocalService _assetTagLocalService;
+
+}

--- a/modules/apps/document-library/document-library-web/src/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/META-INF/resources/document_library/edit_file_entry.jsp
@@ -531,7 +531,7 @@ else {
 
 		var className = 'alert alert-danger';
 
-		var fileTitleErrorNode = $('#<portlet:namespace /fileTitleError');
+		var fileTitleErrorNode = $('#<portlet:namespace />fileTitleError');
 
 		var form = $(document.<portlet:namespace />fm);
 


### PR DESCRIPTION
Hey Julio,

@giros has been working on implementing the permission update handlers, which will make sure that if you change the permission for an asset category or a tag the tag's or category's modifiedDate will be updated.

This pull contains the asset related classes, but there were no service bundles for the services. We have decided to create them anyway, even though they contain only a few classes. Is it ok to create these new bundles or you prefer them to move it into the core?

Thanks,

Máté
