### PR TITLE
[TECHNICAL-SUPPORT]LPS-53554 URLs in sitemap.xml are repeated for web content

### DIFF
--- a/modules/apps/journal/journal-service/src/com/liferay/journal/util/impl/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/com/liferay/journal/util/impl/JournalArticleSitemapURLProvider.java
@@ -65,10 +65,15 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		Set<String> processedArticleIds = new HashSet<>();
 
 		for (JournalArticle journalArticle : journalArticles) {
-			if (processedArticleIds.contains(
-					journalArticle.getArticleId()) ||
+			JournalArticle latestArticle =
+				_journalArticleService.getLatestArticle(
+					journalArticle.getGroupId(), journalArticle.getArticleId(),
+					WorkflowConstants.STATUS_APPROVED);
+
+			if (processedArticleIds.contains(journalArticle.getArticleId()) ||
 				(journalArticle.getStatus() !=
-					WorkflowConstants.STATUS_APPROVED)) {
+					WorkflowConstants.STATUS_APPROVED) ||
+				(latestArticle.getVersion() > journalArticle.getVersion())) {
 
 				continue;
 			}


### PR DESCRIPTION
Hi,

I have discussed with @zsigmondrab,

The problem is that the process will find all the approved versions of a web content so if there is approved versions with different layout uuids, then all of them will be included. There are two ways,

- rewrite a new query that handles this,
- check if the found web content is the latest approved one.

I'm sending you the second solution, as Zsigmond has agreed.
Is this fine or should it be implemented in the first way?
Please review.

Regards,
Zsolt