### PR TITLE
LPS 60022

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -43,7 +43,7 @@ body {
 
 .product-menu {
 	.sidebar-body {
-		bottom: 65px;
+		bottom: 0;
 		left: 0;
 		padding-bottom: 0;
 		padding-top: 0;
@@ -52,7 +52,6 @@ body {
 		top: 120px;
 
 		@include sm() {
-			bottom: 80px;
 			top: 223px;
 		}
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -63,19 +63,12 @@ body {
 }
 
 .product-menu {
-	.sidebar-footer {
-		bottom: 0;
+	.sidebar-user {
 		padding: 10px 24px;
-		position: absolute;
-		width: 100%;
 
 		@include sm() {
 			padding-bottom: 16px;
 			padding-top: 16px;
-		}
-
-		@include media-query(null, 320px) {
-			position: static;
 		}
 
 		.nameplate-content,
@@ -100,20 +93,6 @@ body {
 				height: 48px;
 				line-height: 48px;
 				width: 48px;
-			}
-		}
-
-		.user-subheading {
-			list-style: none;
-			margin: 0 8px;
-			padding: 0;
-
-			> li {
-				float: left;
-
-				&:last-child {
-					float: right;
-				}
 			}
 		}
 	}

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -60,6 +60,14 @@ body {
 			position: static;
 		}
 	}
+
+	&.user-view .sidebar-body {
+		top: 100px;
+
+		@include sm() {
+			top: 150px;
+		}
+	}
 }
 
 .product-menu {

--- a/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_product_menu.scss
+++ b/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_product_menu.scss
@@ -7,7 +7,7 @@
 		vertical-align: text-top;
 	}
 
-	.sidebar-footer .user-icon img {
+	.sidebar-user .user-icon img {
 		display: block;
 		width: 100%;
 	}
@@ -87,31 +87,13 @@
 }
 
 .product-menu {
-	.sidebar-footer {
-		color: $product-menu-footer-color;
+	.sidebar-user {
+		color: $product-menu-nav-link-color;
 	}
 
 	.user-heading {
 		font-size: 19px;
 		font-weight: 500;
-	}
-
-	.user-signout {
-		background-color: $product-menu-user-signout-bg;
-		border-radius: $product-menu-user-signout-border-radius;
-		color: $product-menu-user-signout-icon-color;
-	}
-
-	.user-subheading {
-		a {
-			color: $product-menu-footer-link-color;
-			font-size: 14px;
-			font-weight: 500;
-
-			&:focus, &:hover {
-				color: $product-menu-footer-link-hover-color;
-			}
-		}
 	}
 }
 

--- a/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_variables.scss
+++ b/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_variables.scss
@@ -24,10 +24,6 @@ $product-menu-body-bg: #1F282E !default;
 
 $product-menu-collapse-icon-bg: #1A2126 !default;
 
-$product-menu-footer-color: #869CAD !default;
-$product-menu-footer-link-color: $product-menu-footer-color !default;
-$product-menu-footer-link-hover-color: $product-menu-footer-link-color !default;
-
 $product-menu-header-bg: #1B2228 !default;
 $product-menu-header-color: #FFF !default;
 $product-menu-header-link-color: #FFF !default;


### PR DESCRIPTION
Hey Julio, te cuento:

El primer commit va a solucionar el hueco inferior que queda en la product menu al borrar el sidebar-footer.

Los otros dos commits son para dar forma a la nueva vista sólo de "usuario", con el segundo commit puedes usar el marcado que remplaza a la pestaña, que es este:

```
<div class="sidebar-user">
   <div class="nameplate">
      <div class="nameplate-field">
         <div class="user-icon user-icon-lg"> <img alt="Test Test" src="/image/user_male_portrait?test"> </div>
      </div>
      <div class="nameplate-content">
         <div class="user-heading"> Test Test </div>
      </div>
   </div>
</div>
```

Claro, estaba cabecera es mucho menos alta, por lo que tenemos más espacio para los menús, para modificar esta altura tienes que añadir a la div del product menu la clase "user-view":
```
<div class="product-menu sidebar sidenav-menu user-view">
```

Eso es lo que añade el tercer commit.

Debería verse tal que así:

![image](https://cloud.githubusercontent.com/assets/7963804/10864682/833d5762-7ff6-11e5-8a3d-2e8fe1d9d0e3.png)