### PR TITLE
[Technical Support] LPS-60132 Move the dynamic filter logic from the display context to the AssetPublisherUtil class

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/display/context/AssetPublisherDisplayContext.java
@@ -18,10 +18,8 @@ import com.liferay.asset.publisher.web.configuration.AssetPublisherWebConfigurat
 import com.liferay.asset.publisher.web.constants.AssetPublisherPortletKeys;
 import com.liferay.asset.publisher.web.util.AssetPublisherUtil;
 import com.liferay.dynamic.data.mapping.util.DDMIndexerUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -36,33 +34,32 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.PortletConstants;
 import com.liferay.portal.security.permission.ActionKeys;
-import com.liferay.portal.security.permission.ResourceActionsUtil;
 import com.liferay.portal.service.permission.PortletPermissionUtil;
 import com.liferay.portal.theme.PortletDisplay;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.asset.AssetRendererFactoryRegistryUtil;
-import com.liferay.portlet.asset.model.AssetCategory;
 import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.model.AssetRenderer;
 import com.liferay.portlet.asset.model.AssetRendererFactory;
 import com.liferay.portlet.asset.model.ClassType;
 import com.liferay.portlet.asset.model.ClassTypeField;
 import com.liferay.portlet.asset.model.ClassTypeReader;
-import com.liferay.portlet.asset.service.AssetCategoryLocalServiceUtil;
 import com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil;
 import com.liferay.portlet.asset.service.AssetEntryServiceUtil;
 import com.liferay.portlet.asset.service.persistence.AssetEntryQuery;
 import com.liferay.portlet.asset.util.AssetUtil;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.io.Serializable;
+
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import javax.portlet.PortletConfig;
 import javax.portlet.PortletPreferences;
@@ -221,6 +218,28 @@ public class AssetPublisherDisplayContext {
 		return _assetLinkBehavior;
 	}
 
+	public Map<String, Serializable> getAttributes() {
+		Map<String, String[]> parameters = _request.getParameterMap();
+
+		if (_attributes == null) {
+			for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
+				String name = entry.getKey();
+				String[] values = entry.getValue();
+
+				if (ArrayUtil.isNotEmpty(values)) {
+					if (values.length == 1) {
+						_attributes.put(name, values[0]);
+					}
+					else {
+						_attributes.put(name, values);
+					}
+				}
+			}
+		}
+
+		return _attributes;
+	}
+
 	public long[] getAvailableClassNameIds() {
 		if (_availableClassNameIds == null) {
 			ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
@@ -250,6 +269,19 @@ public class AssetPublisherDisplayContext {
 		}
 
 		return _classTypeIds;
+	}
+
+	public Long getCompanyId() {
+		if (_companyId != null) {
+			return _companyId;
+		}
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_companyId = themeDisplay.getCompanyId();
+
+		return _companyId;
 	}
 
 	public String[] getCompilerTagNames() {
@@ -393,6 +425,32 @@ public class AssetPublisherDisplayContext {
 		return _groupIds;
 	}
 
+	public Layout getLayout() {
+		if (_layout != null) {
+			return _layout;
+		}
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_layout = themeDisplay.getLayout();
+
+		return _layout;
+	}
+
+	public Locale getLocale() {
+		if (_locale != null) {
+			return _locale;
+		}
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_locale = themeDisplay.getLocale();
+
+		return _locale;
+	}
+
 	public String[] getMetadataFields() {
 		if (_metadataFields == null) {
 			_metadataFields = StringUtil.split(
@@ -450,6 +508,17 @@ public class AssetPublisherDisplayContext {
 		}
 
 		return _paginationType;
+	}
+
+	public String getPortletName() {
+		PortletConfig portletConfig = (PortletConfig)_request.getAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG);
+
+		if (portletConfig == null) {
+			return StringPool.BLANK;
+		}
+
+		return portletConfig.getPortletName();
 	}
 
 	public String getPortletResource() {
@@ -528,6 +597,19 @@ public class AssetPublisherDisplayContext {
 		return _rssName;
 	}
 
+	public Long getScopeGroupId() {
+		if (_scopeGroupId != null) {
+			return _scopeGroupId;
+		}
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_scopeGroupId = themeDisplay.getScopeGroupId();
+
+		return _scopeGroupId;
+	}
+
 	public String getSelectionStyle() {
 		if (_selectionStyle == null) {
 			_selectionStyle = GetterUtil.getString(
@@ -563,6 +645,32 @@ public class AssetPublisherDisplayContext {
 		}
 
 		return _socialBookmarksDisplayStyle;
+	}
+
+	public TimeZone getTimeZone() {
+		if (_timeZone != null) {
+			return _timeZone;
+		}
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_timeZone = themeDisplay.getTimeZone();
+
+		return _timeZone;
+	}
+
+	public Long getUserId() {
+		if (_userId != null) {
+			return _userId;
+		}
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_userId = themeDisplay.getUserId();
+
+		return _userId;
 	}
 
 	public AssetEntry incrementViewCounter(AssetEntry assetEntry)
@@ -1091,19 +1199,6 @@ public class AssetPublisherDisplayContext {
 			"ddmStructureFieldValue", getDDMStructureFieldValue());
 	}
 
-
-
-	protected String getPortletName() {
-		PortletConfig portletConfig = (PortletConfig)_request.getAttribute(
-			JavaConstants.JAVAX_PORTLET_CONFIG);
-
-		if (portletConfig == null) {
-			return StringPool.BLANK;
-		}
-
-		return portletConfig.getPortletName();
-	}
-
 	protected void setDDMStructure() throws Exception {
 		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -1161,9 +1256,11 @@ public class AssetPublisherDisplayContext {
 	private Boolean _anyAssetType;
 	private AssetEntryQuery _assetEntryQuery;
 	private String _assetLinkBehavior;
+	private Map<String, Serializable> _attributes;
 	private long[] _availableClassNameIds;
 	private long[] _classNameIds;
 	private long[] _classTypeIds;
+	private Long _companyId;
 	private String[] _compilerTagNames;
 	private String _ddmStructureDisplayFieldValue;
 	private String _ddmStructureFieldLabel;
@@ -1188,6 +1285,8 @@ public class AssetPublisherDisplayContext {
 	private Boolean _excludeZeroViewCount;
 	private String[] _extensions;
 	private long[] _groupIds;
+	private Layout _layout;
+	private Locale _locale;
 	private Boolean _mergeLayoutTags;
 	private Boolean _mergeURLTags;
 	private String[] _metadataFields;
@@ -1206,6 +1305,7 @@ public class AssetPublisherDisplayContext {
 	private String _rssDisplayStyle;
 	private String _rssFeedType;
 	private String _rssName;
+	private Long _scopeGroupId;
 	private String _selectionStyle;
 	private Boolean _showAddContentButton;
 	private Boolean _showAssetTitle;
@@ -1217,5 +1317,7 @@ public class AssetPublisherDisplayContext {
 	private String _socialBookmarksDisplayPosition;
 	private String _socialBookmarksDisplayStyle;
 	private Boolean _subtypeFieldsFilterEnabled;
+	private TimeZone _timeZone;
+	private Long _userId;
 
 }

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetPublisherUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetPublisherUtil.java
@@ -390,26 +390,26 @@ public class AssetPublisherUtil {
 			int end)
 		throws Exception {
 
-		List<AssetEntry> results = new ArrayList<>();
-		int total = 0;
-
 		if (isSearchWithIndex(portletName, assetEntryQuery)) {
 			long[] assetCategoryIds = getAssetCategoryIds(portletPreferences);
+
 			String[] assetTagNames = getAssetTagNames(portletPreferences);
+
 			String keywords = assetEntryQuery.getKeywords();
 
 			return AssetUtil.searchAssetEntries(
-					assetCategoryIds, assetTagNames, keywords, locale,
-					assetEntryQuery, companyId, scopeGroupId, layout, timeZone,
-					userId, start, end, attributes);
+				assetCategoryIds, assetTagNames, keywords, locale,
+				assetEntryQuery, companyId, scopeGroupId, layout, timeZone,
+				userId, start, end, attributes);
 		}
 
-		total = _assetEntryService.getEntriesCount(assetEntryQuery);
+		int total = _assetEntryService.getEntriesCount(assetEntryQuery);
 
 		assetEntryQuery.setStart(start);
 		assetEntryQuery.setEnd(end);
 
-		results = _assetEntryService.getEntries(assetEntryQuery);
+		List<AssetEntry> results = _assetEntryService.getEntries(
+			assetEntryQuery);
 
 		return new BaseModelSearchResult<>(results, total);
 	}
@@ -753,17 +753,20 @@ public class AssetPublisherUtil {
 		AssetEntryQuery assetEntryQuery =
 			assetPublisherDisplayContext.getAssetEntryQuery();
 
-		String portletName = assetPublisherDisplayContext.getPortletName();
+		Layout layout = assetPublisherDisplayContext.getLayout();
 
-		long[] classNameIds = assetPublisherDisplayContext.getClassNameIds();
+		String portletName = assetPublisherDisplayContext.getPortletName();
 
 		Locale locale = assetPublisherDisplayContext.getLocale();
 
+		TimeZone timeZone = assetPublisherDisplayContext.getTimeZone();
+
 		long companyId = assetPublisherDisplayContext.getCompanyId();
 		long scopeGroupId = assetPublisherDisplayContext.getScopeGroupId();
-		Layout layout = assetPublisherDisplayContext.getLayout();
-		TimeZone timeZone = assetPublisherDisplayContext.getTimeZone();
 		long userId = assetPublisherDisplayContext.getUserId();
+
+		long[] classNameIds = assetPublisherDisplayContext.getClassNameIds();
+
 		Map<String, Serializable> attributes =
 			assetPublisherDisplayContext.getAttributes();
 

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetRSSUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetRSSUtil.java
@@ -198,7 +198,9 @@ public class AssetRSSUtil {
 		searchContainer.setDelta(assetPublisherDisplayContext.getRSSDelta());
 
 		List<AssetEntryResult> assetEntryResults =
-			assetPublisherDisplayContext.getAssetEntryResults(searchContainer);
+			AssetPublisherUtil.getAssetEntryResults(
+					assetPublisherDisplayContext,
+				searchContainer, portletPreferences);
 
 		for (AssetEntryResult assetEntryResult : assetEntryResults) {
 			assetEntries.addAll(assetEntryResult.getAssetEntries());

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetRSSUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetRSSUtil.java
@@ -199,8 +199,8 @@ public class AssetRSSUtil {
 
 		List<AssetEntryResult> assetEntryResults =
 			AssetPublisherUtil.getAssetEntryResults(
-					assetPublisherDisplayContext,
-				searchContainer, portletPreferences);
+				assetPublisherDisplayContext, searchContainer,
+				portletPreferences);
 
 		for (AssetEntryResult assetEntryResult : assetEntryResults) {
 			assetEntries.addAll(assetEntryResult.getAssetEntries());

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_dynamic_list.jspf
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_dynamic_list.jspf
@@ -15,7 +15,7 @@
 --%>
 
 <%
-List<AssetEntryResult> assetEntryResults = assetPublisherDisplayContext.getAssetEntryResults(searchContainer);
+List<AssetEntryResult> assetEntryResults = AssetPublisherUtil.getAssetEntryResults(assetPublisherDisplayContext, searchContainer, portletPreferences);
 
 for (AssetEntryResult assetEntryResult : assetEntryResults) {
 	List<AssetEntry> assetEntries = assetEntryResult.getAssetEntries();

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -629,8 +629,8 @@ public class AssetUtil {
 		throws Exception {
 
 		SearchContext searchContext = SearchContextFactory.getInstance(
-				assetCategoryIds, assetTagNames, keywords, locale, companyId,
-				scopeGroupId, layout, timeZone, userId, attributes);
+			assetCategoryIds, assetTagNames, keywords, locale, companyId,
+			scopeGroupId, layout, timeZone, userId, attributes);
 
 		return searchAssetEntries(searchContext, assetEntryQuery, start, end);
 	}

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -82,6 +82,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.TreeMap;
 
 import javax.portlet.PortletMode;
@@ -616,6 +617,20 @@ public class AssetUtil {
 		throws Exception {
 
 		SearchContext searchContext = SearchContextFactory.getInstance(request);
+
+		return searchAssetEntries(searchContext, assetEntryQuery, start, end);
+	}
+
+	public static BaseModelSearchResult<AssetEntry> searchAssetEntries(
+			long[] assetCategoryIds, String[] assetTagNames, String keywords,
+			Locale locale, AssetEntryQuery assetEntryQuery, long companyId,
+			long scopeGroupId, Layout layout, TimeZone timeZone, long userId,
+			int start, int end, Map<String, Serializable> attributes)
+		throws Exception {
+
+		SearchContext searchContext = SearchContextFactory.getInstance(
+				assetCategoryIds, assetTagNames, keywords, locale, companyId,
+				scopeGroupId, layout, timeZone, userId, attributes);
 
 		return searchAssetEntries(searchContext, assetEntryQuery, start, end);
 	}

--- a/portal-service/src/com/liferay/portal/kernel/search/SearchContextFactory.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/SearchContextFactory.java
@@ -18,12 +18,15 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.Layout;
 import com.liferay.portal.theme.ThemeDisplay;
 
 import java.io.Serializable;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -91,6 +94,49 @@ public class SearchContextFactory {
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
 		queryConfig.setLocale(themeDisplay.getLocale());
+
+		return searchContext;
+	}
+
+	public static SearchContext getInstance(
+		long[] assetCategoryIds, String[] assetTagNames, String keywords,
+		Locale locale, long companyId, long scopeGroupId, Layout layout,
+		TimeZone timeZone, long userId, Map<String, Serializable> attributes) {
+
+		SearchContext searchContext = new SearchContext();
+
+		// Theme display
+
+		searchContext.setCompanyId(companyId);
+		searchContext.setGroupIds(new long[] {scopeGroupId});
+		searchContext.setLayout(layout);
+		searchContext.setLocale(locale);
+		searchContext.setTimeZone(timeZone);
+		searchContext.setUserId(userId);
+
+		// Attributes
+
+		if (attributes != null) {
+			searchContext.setAttributes(attributes);
+		}
+		else {
+			searchContext.setAttributes(new HashMap<String, Serializable>());
+		}
+
+		// Asset
+
+		searchContext.setAssetCategoryIds(assetCategoryIds);
+		searchContext.setAssetTagNames(assetTagNames);
+
+		// Keywords
+
+		searchContext.setKeywords(keywords);
+
+		// Query config
+
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		queryConfig.setLocale(locale);
 
 		return searchContext;
 	}


### PR DESCRIPTION
Hi Julio,

here is our proposal for this modification. In the first commit we only moved the logic from the AssetPublisherDisplayContext to the AssetPublisherUtil class and we implemented the possibility to get the entry list without having a request object in the second commit. We tried to separate the logic to make it more understandable.

Please, take a look at or have someone to take a look at and let us know if you have any remarks or questions.

Thank you in advance,
Zsigmond