### PR TITLE
LPS-59490 - Show "null" when removing the Related Assets in MB

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
@@ -227,6 +227,10 @@ public class SearchContainer<R> {
 	}
 
 	public String getEmptyResultsMessage() {
+		if (_emptyResultsMessage == null) {
+			return StringPool.BLANK;
+		}
+
 		return _emptyResultsMessage;
 	}
 


### PR DESCRIPTION
Julio, lo he comentado con Eudaldo y me dice que te pase la pull para que la mires tú. 
Yo creo que la solución no es esta, ya que tal y como está ahora lo que han hecho es que no aparezca el "null" pero se queda la caja azul sin ningún mensaje dentro. No sé como estaba antes ni lo que se quiere, así que te lo dejo para que lo decidáis.