### PR TITLE
[TECHNICAL-SUPPORT] LPS-58576 Check View permission on the Layouts

### DIFF
--- a/modules/apps/document-library/document-library-web/src/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/META-INF/resources/document_library/edit_file_entry.jsp
@@ -531,7 +531,7 @@ else {
 
 		var className = 'alert alert-danger';
 
-		var fileTitleErrorNode = $('#<portlet:namespace /fileTitleError');
+		var fileTitleErrorNode = $('#<portlet:namespace />fileTitleError');
 
 		var form = $(document.<portlet:namespace />fm);
 

--- a/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
@@ -40,6 +40,7 @@ import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.LayoutSetLocalServiceUtil;
+import com.liferay.portal.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.WebKeys;
@@ -350,14 +351,17 @@ public class JournalArticleAssetRenderer
 				_article.getGroupId(), layout.isPrivateLayout(),
 				_article.getArticleId());
 
-		if (!hitLayoutIds.isEmpty()) {
-			Long hitLayoutId = hitLayoutIds.get(0);
-
+		for (Long hitLayoutId : hitLayoutIds) {
 			Layout hitLayout = LayoutLocalServiceUtil.getLayout(
 				_article.getGroupId(), layout.isPrivateLayout(),
 				hitLayoutId.longValue());
 
-			return PortalUtil.getLayoutURL(hitLayout, themeDisplay);
+			if (LayoutPermissionUtil.contains(
+					themeDisplay.getPermissionChecker(), layout,
+					ActionKeys.VIEW)) {
+
+				return PortalUtil.getLayoutURL(hitLayout, themeDisplay);
+			}
 		}
 
 		return noSuchEntryRedirect;


### PR DESCRIPTION
Hi Julio,

it's a small fix to prevent generating non accessible links.

As the Portal refuses to show the layout without View permission, the article is not displayed.

Furthermore the layout's name is displayed in the URL, which is not desired.

Thanks,
Tamás