### PR TITLE
LPS-54528 Empty RSS feed in Asset Publisher when ordering by custom field of a structure

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/META-INF/resources/view_dynamic_list.jspf
+++ b/modules/apps/asset/asset-publisher-web/src/META-INF/resources/view_dynamic_list.jspf
@@ -15,7 +15,7 @@
 --%>
 
 <%
-List<AssetEntryResult> assetEntryResults = assetPublisherDisplayContext.getAssetEntryResults(searchContainer);
+List<AssetEntryResult> assetEntryResults = assetPublisherDisplayContext.getAssetEntryResults(searchContainer.getStart(), searchContainer.getEnd(), searchContainer);
 
 for (AssetEntryResult assetEntryResult : assetEntryResults) {
 	List<AssetEntry> assetEntries = assetEntryResult.getAssetEntries();

--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/context/AssetPublisherDisplayContext.java
@@ -222,7 +222,7 @@ public class AssetPublisherDisplayContext {
 	}
 
 	public List<AssetEntryResult> getAssetEntryResults(
-			SearchContainer searchContainer)
+			int start, int end, SearchContainer searchContainer)
 		throws Exception {
 
 		if (!showAssetEntryResults()) {
@@ -234,13 +234,13 @@ public class AssetPublisherDisplayContext {
 
 		if (assetVocabularyId > 0) {
 			return getAssetEntryResultsByVocabulary(
-				assetVocabularyId, searchContainer);
+				assetVocabularyId, start, end, searchContainer);
 		}
 		else if (assetVocabularyId <= -1) {
-			return getAssetEntryResultsByClassName(searchContainer);
+			return getAssetEntryResultsByClassName(start, end, searchContainer);
 		}
 
-		return getAssetEntryResultsByDefault(searchContainer);
+		return getAssetEntryResultsByDefault(start, end, searchContainer);
 	}
 
 	public String getAssetLinkBehavior() {
@@ -1126,7 +1126,7 @@ public class AssetPublisherDisplayContext {
 	}
 
 	protected List<AssetEntryResult> getAssetEntryResultsByClassName(
-			SearchContainer searchContainer)
+			int start, int end, SearchContainer searchContainer)
 		throws Exception {
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
@@ -1135,9 +1135,6 @@ public class AssetPublisherDisplayContext {
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery();
 
 		List<AssetEntryResult> assetEntryResults = new ArrayList<>();
-
-		int end = searchContainer.getEnd();
-		int start = searchContainer.getStart();
 
 		int total = 0;
 
@@ -1191,19 +1188,18 @@ public class AssetPublisherDisplayContext {
 			}
 		}
 
-		searchContainer.setTotal(total);
+		if (searchContainer != null) {
+			searchContainer.setTotal(total);
+		}
 
 		return assetEntryResults;
 	}
 
 	protected List<AssetEntryResult> getAssetEntryResultsByDefault(
-			SearchContainer searchContainer)
+			int start, int end, SearchContainer searchContainer)
 		throws Exception {
 
 		List<AssetEntryResult> assetEntryResults = new ArrayList<>();
-
-		int end = searchContainer.getEnd();
-		int start = searchContainer.getStart();
 
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery();
 
@@ -1214,7 +1210,9 @@ public class AssetPublisherDisplayContext {
 
 		int total = baseModelSearchResult.getLength();
 
-		searchContainer.setTotal(total);
+		if (searchContainer != null) {
+			searchContainer.setTotal(total);
+		}
 
 		List<AssetEntry> assetEntries = baseModelSearchResult.getBaseModels();
 
@@ -1226,7 +1224,8 @@ public class AssetPublisherDisplayContext {
 	}
 
 	protected List<AssetEntryResult> getAssetEntryResultsByVocabulary(
-			long assetVocabularyId, SearchContainer searchContainer)
+			long assetVocabularyId, int start, int end,
+			SearchContainer searchContainer)
 		throws Exception {
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
@@ -1241,9 +1240,6 @@ public class AssetPublisherDisplayContext {
 				assetVocabularyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		assetEntryQuery.setClassNameIds(getClassNameIds());
-
-		int end = searchContainer.getEnd();
-		int start = searchContainer.getStart();
 
 		int total = 0;
 
@@ -1293,7 +1289,9 @@ public class AssetPublisherDisplayContext {
 			assetEntryQuery.setStart(QueryUtil.ALL_POS);
 		}
 
-		searchContainer.setTotal(total);
+		if (searchContainer != null) {
+			searchContainer.setTotal(total);
+		}
 
 		return assetEntryResults;
 	}

--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/util/AssetRSSUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/util/AssetRSSUtil.java
@@ -55,8 +55,6 @@ import javax.portlet.PortletResponse;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
 
-import javax.servlet.http.HttpServletRequest;
-
 /**
  * @author Brian Wing Shun Chan
  * @author Julio Camarero
@@ -87,29 +85,10 @@ public class AssetRSSUtil {
 		String format = RSSUtil.getFeedTypeFormat(rssFeedType);
 		double version = RSSUtil.getFeedTypeVersion(rssFeedType);
 
-		List<AssetEntry> assetEntries = new ArrayList<>();
-
-		if (selectionStyle.equals("dynamic")) {
-			AssetPublisherDisplayContext displayContext =
-				new AssetPublisherDisplayContext(
-					PortalUtil.getHttpServletRequest(portletRequest),
-					portletPreferences);
-
-			List<AssetEntryResult> assetEntryResults =
-				displayContext.getAssetEntryResults(
-					0, displayContext.getRSSDelta(), null);
-
-			for (AssetEntryResult assetEntryResult : assetEntryResults) {
-				assetEntries.addAll(assetEntryResult.getAssetEntries());
-			}
-		}
-		else {
-			assetEntries = getAssetEntries(portletRequest, portletPreferences);
-		}
-
 		String rss = exportToRSS(
 			portletRequest, portletResponse, rssName, null, format, version,
-			rssDisplayStyle, assetLinkBehavior, assetEntries);
+			rssDisplayStyle, assetLinkBehavior,
+			getAssetEntries(portletRequest, portletPreferences));
 
 		return rss.getBytes(StringPool.UTF8);
 	}
@@ -206,15 +185,22 @@ public class AssetRSSUtil {
 			PortletPreferences portletPreferences)
 		throws Exception {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
+		List<AssetEntry> assetEntries = new ArrayList<>();
 
-		int rssDelta = GetterUtil.getInteger(
-			portletPreferences.getValue("rssDelta", "20"));
+		AssetPublisherDisplayContext displayContext =
+			new AssetPublisherDisplayContext(
+				PortalUtil.getHttpServletRequest(portletRequest),
+				portletPreferences);
 
-		return AssetPublisherUtil.getAssetEntries(
-			portletPreferences, themeDisplay.getLayout(),
-			themeDisplay.getScopeGroupId(), rssDelta, true);
+		List<AssetEntryResult> assetEntryResults =
+			displayContext.getAssetEntryResults(
+				0, displayContext.getRSSDelta(), null);
+
+		for (AssetEntryResult assetEntryResult : assetEntryResults) {
+			assetEntries.addAll(assetEntryResult.getAssetEntries());
+		}
+
+		return assetEntries;
 	}
 
 	protected static String getAssetPublisherURL(PortletRequest portletRequest)

--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/util/AssetRSSUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/util/AssetRSSUtil.java
@@ -16,7 +16,6 @@ package com.liferay.asset.publisher.web.util;
 
 import com.liferay.asset.publisher.web.context.AssetEntryResult;
 import com.liferay.asset.publisher.web.context.AssetPublisherDisplayContext;
-import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -91,24 +90,14 @@ public class AssetRSSUtil {
 		List<AssetEntry> assetEntries = new ArrayList<>();
 
 		if (selectionStyle.equals("dynamic")) {
-			int rssDelta = GetterUtil.getInteger(
-				portletPreferences.getValue("rssDelta", "20"));
-
-			SearchContainer<Object> searchContainer =
-				new SearchContainer<Object>(
-					portletRequest, null, null,
-					SearchContainer.DEFAULT_CUR_PARAM,
-				0, rssDelta, portletResponse.createRenderURL(), null, null);
-
-			HttpServletRequest httpServletRequest =
-				PortalUtil.getHttpServletRequest(portletRequest);
-
 			AssetPublisherDisplayContext displayContext =
 				new AssetPublisherDisplayContext(
-					httpServletRequest, portletPreferences);
+					PortalUtil.getHttpServletRequest(portletRequest),
+					portletPreferences);
 
 			List<AssetEntryResult> assetEntryResults =
-				displayContext.getAssetEntryResults(searchContainer);
+				displayContext.getAssetEntryResults(
+					0, displayContext.getRSSDelta(), null);
 
 			for (AssetEntryResult assetEntryResult : assetEntryResults) {
 				assetEntries.addAll(assetEntryResult.getAssetEntries());


### PR DESCRIPTION
Hi Julio,

I have realized RSS subscription is disabled when using manual selection, this is why an empty byte array is returned when selection is not dynamic. So I have modified the getAssetEntries in AssetRSSUtil to use the new call.

I'm using the current API because a customer has requested this RSS fix to be in a fix pack. Later the API will be moved to AssetPublisherUtil.

Please review.
Regards,
Zsolt