### PR TITLE
LPS-60142 Permission checking fails for control panel

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -293,7 +293,11 @@ public class PortletPermissionImpl implements PortletPermission {
 				groupId, name, primKey, actionId);
 		}
 
-		if (!actionId.equals(ActionKeys.VIEW) && !layout.isTypeControlPanel() &&
+		if ((layout instanceof VirtualLayout) && layout.isTypeControlPanel()) {
+			layout = ((VirtualLayout)layout).getSourceLayout();
+		}
+
+		if (!actionId.equals(ActionKeys.VIEW) &&
 			(layout instanceof VirtualLayout)) {
 
 			return hasCustomizePermission(
@@ -302,7 +306,7 @@ public class PortletPermissionImpl implements PortletPermission {
 
 		Group group = layout.getGroup();
 
-		if (!group.isLayoutSetPrototype() && !layout.isTypeControlPanel() &&
+		if (!group.isLayoutSetPrototype() &&
 			actionId.equals(ActionKeys.CONFIGURATION) &&
 			!SitesUtil.isLayoutUpdateable(layout)) {
 


### PR DESCRIPTION
Hi Julio,

https://issues.liferay.com/browse/LPS-60142

After https://github.com/liferay/liferay-portal/commit/fc3478b0b2e438210182e5ea6bf8fe07fa34f455 the `layout.getGroup()` no longer returns Control Panel group and `group.isControlPanelGroup()` returns false now.

Therefore https://github.com/topolik/liferay-portal/blob/LPS-60142/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java#L348-352 creates resource permissions for web/guest/home layout, even though most of admin portlets won't be ever displayed there.

Plus it initiates permission checking on a wrong groupId.

I'm not sure if this covers all places, please discuss with @jorgeferrer or @rotty3000, there might be other permission regressions in control panel or elsewhere I'm not aware of. For example I see ServicePreAction has several `group.isControlPanel()` checks with `group = layout.getGroup()`, I guess this is broken too.

Thanks!