### PR TITLE
[Technical Support] LPS-59732 Change in the Look&Feel in a portlet of a Page Template will blank out JavaScript and Query String field of a page created from that template

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/META-INF/resources/layout/details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/META-INF/resources/layout/details.jsp
@@ -134,6 +134,10 @@ StringBuilder friendlyURLBase = new StringBuilder();
 
 		<aui:input name="layoutPrototypeUuid" type="hidden" value="<%= selLayout.getLayoutPrototypeUuid() %>" />
 
+		<div class='portlet-msg-info <%= selLayout.isLayoutPrototypeLinkEnabled() ? "" : "hide" %>' id="<portlet:namespace/>layoutPrototypeInfoMessage">
+			<liferay-ui:message key="this-page-is-linked-to-a-page-template" />
+		</div>
+
 		<aui:input label='<%= LanguageUtil.format(request, "automatically-apply-changes-done-to-the-page-template-x", HtmlUtil.escape(layoutPrototype.getName(user.getLocale())), false) %>' name="layoutPrototypeLinkEnabled" type="checkbox" value="<%= selLayout.isLayoutPrototypeLinkEnabled() %>" />
 
 		<div class='<%= selLayout.isLayoutPrototypeLinkEnabled() ? "" : "hide" %>' id="<portlet:namespace/>layoutPrototypeMergeAlert">
@@ -210,6 +214,7 @@ StringBuilder friendlyURLBase = new StringBuilder();
 </aui:fieldset>
 
 <aui:script>
+	Liferay.Util.toggleBoxes('<portlet:namespace />layoutPrototypeLinkEnabled', '<portlet:namespace />layoutPrototypeInfoMessage');
 	Liferay.Util.toggleBoxes('<portlet:namespace />layoutPrototypeLinkEnabled', '<portlet:namespace />layoutPrototypeMergeAlert');
 	Liferay.Util.toggleBoxes('<portlet:namespace />layoutPrototypeLinkEnabled', '<portlet:namespace />typeOptions', true);
 </aui:script>


### PR DESCRIPTION
Hi Julio,

we know that we have a new mechanism to show the messages to the users through the info (i) icon in the bar on the top of the page, however, it seemingly not enough in some cases.

In this particular case, it seems much easier to show the message in a more visible way then to change the basic logic of handling of the editing pages in any way.

In addition, the info icon cannot be seen in case of page editing in the current state of the master.

This is a UI change rather, though, so please forward that to anyone who you think better to review.

Thank you,
Zsigmond