### PR TITLE
[Technical Support]LPS-58592 Getting double entries for web contents on Asset publisher portlet in staging

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -195,7 +195,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 					}
 					%>
 
-					<c:if test="<%= !types.isEmpty() %>">
+					<c:if test="<%= !(types.isEmpty() || siteGroup.isLayoutPrototype() || siteGroup.isLayoutSetPrototype()) %>">
 
 						<%
 						data = new HashMap<String, Object>();

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -203,6 +203,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 						PortletURL siteBrowserURL = PortletProviderUtil.getPortletURL(renderRequest, Group.class.getName(), PortletProvider.Action.BROWSE);
 
 						siteBrowserURL.setParameter("groupId", String.valueOf(layout.getGroupId()));
+						siteBrowserURL.setParameter("includeCurrentGroup", Boolean.FALSE.toString());
 						siteBrowserURL.setParameter("selectedGroupIds", StringUtil.merge(assetPublisherDisplayContext.getGroupIds()));
 						siteBrowserURL.setParameter("types", StringUtil.merge(types));
 						siteBrowserURL.setParameter("filter", "contentSharingWithChildrenEnabled");


### PR DESCRIPTION
Hey Julio

This is a a fix for LPS-58592.

See the previous talk: https://github.com/juliocamarero/liferay-portal/pull/3693

One thing I am confused about is how to configure Current Page as AP's scope?

The list only shows:
1. Current site(page template)
2. Global
3. Other site..

I removed Other site.. option for page template and site template simply.

Please help to review it 

Thanks
John.