### PR TITLE
[TECHNICAL-SUPPORT] Web Content Display, Asset Publisher portlets: "show available locales" feature - country flags not sorted

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -36,7 +36,6 @@ import com.liferay.portal.kernel.templateparser.TransformerListener;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -57,6 +56,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Brian Wing Shun Chan
@@ -153,8 +153,13 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 
 	@Override
 	public String[] getAvailableLanguageIds() {
-		Set<String> availableLanguageIds = SetUtil.fromArray(
-			super.getAvailableLanguageIds());
+		String[] availableLanguageIdsArray = super.getAvailableLanguageIds();
+
+		Set<String> availableLanguageIds = new TreeSet<>();
+
+		for (int i = 0; i < availableLanguageIdsArray.length; i++) {
+			availableLanguageIds.add(availableLanguageIdsArray[i]);
+		}
 
 		Document document = getDocument();
 


### PR DESCRIPTION
Hi Julio,

Currently the Web Content Display and Asset Publisher portlets show the flags for the translations related to a Journal Article in a random order.

As far as I can see, all the getAvailableLanguageIds methods in *ModelImpl classes are using TreeSets, so the returned languageIds are ordered alphabetically.

I think we should follow this pattern in JournalArticleImpl, so the country flags will be ordered as well.

Thanks,
Tamás