### PR TITLE
LPS-61533 Lazy loading product menu -- CONTENT ON DEMAND

### DIFF
--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/BasePanelApp.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/BasePanelApp.java
@@ -88,8 +88,15 @@ public abstract class BasePanelApp implements PanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean include(
+			HttpServletRequest request, HttpServletResponse response)
+		throws IOException {
+
+		return false;
+	}
+
+	@Override
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		try {
@@ -108,14 +115,6 @@ public abstract class BasePanelApp implements PanelApp {
 		catch (Exception e) {
 			throw new PortalException(e);
 		}
-	}
-
-	@Override
-	public boolean include(
-			HttpServletRequest request, HttpServletResponse response)
-		throws IOException {
-
-		return false;
 	}
 
 	@Override

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/BasePanelCategory.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/BasePanelCategory.java
@@ -63,14 +63,6 @@ public abstract class BasePanelCategory implements PanelCategory {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		return true;
-	}
-
-	@Override
 	public int hashCode() {
 		return HashUtil.hash(0, getKey());
 	}
@@ -100,6 +92,13 @@ public abstract class BasePanelCategory implements PanelCategory {
 
 		return panelCategoryHelper.containsPortlet(
 			themeDisplay.getPpid(), this);
+	}
+
+	@Override
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
+		throws PortalException {
+
+		return true;
 	}
 
 }

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
@@ -54,7 +54,7 @@ public class PanelAppRegistry {
 
 		for (PanelApp panelApp : panelApps) {
 			try {
-				if (panelApp.hasAccessPermission(permissionChecker, group)) {
+				if (panelApp.isShow(permissionChecker, group)) {
 					return panelApp;
 				}
 			}
@@ -106,8 +106,7 @@ public class PanelAppRegistry {
 				@Override
 				public boolean filter(PanelApp panelApp) {
 					try {
-						return panelApp.hasAccessPermission(
-							permissionChecker, group);
+						return panelApp.isShow(permissionChecker, group);
 					}
 					catch (PortalException pe) {
 						_log.error(pe, pe);

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelCategoryRegistry.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelCategoryRegistry.java
@@ -88,8 +88,7 @@ public class PanelCategoryRegistry {
 				@Override
 				public boolean filter(PanelCategory panelCategory) {
 					try {
-						return panelCategory.hasAccessPermission(
-							permissionChecker, group);
+						return panelCategory.isShow(permissionChecker, group);
 					}
 					catch (PortalException pe) {
 						_log.error(pe, pe);
@@ -110,9 +109,7 @@ public class PanelCategoryRegistry {
 
 		for (PanelCategory panelCategory : panelCategories) {
 			try {
-				if (panelCategory.hasAccessPermission(
-						permissionChecker, group)) {
-
+				if (panelCategory.isShow(permissionChecker, group)) {
 					return panelCategory;
 				}
 			}

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelEntry.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelEntry.java
@@ -29,8 +29,7 @@ public interface PanelEntry {
 
 	public String getLabel(Locale locale);
 
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException;
 
 }

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/RootPanelCategory.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/RootPanelCategory.java
@@ -15,13 +15,10 @@
 package com.liferay.application.list;
 
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.permission.PermissionChecker;
-
-import java.io.IOException;
 
 import java.util.Locale;
 

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/RootPanelCategory.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/RootPanelCategory.java
@@ -62,16 +62,14 @@ public class RootPanelCategory implements PanelCategory {
 
 	@Override
 	public boolean include(
-			HttpServletRequest request, HttpServletResponse response)
-		throws IOException {
+		HttpServletRequest request, HttpServletResponse response) {
 
 		return false;
 	}
 
 	@Override
 	public boolean includeHeader(
-			HttpServletRequest request, HttpServletResponse response)
-		throws IOException {
+		HttpServletRequest request, HttpServletResponse response) {
 
 		return false;
 	}
@@ -84,9 +82,7 @@ public class RootPanelCategory implements PanelCategory {
 	}
 
 	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
+	public boolean isShow(PermissionChecker permissionChecker, Group group) {
 		return true;
 	}
 

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/RootPanelCategory.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/RootPanelCategory.java
@@ -61,14 +61,6 @@ public class RootPanelCategory implements PanelCategory {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		return true;
-	}
-
-	@Override
 	public boolean include(
 			HttpServletRequest request, HttpServletResponse response)
 		throws IOException {
@@ -89,6 +81,13 @@ public class RootPanelCategory implements PanelCategory {
 		HttpServletRequest request, PanelCategoryHelper panelCategoryHelper) {
 
 		return false;
+	}
+
+	@Override
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
+		throws PortalException {
+
+		return true;
 	}
 
 	private RootPanelCategory() {

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/application/list/ConfigurationAdminPanelApp.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/application/list/ConfigurationAdminPanelApp.java
@@ -18,10 +18,7 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.configuration.admin.web.constants.ConfigurationAdminPortletKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.PermissionChecker;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,13 +39,6 @@ public class ConfigurationAdminPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return ConfigurationAdminPortletKeys.CONFIGURATION_ADMIN;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		return permissionChecker.isOmniadmin();
 	}
 
 	@Override

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/application/list/ConfigurationAdminPanelApp.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/application/list/ConfigurationAdminPanelApp.java
@@ -45,8 +45,7 @@ public class ConfigurationAdminPanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		return permissionChecker.isOmniadmin();

--- a/modules/apps/control-menu/control-menu-api/src/main/java/com/liferay/control/menu/BaseControlMenuEntry.java
+++ b/modules/apps/control-menu/control-menu-api/src/main/java/com/liferay/control/menu/BaseControlMenuEntry.java
@@ -74,13 +74,6 @@ public abstract class BaseControlMenuEntry implements ControlMenuEntry {
 	}
 
 	@Override
-	public boolean hasAccessPermission(HttpServletRequest request)
-		throws PortalException {
-
-		return true;
-	}
-
-	@Override
 	public int hashCode() {
 		return HashUtil.hash(0, getKey());
 	}
@@ -91,6 +84,11 @@ public abstract class BaseControlMenuEntry implements ControlMenuEntry {
 		throws IOException {
 
 		return false;
+	}
+
+	@Override
+	public boolean isShow(HttpServletRequest request) throws PortalException {
+		return true;
 	}
 
 	@Override

--- a/modules/apps/control-menu/control-menu-api/src/main/java/com/liferay/control/menu/ControlMenuEntry.java
+++ b/modules/apps/control-menu/control-menu-api/src/main/java/com/liferay/control/menu/ControlMenuEntry.java
@@ -41,12 +41,11 @@ public interface ControlMenuEntry {
 
 	public String getURL(HttpServletRequest request);
 
-	public boolean hasAccessPermission(HttpServletRequest request)
-		throws PortalException;
-
 	public boolean include(
 			HttpServletRequest request, HttpServletResponse response)
 		throws IOException;
+
+	public boolean isShow(HttpServletRequest request) throws PortalException;
 
 	public boolean isUseDialog();
 

--- a/modules/apps/control-menu/control-menu-api/src/main/java/com/liferay/control/menu/util/ControlMenuEntryRegistry.java
+++ b/modules/apps/control-menu/control-menu-api/src/main/java/com/liferay/control/menu/util/ControlMenuEntryRegistry.java
@@ -74,7 +74,7 @@ public class ControlMenuEntryRegistry {
 				@Override
 				public boolean filter(ControlMenuEntry controlMenuEntry) {
 					try {
-						return controlMenuEntry.hasAccessPermission(request);
+						return controlMenuEntry.isShow(request);
 					}
 					catch (PortalException pe) {
 						_log.error(pe, pe);

--- a/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/AddContentControlMenuEntry.java
+++ b/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/AddContentControlMenuEntry.java
@@ -53,9 +53,7 @@ public class AddContentControlMenuEntry
 	}
 
 	@Override
-	public boolean hasAccessPermission(HttpServletRequest request)
-		throws PortalException {
-
+	public boolean isShow(HttpServletRequest request) throws PortalException {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
@@ -72,7 +70,7 @@ public class AddContentControlMenuEntry
 			return false;
 		}
 
-		return super.hasAccessPermission(request);
+		return super.isShow(request);
 	}
 
 	@Override

--- a/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/IndexingControlMenuEntry.java
+++ b/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/IndexingControlMenuEntry.java
@@ -85,9 +85,7 @@ public class IndexingControlMenuEntry
 	}
 
 	@Override
-	public boolean hasAccessPermission(HttpServletRequest request)
-		throws PortalException {
-
+	public boolean isShow(HttpServletRequest request) throws PortalException {
 		int count = _backgroundTaskManager.getBackgroundTasksCount(
 			CompanyConstants.SYSTEM,
 			new String[] {
@@ -100,7 +98,7 @@ public class IndexingControlMenuEntry
 			return false;
 		}
 
-		return super.hasAccessPermission(request);
+		return super.isShow(request);
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/InformationMessagesControlMenuEntry.java
+++ b/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/InformationMessagesControlMenuEntry.java
@@ -57,28 +57,6 @@ public class InformationMessagesControlMenuEntry
 		return "/entries/information_messages.jsp";
 	}
 
-	@Override
-	public boolean hasAccessPermission(HttpServletRequest request)
-		throws PortalException {
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		Layout layout = themeDisplay.getLayout();
-
-		if (layout.isTypeControlPanel()) {
-			return false;
-		}
-
-		if (!isCustomizableLayout(themeDisplay) &&
-			!isLinkedLayout(themeDisplay) && !isModifiedLayout(themeDisplay)) {
-
-			return false;
-		}
-
-		return super.hasAccessPermission(request);
-	}
-
 	public boolean hasUpdateLayoutPermission(ThemeDisplay themeDisplay)
 		throws PortalException {
 
@@ -178,6 +156,26 @@ public class InformationMessagesControlMenuEntry
 		}
 
 		return true;
+	}
+
+	@Override
+	public boolean isShow(HttpServletRequest request) throws PortalException {
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout.isTypeControlPanel()) {
+			return false;
+		}
+
+		if (!isCustomizableLayout(themeDisplay) &&
+			!isLinkedLayout(themeDisplay) && !isModifiedLayout(themeDisplay)) {
+
+			return false;
+		}
+
+		return super.isShow(request);
 	}
 
 	@Override

--- a/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/ManageLayoutControlMenuEntry.java
+++ b/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/ManageLayoutControlMenuEntry.java
@@ -99,9 +99,7 @@ public class ManageLayoutControlMenuEntry
 	}
 
 	@Override
-	public boolean hasAccessPermission(HttpServletRequest request)
-		throws PortalException {
-
+	public boolean isShow(HttpServletRequest request) throws PortalException {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
@@ -117,7 +115,7 @@ public class ManageLayoutControlMenuEntry
 			return false;
 		}
 
-		return super.hasAccessPermission(request);
+		return super.isShow(request);
 	}
 
 }

--- a/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/ToggleControlsControlMenuEntry.java
+++ b/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/ToggleControlsControlMenuEntry.java
@@ -100,9 +100,7 @@ public class ToggleControlsControlMenuEntry
 	}
 
 	@Override
-	public boolean hasAccessPermission(HttpServletRequest request)
-		throws PortalException {
-
+	public boolean isShow(HttpServletRequest request) throws PortalException {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
@@ -125,7 +123,7 @@ public class ToggleControlsControlMenuEntry
 			return false;
 		}
 
-		return super.hasAccessPermission(request);
+		return super.isShow(request);
 	}
 
 	protected boolean hasCustomizePermission(ThemeDisplay themeDisplay)

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/application/list/ExportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/application/list/ExportPanelApp.java
@@ -47,8 +47,7 @@ public class ExportPanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/application/list/ExportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/application/list/ExportPanelApp.java
@@ -18,12 +18,7 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.exportimport.web.constants.ExportImportPortletKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.ActionKeys;
-import com.liferay.portal.security.permission.PermissionChecker;
-import com.liferay.portal.service.permission.GroupPermissionUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,18 +39,6 @@ public class ExportPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return ExportImportPortletKeys.EXPORT;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
-			return false;
-		}
-
-		return GroupPermissionUtil.contains(
-			permissionChecker, group, ActionKeys.EXPORT_IMPORT_LAYOUTS);
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/application/list/ImportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/application/list/ImportPanelApp.java
@@ -47,8 +47,7 @@ public class ImportPanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/application/list/ImportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/application/list/ImportPanelApp.java
@@ -18,12 +18,7 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.exportimport.web.constants.ExportImportPortletKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.ActionKeys;
-import com.liferay.portal.security.permission.PermissionChecker;
-import com.liferay.portal.service.permission.GroupPermissionUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,18 +39,6 @@ public class ImportPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return ExportImportPortletKeys.IMPORT;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
-			return false;
-		}
-
-		return GroupPermissionUtil.contains(
-			permissionChecker, group, ActionKeys.EXPORT_IMPORT_LAYOUTS);
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/portlet/ExportControlPanelEntry.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/portlet/ExportControlPanelEntry.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.web.portlet;
+
+import com.liferay.exportimport.web.constants.ExportImportPortletKeys;
+import com.liferay.portlet.ControlPanelEntry;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Julio Camarero
+ */
+@Component(
+	immediate = true,
+	property = {"javax.portlet.name=" + ExportImportPortletKeys.EXPORT},
+	service = ControlPanelEntry.class
+)
+public class ExportControlPanelEntry extends ExportImportControlPanelEntry {
+}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/portlet/ExportImportControlPanelEntry.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/portlet/ExportImportControlPanelEntry.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.web.portlet;
+
+import com.liferay.exportimport.web.constants.ExportImportPortletKeys;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Portlet;
+import com.liferay.portal.security.permission.ActionKeys;
+import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.service.permission.GroupPermissionUtil;
+import com.liferay.portlet.BaseControlPanelEntry;
+import com.liferay.portlet.ControlPanelEntry;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Julio Camarero
+ */
+@Component(
+	immediate = true,
+	property = {"javax.portlet.name=" + ExportImportPortletKeys.EXPORT_IMPORT},
+	service = ControlPanelEntry.class
+)
+public class ExportImportControlPanelEntry extends BaseControlPanelEntry {
+
+	@Override
+	protected boolean hasAccessPermissionDenied(
+			PermissionChecker permissionChecker, Group group, Portlet portlet)
+		throws Exception {
+
+		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
+			return true;
+		}
+
+		return super.hasAccessPermissionDenied(
+			permissionChecker, group, portlet);
+	}
+
+	@Override
+	protected boolean hasAccessPermissionExplicitlyGranted(
+			PermissionChecker permissionChecker, Group group, Portlet portlet)
+		throws PortalException {
+
+		if (GroupPermissionUtil.contains(
+				permissionChecker, group, ActionKeys.EXPORT_IMPORT_LAYOUTS)) {
+
+			return true;
+		}
+
+		return super.hasAccessPermissionExplicitlyGranted(
+			permissionChecker, group, portlet);
+	}
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/portlet/ImportControlPanelEntry.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/portlet/ImportControlPanelEntry.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.web.portlet;
+
+import com.liferay.exportimport.web.constants.ExportImportPortletKeys;
+import com.liferay.portlet.ControlPanelEntry;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Julio Camarero
+ */
+@Component(
+	immediate = true,
+	property = {"javax.portlet.name=" + ExportImportPortletKeys.IMPORT},
+	service = ControlPanelEntry.class
+)
+public class ImportControlPanelEntry extends ExportImportControlPanelEntry {
+}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/upgrade/JournalServiceUpgrade.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/upgrade/JournalServiceUpgrade.java
@@ -16,7 +16,7 @@ package com.liferay.journal.upgrade;
 
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLinkLocalService;
-import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
+import com.liferay.dynamic.data.mapping.util.DefaultDDMStructureHelper;
 import com.liferay.journal.upgrade.v0_0_2.UpgradeClassNames;
 import com.liferay.journal.upgrade.v0_0_3.UpgradeJournalArticleType;
 import com.liferay.journal.upgrade.v1_0_0.UpgradeCompanyId;
@@ -72,9 +72,9 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 			"com.liferay.journal.service", "0.0.3", "1.0.0",
 			new UpgradeSchema(), new UpgradeCompanyId(),
 			new UpgradeJournal(
-				_companyLocalService, _ddmStructureLocalService,
-				_ddmTemplateLinkLocalService, _ddmTemplateLocalService,
-				_groupLocalService, _userLocalService),
+				_companyLocalService, _ddmTemplateLinkLocalService,
+				_defaultDDMStructureHelper, _groupLocalService,
+				_userLocalService),
 			new UpgradeJournalArticles(
 				_assetCategoryLocalService, _ddmStructureLocalService,
 				_groupLocalService, _layoutLocalService),
@@ -157,10 +157,10 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 	}
 
 	@Reference(unbind = "-")
-	protected void setDDMTemplateLocalService(
-		DDMTemplateLocalService ddmTemplateLocalService) {
+	protected void setDefaultDDMStructureHelper(
+		DefaultDDMStructureHelper defaultDDMStructureHelper) {
 
-		_ddmTemplateLocalService = ddmTemplateLocalService;
+		_defaultDDMStructureHelper = defaultDDMStructureHelper;
 	}
 
 	@Reference(unbind = "-")
@@ -199,7 +199,7 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 	private volatile CompanyLocalService _companyLocalService;
 	private volatile DDMStructureLocalService _ddmStructureLocalService;
 	private volatile DDMTemplateLinkLocalService _ddmTemplateLinkLocalService;
-	private volatile DDMTemplateLocalService _ddmTemplateLocalService;
+	private volatile DefaultDDMStructureHelper _defaultDDMStructureHelper;
 	private volatile GroupLocalService _groupLocalService;
 	private volatile LayoutLocalService _layoutLocalService;
 	private volatile SettingsFactory _settingsFactory;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/upgrade/v1_0_0/UpgradeJournal.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/upgrade/v1_0_0/UpgradeJournal.java
@@ -82,15 +82,18 @@ public class UpgradeJournal extends UpgradeProcess {
 
 		PermissionThreadLocal.setAddResource(false);
 
-		_defaultDDMStructureHelper.addDDMStructures(
-			defaultUserId, group.getGroupId(),
-			PortalUtil.getClassNameId(JournalArticle.class),
-			getClass().getClassLoader(),
-			"com/liferay/journal/upgrade/v1_0_0/dependencies" +
-				"/basic-web-content-structure.xml",
-			new ServiceContext());
-
-		PermissionThreadLocal.setAddResource(addResource);
+		try {
+			_defaultDDMStructureHelper.addDDMStructures(
+				defaultUserId, group.getGroupId(),
+				PortalUtil.getClassNameId(JournalArticle.class),
+				getClass().getClassLoader(),
+				"com/liferay/journal/upgrade/v1_0_0/dependencies" +
+					"/basic-web-content-structure.xml",
+				new ServiceContext());
+		}
+		finally {
+			PermissionThreadLocal.setAddResource(addResource);
+		}
 
 		String defaultLanguageId = UpgradeProcessUtil.getDefaultLanguageId(
 			companyId);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/upgrade/v1_0_0/UpgradeJournal.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/upgrade/v1_0_0/UpgradeJournal.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.security.permission.PermissionThreadLocal;
 import com.liferay.portal.service.CompanyLocalService;
 import com.liferay.portal.service.GroupLocalService;
 import com.liferay.portal.service.ServiceContext;
@@ -77,6 +78,10 @@ public class UpgradeJournal extends UpgradeProcess {
 
 		long defaultUserId = _userLocalService.getDefaultUserId(companyId);
 
+		boolean addResource = PermissionThreadLocal.isAddResource();
+
+		PermissionThreadLocal.setAddResource(false);
+
 		_defaultDDMStructureHelper.addDDMStructures(
 			defaultUserId, group.getGroupId(),
 			PortalUtil.getClassNameId(JournalArticle.class),
@@ -84,6 +89,8 @@ public class UpgradeJournal extends UpgradeProcess {
 			"com/liferay/journal/upgrade/v1_0_0/dependencies" +
 				"/basic-web-content-structure.xml",
 			new ServiceContext());
+
+		PermissionThreadLocal.setAddResource(addResource);
 
 		String defaultLanguageId = UpgradeProcessUtil.getDefaultLanguageId(
 			companyId);

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/application/list/MarketplaceAppManagerPanelApp.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/application/list/MarketplaceAppManagerPanelApp.java
@@ -46,8 +46,7 @@ public class MarketplaceAppManagerPanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		return permissionChecker.isOmniadmin();

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/application/list/MarketplaceAppManagerPanelApp.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/application/list/MarketplaceAppManagerPanelApp.java
@@ -18,10 +18,7 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.marketplace.app.manager.web.constants.MarketplaceAppManagerPortletKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.PermissionChecker;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -43,13 +40,6 @@ public class MarketplaceAppManagerPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return MarketplaceAppManagerPortletKeys.MARKETPLACE_APP_MANAGER;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		return permissionChecker.isOmniadmin();
 	}
 
 	@Override

--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/application/list/MarketplacePurchasedPanelApp.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/application/list/MarketplacePurchasedPanelApp.java
@@ -46,8 +46,7 @@ public class MarketplacePurchasedPanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		return permissionChecker.isOmniadmin();

--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/application/list/MarketplacePurchasedPanelApp.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/application/list/MarketplacePurchasedPanelApp.java
@@ -18,10 +18,7 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.marketplace.store.web.constants.MarketplaceStorePortletKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.PermissionChecker;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -43,13 +40,6 @@ public class MarketplacePurchasedPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return MarketplaceStorePortletKeys.MARKETPLACE_PURCHASED;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		return permissionChecker.isOmniadmin();
 	}
 
 	@Override

--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/application/list/MarketplaceStorePanelApp.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/application/list/MarketplaceStorePanelApp.java
@@ -18,10 +18,7 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.marketplace.store.web.constants.MarketplaceStorePortletKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.PermissionChecker;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -43,13 +40,6 @@ public class MarketplaceStorePanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return MarketplaceStorePortletKeys.MARKETPLACE_STORE;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		return permissionChecker.isOmniadmin();
 	}
 
 	@Override

--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/application/list/MarketplaceStorePanelApp.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/application/list/MarketplaceStorePanelApp.java
@@ -46,8 +46,7 @@ public class MarketplaceStorePanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		return permissionChecker.isOmniadmin();

--- a/modules/apps/portal-instances/portal-instances-web/src/main/java/com/liferay/portal/instances/web/application/list/PortalInstancesPanelApp.java
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/java/com/liferay/portal/instances/web/application/list/PortalInstancesPanelApp.java
@@ -45,8 +45,7 @@ public class PortalInstancesPanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		return permissionChecker.isOmniadmin();

--- a/modules/apps/portal-instances/portal-instances-web/src/main/java/com/liferay/portal/instances/web/application/list/PortalInstancesPanelApp.java
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/java/com/liferay/portal/instances/web/application/list/PortalInstancesPanelApp.java
@@ -18,10 +18,7 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.portal.instances.web.constants.PortalInstancesPortletKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.PermissionChecker;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,13 +39,6 @@ public class PortalInstancesPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return PortalInstancesPortletKeys.PORTAL_INSTANCES;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		return permissionChecker.isOmniadmin();
 	}
 
 	@Override

--- a/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/application/list/ControlPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/application/list/ControlPanelCategory.java
@@ -59,8 +59,7 @@ public class ControlPanelCategory extends BasePanelCategory {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		if (PortalPermissionUtil.contains(

--- a/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/application/list/SitesPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/application/list/SitesPanelCategory.java
@@ -57,8 +57,7 @@ public class SitesPanelCategory extends BasePanelCategory {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		if (PortalPermissionUtil.contains(

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/control/menu/ProductMenuControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/control/menu/ProductMenuControlMenuEntry.java
@@ -54,9 +54,7 @@ public class ProductMenuControlMenuEntry extends BaseJSPControlMenuEntry {
 	}
 
 	@Override
-	public boolean hasAccessPermission(HttpServletRequest request)
-		throws PortalException {
-
+	public boolean isShow(HttpServletRequest request) throws PortalException {
 		if (_panelCategoryRegistry == null) {
 			return false;
 		}
@@ -76,7 +74,7 @@ public class ProductMenuControlMenuEntry extends BaseJSPControlMenuEntry {
 			return false;
 		}
 
-		return super.hasAccessPermission(request);
+		return super.isShow(request);
 	}
 
 	@Override

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/control_menu/product_menu_control_menu_entry.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/control_menu/product_menu_control_menu_entry.jsp
@@ -21,7 +21,11 @@ String productMenuState = SessionClicks.get(request, "com.liferay.control.menu.w
 %>
 
 <li class="<%= Validator.equals(productMenuState, "open") ? "active" : StringPool.BLANK %>">
-	<a class="control-menu-icon sidenav-toggler" data-content="body" data-qa-id="productMenu" data-target="#sidenavSliderId,#wrapper" data-title="<%= HtmlUtil.escape(LanguageUtil.get(request, "menu")) %>" data-toggle="sidenav" data-type="fixed-push" data-type-mobile="fixed" href="#sidenavSliderId" id="sidenavToggleId">
+	<liferay-portlet:renderURL portletName="<%= ProductNavigationProductMenuPortletKeys.PRODUCT_NAVIGATION_PRODUCT_MENU %>" var="portletURL" windowState="exclusive">
+		<portlet:param name="mvcPath" value="/portlet/product_menu.jsp" />
+	</liferay-portlet:renderURL>
+
+	<a class="control-menu-icon sidenav-toggler" data-content="body" data-panelurl="<%= portletURL.toString() %>" data-qa-id="productMenu" data-target="#sidenavSliderId,#wrapper" data-title="<%= HtmlUtil.escape(LanguageUtil.get(request, "menu")) %>" data-toggle="sidenav" data-type="fixed-push" data-type-mobile="fixed" href="#sidenavSliderId" id="sidenavToggleId">
 		<div class="toast-animation">
 			<div class="pm"></div>
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
@@ -20,8 +20,10 @@
 
 <%@ taglib uri="http://liferay.com/tld/application-list" prefix="liferay-application-list" %><%@
 taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
+taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.application.list.PanelCategory" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
@@ -1,0 +1,72 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/portlet/init.jsp" %>
+
+<c:if test="<%= productMenuDisplayContext.isShowProductMenu() %>">
+	<h4 class="sidebar-header">
+		<a href="<%= themeDisplay.getURLPortal() %>">
+			<span class="company-details">
+				<img alt="" class="company-logo" src="<%= themeDisplay.getCompanyLogo() %>" />
+				<span class="company-name"><%= company.getName() %></span>
+			</span>
+
+			<aui:icon cssClass="icon-monospaced sidenav-close visible-xs-block" image="remove" url="javascript:;" />
+		</a>
+	</h4>
+
+	<div class="sidebar-body">
+		<div aria-multiselectable="true" class="panel-group" id="<portlet:namespace />Accordion" role="tablist">
+
+			<%
+			List<PanelCategory> childPanelCategories = productMenuDisplayContext.getChildPanelCategories();
+
+			for (PanelCategory childPanelCategory : childPanelCategories) {
+			%>
+
+				<div class="panel">
+					<div class="panel-heading" id="<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Heading" role="tab">
+						<div class="panel-title">
+							<c:if test="<%= !childPanelCategory.includeHeader(request, new PipingServletResponse(pageContext)) %>">
+								<div aria-controls="#<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Collapse" aria-expanded="<%= Validator.equals(childPanelCategory.getKey(), productMenuDisplayContext.getRootPanelCategoryKey()) %>" class="panel-toggler collapse-icon <%= Validator.equals(childPanelCategory.getKey(), productMenuDisplayContext.getRootPanelCategoryKey()) ? StringPool.BLANK : "collapsed" %>" class="collapsed" data-parent="#<portlet:namespace />Accordion" data-toggle="collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Collapse" role="button">
+									<span><%= childPanelCategory.getLabel(locale) %></span>
+
+									<%
+									int notificationsCount = productMenuDisplayContext.getNotificationsCount(childPanelCategory);
+									%>
+
+									<c:if test="<%= notificationsCount > 0 %>">
+										<span class="panel-notifications-count sticker sticker-right sticker-rounded sticker-sm sticker-warning"><%= notificationsCount %></span>
+									</c:if>
+								</div>
+							</c:if>
+						</div>
+					</div>
+
+					<div aria-expanded="false" aria-labelledby="<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Heading" class="panel-collapse collapse <%= Validator.equals(childPanelCategory.getKey(), productMenuDisplayContext.getRootPanelCategoryKey()) ? "in" : StringPool.BLANK %>" id="<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Collapse" role="tabpanel">
+						<div class="panel-body">
+							<liferay-application-list:panel-content panelCategory="<%= childPanelCategory %>" />
+						</div>
+					</div>
+				</div>
+
+			<%
+			}
+			%>
+
+		</div>
+	</div>
+</c:if>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -16,80 +16,76 @@
 
 <%@ include file="/portlet/init.jsp" %>
 
-<c:if test="<%= productMenuDisplayContext.isShowProductMenu() %>">
-	<h4 class="sidebar-header">
-		<a href="<%= themeDisplay.getURLPortal() %>">
-			<span class="company-details">
-				<img alt="" class="company-logo" src="<%= themeDisplay.getCompanyLogo() %>" />
-				<span class="company-name"><%= company.getName() %></span>
-			</span>
+<%
+String productMenuState = SessionClicks.get(request, "com.liferay.control.menu.web_productMenuState", "closed");
+%>
 
-			<aui:icon cssClass="icon-monospaced sidenav-close visible-xs-block" image="remove" url="javascript:;" />
-		</a>
-	</h4>
+<div class="<%= Validator.equals(productMenuState, "open") ? "has-content" : StringPool.BLANK %>" id="productMenuSidebar">
+	<c:if test='<%= Validator.equals(productMenuState, "open") %>'>
+		<liferay-util:include page="/portlet/product_menu.jsp" servletContext="<%= application %>" />
+	</c:if>
+</div>
 
-	<div class="sidebar-body">
-		<div aria-multiselectable="true" class="panel-group" id="<portlet:namespace />Accordion" role="tablist">
+<aui:script use="liferay-store">
+	AUI.$('#sidenavToggleId').sideNavigation();
 
-			<%
-			List<PanelCategory> childPanelCategories = productMenuDisplayContext.getChildPanelCategories();
+	var sidenavSlider = AUI.$('#sidenavSliderId');
 
-			for (PanelCategory childPanelCategory : childPanelCategories) {
-			%>
+	sidenavSlider.off('closed.lexicon.sidenav');
+	sidenavSlider.off('open.lexicon.sidenav');
 
-				<div class="panel">
-					<div class="panel-heading" id="<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Heading" role="tab">
-						<div class="panel-title">
-							<c:if test="<%= !childPanelCategory.includeHeader(request, new PipingServletResponse(pageContext)) %>">
-								<div aria-controls="#<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Collapse" aria-expanded="<%= Validator.equals(childPanelCategory.getKey(), productMenuDisplayContext.getRootPanelCategoryKey()) %>" class="panel-toggler collapse-icon <%= Validator.equals(childPanelCategory.getKey(), productMenuDisplayContext.getRootPanelCategoryKey()) ? StringPool.BLANK : "collapsed" %>" class="collapsed" data-parent="#<portlet:namespace />Accordion" data-toggle="collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Collapse" role="button">
-									<span><%= childPanelCategory.getLabel(locale) %></span>
+	sidenavSlider.on(
+		'closed.lexicon.sidenav',
+		function(event) {
+			Liferay.Store('com.liferay.control.menu.web_productMenuState', 'closed');
+		}
+	);
 
-									<%
-									int notificationsCount = productMenuDisplayContext.getNotificationsCount(childPanelCategory);
-									%>
+	sidenavSlider.on(
+		'open.lexicon.sidenav',
+		function(event) {
+		   	var productMenuSidebar = A.one('#productMenuSidebar');
 
-									<c:if test="<%= notificationsCount > 0 %>">
-										<span class="panel-notifications-count sticker sticker-right sticker-rounded sticker-sm sticker-warning"><%= notificationsCount %></span>
-									</c:if>
-								</div>
-							</c:if>
-						</div>
-					</div>
+	 		if (productMenuSidebar && !productMenuSidebar.hasClass('has-content')) {
+	 			<portlet:namespace />getProductMenuSidebar();
+	 		}
 
-					<div aria-expanded="false" aria-labelledby="<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Heading" class="panel-collapse collapse <%= Validator.equals(childPanelCategory.getKey(), productMenuDisplayContext.getRootPanelCategoryKey()) ? "in" : StringPool.BLANK %>" id="<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Collapse" role="tabpanel">
-						<div class="panel-body">
-							<liferay-application-list:panel-content panelCategory="<%= childPanelCategory %>" />
-						</div>
-					</div>
-				</div>
+			Liferay.Store('com.liferay.control.menu.web_productMenuState', 'open');
+		}
+	);
+</aui:script>
 
-			<%
+<aui:script>
+	Liferay.provide(
+		window,
+		'<portlet:namespace />getProductMenuSidebar',
+		function() {
+			var A = AUI();
+
+			var sidenavToggle = A.one('#sidenavToggleId');
+
+			if (sidenavToggle) {
+				var uri = sidenavToggle.attr('data-panelurl');
+
+				A.io.request(
+					uri,
+					{
+						after: {
+							success: function(event, id, obj) {
+								var response = this.get('responseData');
+
+								var productMenuSidebar = A.one('#productMenuSidebar');
+
+								productMenuSidebar.plug(A.Plugin.ParseContent);
+
+								productMenuSidebar.setContent(response);
+								productMenuSidebar.addClass('has-content');
+							}
+						}
+					}
+				);
 			}
-			%>
-
-		</div>
-	</div>
-
-	<aui:script use="liferay-store">
-		AUI.$('#sidenavToggleId').sideNavigation();
-
-		var sidenavSlider = AUI.$('#sidenavSliderId');
-
-		sidenavSlider.off('closed.lexicon.sidenav');
-		sidenavSlider.off('open.lexicon.sidenav');
-
-		sidenavSlider.on(
-			'closed.lexicon.sidenav',
-			function(event) {
-				Liferay.Store('com.liferay.control.menu.web_productMenuState', 'closed');
-			}
-		);
-
-		sidenavSlider.on(
-			'open.lexicon.sidenav',
-			function(event) {
-				Liferay.Store('com.liferay.control.menu.web_productMenuState', 'open');
-			}
-		);
-	</aui:script>
-</c:if>
+		},
+		['aui-io-request', 'aui-parse-content', 'event-outside']
+	);
+</aui:script>

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/java/com/liferay/product/navigation/simulation/device/application/list/DevicePreviewPanelApp.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/java/com/liferay/product/navigation/simulation/device/application/list/DevicePreviewPanelApp.java
@@ -57,8 +57,7 @@ public class DevicePreviewPanelApp extends BaseJSPPanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		if (group.isControlPanel()) {
@@ -69,7 +68,7 @@ public class DevicePreviewPanelApp extends BaseJSPPanelApp {
 			return false;
 		}
 
-		return super.hasAccessPermission(permissionChecker, group);
+		return super.isShow(permissionChecker, group);
 	}
 
 	@Override

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/java/com/liferay/product/navigation/simulation/web/control/SimulationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/java/com/liferay/product/navigation/simulation/web/control/SimulationControlMenuEntry.java
@@ -55,9 +55,7 @@ public class SimulationControlMenuEntry
 	}
 
 	@Override
-	public boolean hasAccessPermission(HttpServletRequest request)
-		throws PortalException {
-
+	public boolean isShow(HttpServletRequest request) throws PortalException {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
@@ -79,7 +77,7 @@ public class SimulationControlMenuEntry
 			return false;
 		}
 
-		return super.hasAccessPermission(request);
+		return super.isShow(request);
 	}
 
 	@Override

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/application/list/PublishingToolsPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/application/list/PublishingToolsPanelCategory.java
@@ -17,10 +17,7 @@ package com.liferay.product.navigation.site.administration.application.list;
 import com.liferay.application.list.BasePanelCategory;
 import com.liferay.application.list.PanelCategory;
 import com.liferay.application.list.constants.PanelCategoryKeys;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.model.Group;
-import com.liferay.portal.security.permission.PermissionChecker;
 
 import java.util.Locale;
 
@@ -53,17 +50,6 @@ public class PublishingToolsPanelCategory extends BasePanelCategory {
 	public String getLabel(Locale locale) {
 		return LanguageUtil.get(
 			locale, "category.site_administration.publishing_tools");
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
-			return false;
-		}
-
-		return true;
 	}
 
 }

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/application/list/PublishingToolsPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/application/list/PublishingToolsPanelCategory.java
@@ -56,8 +56,7 @@ public class PublishingToolsPanelCategory extends BasePanelCategory {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {

--- a/modules/apps/server-admin/server-admin-web/src/main/java/com/liferay/server/admin/web/application/list/ServerAdminPanelApp.java
+++ b/modules/apps/server-admin/server-admin-web/src/main/java/com/liferay/server/admin/web/application/list/ServerAdminPanelApp.java
@@ -45,8 +45,7 @@ public class ServerAdminPanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		return permissionChecker.isOmniadmin();

--- a/modules/apps/server-admin/server-admin-web/src/main/java/com/liferay/server/admin/web/application/list/ServerAdminPanelApp.java
+++ b/modules/apps/server-admin/server-admin-web/src/main/java/com/liferay/server/admin/web/application/list/ServerAdminPanelApp.java
@@ -17,10 +17,7 @@ package com.liferay.server.admin.web.application.list;
 import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
@@ -42,13 +39,6 @@ public class ServerAdminPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return PortletKeys.SERVER_ADMIN;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		return permissionChecker.isOmniadmin();
 	}
 
 	@Override

--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/application/list/StagingProcessesPanelApp.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/application/list/StagingProcessesPanelApp.java
@@ -45,8 +45,7 @@ public class StagingProcessesPanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {

--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/portlet/StagingProcessesControlPanelEntry.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/portlet/StagingProcessesControlPanelEntry.java
@@ -12,41 +12,38 @@
  * details.
  */
 
-package com.liferay.staging.processes.web.application.list;
+package com.liferay.staging.processes.web.portlet;
 
-import com.liferay.application.list.BasePanelApp;
-import com.liferay.application.list.PanelApp;
-import com.liferay.application.list.constants.PanelCategoryKeys;
+import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
+import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portlet.BaseControlPanelEntry;
+import com.liferay.portlet.ControlPanelEntry;
 import com.liferay.staging.processes.web.constants.StagingProcessesPortletKeys;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Levente Hudák
+ * @author Julio Camarero
  */
 @Component(
 	immediate = true,
-	property = {
-		"panel.category.key=" + PanelCategoryKeys.SITE_ADMINISTRATION_PUBLISHING_TOOLS,
-		"service.ranking:Integer=100"
-	},
-	service = PanelApp.class
+	property = {"javax.portlet.name=" + StagingProcessesPortletKeys.STAGING_PROCESSES},
+	service = ControlPanelEntry.class
 )
-public class StagingProcessesPanelApp extends BasePanelApp {
+public class StagingProcessesControlPanelEntry extends BaseControlPanelEntry {
 
 	@Override
-	public String getPortletId() {
-		return StagingProcessesPortletKeys.STAGING_PROCESSES;
-	}
+	protected boolean hasAccessPermissionDenied(
+			PermissionChecker permissionChecker, Group group, Portlet portlet)
+		throws Exception {
 
-	@Reference(
-		target = "(javax.portlet.name=" + StagingProcessesPortletKeys.STAGING_PROCESSES + ")",
-		unbind = "-"
-	)
-	public void setPortlet(Portlet portlet) {
-		super.setPortlet(portlet);
+		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
+			return true;
+		}
+
+		return super.hasAccessPermissionDenied(
+			permissionChecker, group, portlet);
 	}
 
 }

--- a/modules/apps/workflow/workflow-definition-link-web/src/main/java/com/liferay/workflow/definition/link/web/application/list/WorkflowDefinitionLinkPanelApp.java
+++ b/modules/apps/workflow/workflow-definition-link-web/src/main/java/com/liferay/workflow/definition/link/web/application/list/WorkflowDefinitionLinkPanelApp.java
@@ -45,15 +45,14 @@ public class WorkflowDefinitionLinkPanelApp extends BasePanelApp {
 	}
 
 	@Override
-	public boolean hasAccessPermission(
-			PermissionChecker permissionChecker, Group group)
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
 		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
 			return false;
 		}
 
-		return super.hasAccessPermission(permissionChecker, group);
+		return super.isShow(permissionChecker, group);
 	}
 
 	@Override

--- a/modules/apps/workflow/workflow-definition-link-web/src/main/java/com/liferay/workflow/definition/link/web/application/list/WorkflowDefinitionLinkPanelApp.java
+++ b/modules/apps/workflow/workflow-definition-link-web/src/main/java/com/liferay/workflow/definition/link/web/application/list/WorkflowDefinitionLinkPanelApp.java
@@ -17,10 +17,7 @@ package com.liferay.workflow.definition.link.web.application.list;
 import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.workflow.definition.link.web.portlet.constants.WorkflowDefinitionLinkPortletKeys;
 
 import org.osgi.service.component.annotations.Component;
@@ -42,17 +39,6 @@ public class WorkflowDefinitionLinkPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return WorkflowDefinitionLinkPortletKeys.WORKFLOW_DEFINITION_LINK;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
-			return false;
-		}
-
-		return super.isShow(permissionChecker, group);
 	}
 
 	@Override

--- a/modules/apps/workflow/workflow-definition-link-web/src/main/java/com/liferay/workflow/definition/link/web/portlet/WorkflowDefinitionLinkControlPanelControlPanelEntry.java
+++ b/modules/apps/workflow/workflow-definition-link-web/src/main/java/com/liferay/workflow/definition/link/web/portlet/WorkflowDefinitionLinkControlPanelControlPanelEntry.java
@@ -21,15 +21,15 @@ import com.liferay.workflow.definition.link.web.portlet.constants.WorkflowDefini
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author Marcellus Tavares
+ * @author Julio Camarero
  */
 @Component(
 	immediate = true,
 	property = {
-		"javax.portlet.name=" + WorkflowDefinitionLinkPortletKeys.WORKFLOW_DEFINITION_LINK
+		"javax.portlet.name=" + WorkflowDefinitionLinkPortletKeys.WORKFLOW_DEFINITION_LINK_CONTROL_PANEL
 	},
 	service = ControlPanelEntry.class
 )
-public class WorkflowDefinitionLinkControlPanelEntry
+public class WorkflowDefinitionLinkControlPanelControlPanelEntry
 	extends WorkflowControlPanelEntry {
 }

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/JspServlet.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/JspServlet.java
@@ -76,8 +76,7 @@ import org.osgi.framework.wiring.BundleWiring;
 public class JspServlet extends HttpServlet {
 
 	public JspServlet() {
-		_jspBundle = FrameworkUtil.getBundle(
-			com.liferay.portal.servlet.jsp.compiler.JspServlet.class);
+		_jspBundle = FrameworkUtil.getBundle(JspServlet.class);
 	}
 
 	@Override

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/JspServlet.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/JspServlet.java
@@ -75,10 +75,6 @@ import org.osgi.framework.wiring.BundleWiring;
  */
 public class JspServlet extends HttpServlet {
 
-	public JspServlet() {
-		_jspBundle = FrameworkUtil.getBundle(JspServlet.class);
-	}
-
 	@Override
 	public void destroy() {
 		_jspServlet.destroy();
@@ -443,12 +439,13 @@ public class JspServlet extends HttpServlet {
 
 	private static final Class<?>[] _INTERFACES = {ServletContext.class};
 
+	private static final Bundle _jspBundle = FrameworkUtil.getBundle(
+		JspServlet.class);
 	private static final Pattern _originalJspPattern = Pattern.compile(
 		"^(?<file>.*)(\\.(portal|original))(?<extension>\\.(jsp|jspf))$");
 
 	private Bundle[] _allParticipatingBundles;
 	private Bundle _bundle;
-	private final Bundle _jspBundle;
 	private JspBundleClassloader _jspBundleClassloader;
 	private final HttpServlet _jspServlet =
 		new org.apache.jasper.servlet.JspServlet();

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
@@ -454,7 +454,7 @@ public class JspCompiler extends Jsr199JavaCompiler {
 		Bundle systemBundle = bundleContext.getBundle(0);
 
 		if (systemBundle == null) {
-			throw new IllegalStateException(
+			throw new ExceptionInInitializerError(
 				"Unable to access to system bundle");
 		}
 

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
@@ -236,7 +236,8 @@ public class JspCompiler extends Jsr199JavaCompiler {
 	}
 
 	protected void collectTLDMappings(
-		Map<String, String[]> tldMappings, Bundle bundle) {
+			Map<String, String[]> tldMappings, Bundle bundle)
+		throws IOException {
 
 		BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
 

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
@@ -14,13 +14,8 @@
 
 package com.liferay.portal.servlet.jsp.compiler.internal;
 
-import com.liferay.portal.kernel.util.ReflectionUtil;
-
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -256,7 +251,7 @@ public class JspCompiler extends Jsr199JavaCompiler {
 		for (String resourcePath : resourcePaths) {
 			URL url = bundle.getResource(resourcePath);
 
-			String uri = getTldUri(url);
+			String uri = TldURIUtil.getTldURI(url);
 
 			if (uri != null) {
 				tldMappings.put(uri, new String[] {"/" + resourcePath, null});
@@ -288,55 +283,6 @@ public class JspCompiler extends Jsr199JavaCompiler {
 		}
 
 		return super.getJavaFileManager(javaFileManager);
-	}
-
-	protected String getTldUri(URL url) {
-		try (InputStream inputStream = url.openStream();
-			InputStreamReader inputStreamReader = new InputStreamReader(
-				inputStream);
-			BufferedReader bufferedReader = new BufferedReader(
-				inputStreamReader)) {
-
-			StringBuilder sb = null;
-
-			String line = null;
-
-			while ((line = bufferedReader.readLine()) != null) {
-				if (sb == null) {
-					int x = line.indexOf("<uri>");
-
-					if (x < 0) {
-						continue;
-					}
-
-					x += 5;
-
-					int y = line.indexOf("</uri>", x);
-
-					if (y >= 0) {
-						return line.substring(x, y);
-					}
-
-					sb = new StringBuilder(line.substring(x));
-				}
-				else {
-					int y = line.indexOf("</uri>");
-
-					if (y >= 0) {
-						sb.append(line.substring(0, y));
-
-						return sb.toString();
-					}
-
-					sb.append(line);
-				}
-			}
-
-			return null;
-		}
-		catch (IOException ioe) {
-			return ReflectionUtil.throwException(ioe);
-		}
 	}
 
 	protected void initClassPath(ServletContext servletContext) {

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
@@ -150,8 +150,7 @@ public class JspCompiler extends Jsr199JavaCompiler {
 		JspCompilationContext jspCompilationContext,
 		ErrorDispatcher errorDispatcher, boolean suppressLogging) {
 
-		Bundle jspBundle = FrameworkUtil.getBundle(
-			com.liferay.portal.servlet.jsp.compiler.JspServlet.class);
+		Bundle jspBundle = FrameworkUtil.getBundle(JspCompiler.class);
 
 		BundleWiring bundleWiring = jspBundle.adapt(BundleWiring.class);
 

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspCompiler.java
@@ -150,43 +150,7 @@ public class JspCompiler extends Jsr199JavaCompiler {
 		JspCompilationContext jspCompilationContext,
 		ErrorDispatcher errorDispatcher, boolean suppressLogging) {
 
-		Bundle jspBundle = FrameworkUtil.getBundle(JspCompiler.class);
-
-		BundleWiring bundleWiring = jspBundle.adapt(BundleWiring.class);
-
-		_jspBundleWirings.add(bundleWiring);
-
-		for (BundleWire bundleWire : bundleWiring.getRequiredWires(null)) {
-			BundleWiring providedBundleWiring = bundleWire.getProviderWiring();
-
-			_jspBundleWirings.add(providedBundleWiring);
-		}
-
-		BundleContext bundleContext = jspBundle.getBundleContext();
-
-		Bundle systemBundle = bundleContext.getBundle(0);
-
-		if (systemBundle == null) {
-			throw new IllegalStateException(
-				"Unable to access to system bundle");
-		}
-
-		BundleWiring systemBundleWiring = systemBundle.adapt(
-			BundleWiring.class);
-
-		for (BundleCapability bundleCapability :
-				systemBundleWiring.getCapabilities(
-					BundleRevision.PACKAGE_NAMESPACE)) {
-
-			Map<String, Object> attributes = bundleCapability.getAttributes();
-
-			Object packageName = attributes.get(
-				BundleRevision.PACKAGE_NAMESPACE);
-
-			if (packageName != null) {
-				_systemPackageNames.add(packageName);
-			}
-		}
+		BundleContext bundleContext = _jspBundle.getBundleContext();
 
 		_logger = new Logger(bundleContext);
 
@@ -208,7 +172,7 @@ public class JspCompiler extends Jsr199JavaCompiler {
 		_bundle = _allParticipatingBundles[0];
 
 		_javaFileObjectResolver = new JspJavaFileObjectResolver(
-			_bundle, jspBundle, _logger);
+			_bundle, _jspBundle, _logger);
 
 		jspCompilationContext.setClassLoader(jspBundleClassloader);
 
@@ -468,12 +432,54 @@ public class JspCompiler extends Jsr199JavaCompiler {
 		"javax.servlet.ServletException"
 	};
 
+	private static final Bundle _jspBundle = FrameworkUtil.getBundle(
+		JspCompiler.class);
+	private static final Set<BundleWiring> _jspBundleWirings =
+		new LinkedHashSet<>();
+	private static final Set<Object> _systemPackageNames = new HashSet<>();
+
+	static {
+		BundleWiring bundleWiring = _jspBundle.adapt(BundleWiring.class);
+
+		_jspBundleWirings.add(bundleWiring);
+
+		for (BundleWire bundleWire : bundleWiring.getRequiredWires(null)) {
+			BundleWiring providedBundleWiring = bundleWire.getProviderWiring();
+
+			_jspBundleWirings.add(providedBundleWiring);
+		}
+
+		BundleContext bundleContext = _jspBundle.getBundleContext();
+
+		Bundle systemBundle = bundleContext.getBundle(0);
+
+		if (systemBundle == null) {
+			throw new IllegalStateException(
+				"Unable to access to system bundle");
+		}
+
+		BundleWiring systemBundleWiring = systemBundle.adapt(
+			BundleWiring.class);
+
+		for (BundleCapability bundleCapability :
+				systemBundleWiring.getCapabilities(
+					BundleRevision.PACKAGE_NAMESPACE)) {
+
+			Map<String, Object> attributes = bundleCapability.getAttributes();
+
+			Object packageName = attributes.get(
+				BundleRevision.PACKAGE_NAMESPACE);
+
+			if (packageName != null) {
+				_systemPackageNames.add(packageName);
+			}
+		}
+	}
+
 	private Bundle[] _allParticipatingBundles;
 	private Bundle _bundle;
 	private final List<File> _classPath = new ArrayList<>();
 	private JavaFileObjectResolver _javaFileObjectResolver;
-	private final Set<BundleWiring> _jspBundleWirings = new LinkedHashSet<>();
 	private Logger _logger;
-	private final Set<Object> _systemPackageNames = new HashSet<>();
 
 }

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtil.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtil.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.servlet.jsp.compiler.internal;
 
-import com.liferay.portal.kernel.util.ReflectionUtil;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,7 +26,7 @@ import java.net.URL;
  */
 public class TldURIUtil {
 
-	public static String getTldURI(URL url) {
+	public static String getTldURI(URL url) throws IOException {
 		try (InputStream inputStream = url.openStream();
 			InputStreamReader inputStreamReader = new InputStreamReader(
 				inputStream);
@@ -71,9 +69,6 @@ public class TldURIUtil {
 			}
 
 			return null;
-		}
-		catch (IOException ioe) {
-			return ReflectionUtil.throwException(ioe);
 		}
 	}
 

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtil.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtil.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.servlet.jsp.compiler.internal;
+
+import com.liferay.portal.kernel.util.ReflectionUtil;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import java.net.URL;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class TldURIUtil {
+
+	public static String getTldURI(URL url) {
+		try (InputStream inputStream = url.openStream();
+			InputStreamReader inputStreamReader = new InputStreamReader(
+				inputStream);
+			BufferedReader bufferedReader = new BufferedReader(
+				inputStreamReader)) {
+
+			StringBuilder sb = null;
+
+			String line = null;
+
+			while ((line = bufferedReader.readLine()) != null) {
+				if (sb == null) {
+					int x = line.indexOf("<uri>");
+
+					if (x < 0) {
+						continue;
+					}
+
+					x += 5;
+
+					int y = line.indexOf("</uri>", x);
+
+					if (y >= 0) {
+						return line.substring(x, y);
+					}
+
+					sb = new StringBuilder(line.substring(x));
+				}
+				else {
+					int y = line.indexOf("</uri>");
+
+					if (y >= 0) {
+						sb.append(line.substring(0, y));
+
+						return sb.toString();
+					}
+
+					sb.append(line);
+				}
+			}
+
+			return null;
+		}
+		catch (IOException ioe) {
+			return ReflectionUtil.throwException(ioe);
+		}
+	}
+
+}

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtil.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtil.java
@@ -14,7 +14,8 @@
 
 package com.liferay.portal.servlet.jsp.compiler.internal;
 
-import java.io.BufferedReader;
+import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -30,14 +31,14 @@ public class TldURIUtil {
 		try (InputStream inputStream = url.openStream();
 			InputStreamReader inputStreamReader = new InputStreamReader(
 				inputStream);
-			BufferedReader bufferedReader = new BufferedReader(
-				inputStreamReader)) {
+			UnsyncBufferedReader unsyncBufferedReader =
+				new UnsyncBufferedReader(inputStreamReader)) {
 
 			StringBuilder sb = null;
 
 			String line = null;
 
-			while ((line = bufferedReader.readLine()) != null) {
+			while ((line = unsyncBufferedReader.readLine()) != null) {
 				if (sb == null) {
 					int x = line.indexOf("<uri>");
 

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtil.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.servlet.jsp.compiler.internal;
 
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
+import com.liferay.portal.kernel.util.StringBundler;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,7 +35,7 @@ public class TldURIUtil {
 			UnsyncBufferedReader unsyncBufferedReader =
 				new UnsyncBufferedReader(inputStreamReader)) {
 
-			StringBuilder sb = null;
+			StringBundler sb = null;
 
 			String line = null;
 
@@ -54,7 +55,7 @@ public class TldURIUtil {
 						return line.substring(x, y);
 					}
 
-					sb = new StringBuilder(line.substring(x));
+					sb = new StringBundler(line.substring(x));
 				}
 				else {
 					int y = line.indexOf("</uri>");

--- a/modules/portal/portal-servlet-jsp-compiler/src/test/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtilTest.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/test/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtilTest.java
@@ -22,42 +22,34 @@ import org.junit.Test;
 /**
  * @author Raymond Augé
  */
-public class JspCompilerTest {
+public class TldURIUtilTest {
 
 	@Test
 	public void testGetTldUri1() throws Exception {
-		JspCompiler jspCompiler = new JspCompiler();
+		URL url = TldURIUtilTest.class.getResource("dependencies/test_1.tld");
 
-		URL url = JspCompilerTest.class.getResource("dependencies/test_1.tld");
-
-		Assert.assertEquals("This is a test.", jspCompiler.getTldUri(url));
+		Assert.assertEquals("This is a test.", TldURIUtil.getTldURI(url));
 	}
 
 	@Test
 	public void testGetTldUri2() throws Exception {
-		JspCompiler jspCompiler = new JspCompiler();
+		URL url = TldURIUtilTest.class.getResource("dependencies/test_2.tld");
 
-		URL url = JspCompilerTest.class.getResource("dependencies/test_2.tld");
-
-		Assert.assertEquals("This is a test.", jspCompiler.getTldUri(url));
+		Assert.assertEquals("This is a test.", TldURIUtil.getTldURI(url));
 	}
 
 	@Test
 	public void testGetTldUri3() throws Exception {
-		JspCompiler jspCompiler = new JspCompiler();
+		URL url = TldURIUtilTest.class.getResource("dependencies/test_3.tld");
 
-		URL url = JspCompilerTest.class.getResource("dependencies/test_3.tld");
-
-		Assert.assertNull(jspCompiler.getTldUri(url));
+		Assert.assertNull(TldURIUtil.getTldURI(url));
 	}
 
 	@Test
 	public void testGetTldUri4() throws Exception {
-		JspCompiler jspCompiler = new JspCompiler();
+		URL url = TldURIUtilTest.class.getResource("dependencies/test_4.tld");
 
-		URL url = JspCompilerTest.class.getResource("dependencies/test_4.tld");
-
-		Assert.assertNull(jspCompiler.getTldUri(url));
+		Assert.assertNull(TldURIUtil.getTldURI(url));
 	}
 
 }

--- a/modules/portal/portal-servlet-jsp-compiler/src/test/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtilTest.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/test/java/com/liferay/portal/servlet/jsp/compiler/internal/TldURIUtilTest.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.servlet.jsp.compiler.internal;
 
+import java.io.IOException;
+
 import java.net.URL;
 
 import org.junit.Assert;
@@ -25,28 +27,28 @@ import org.junit.Test;
 public class TldURIUtilTest {
 
 	@Test
-	public void testGetTldUri1() throws Exception {
+	public void testGetTldUri1() throws IOException {
 		URL url = TldURIUtilTest.class.getResource("dependencies/test_1.tld");
 
 		Assert.assertEquals("This is a test.", TldURIUtil.getTldURI(url));
 	}
 
 	@Test
-	public void testGetTldUri2() throws Exception {
+	public void testGetTldUri2() throws IOException {
 		URL url = TldURIUtilTest.class.getResource("dependencies/test_2.tld");
 
 		Assert.assertEquals("This is a test.", TldURIUtil.getTldURI(url));
 	}
 
 	@Test
-	public void testGetTldUri3() throws Exception {
+	public void testGetTldUri3() throws IOException {
 		URL url = TldURIUtilTest.class.getResource("dependencies/test_3.tld");
 
 		Assert.assertNull(TldURIUtil.getTldURI(url));
 	}
 
 	@Test
-	public void testGetTldUri4() throws Exception {
+	public void testGetTldUri4() throws IOException {
 		URL url = TldURIUtilTest.class.getResource("dependencies/test_4.tld");
 
 		Assert.assertNull(TldURIUtil.getTldURI(url));

--- a/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
@@ -491,9 +491,9 @@ public class UserImpl extends UserBaseImpl {
 
 	@Override
 	public String getInitials() {
-		String[] names = StringUtil.split(getFullName(), StringPool.SPACE);
+		String[] names = new String[] {getFirstName(), getLastName()};
 
-		StringBundler sb = new StringBundler(names.length);
+		StringBundler sb = new StringBundler(2);
 
 		for (String name : names) {
 			sb.append(StringUtil.toUpperCase(StringUtil.shorten(name, 1)));

--- a/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
@@ -491,9 +491,9 @@ public class UserImpl extends UserBaseImpl {
 
 	@Override
 	public String getInitials() {
-		String[] names = new String[] {getFirstName(), getLastName()};
-
 		StringBundler sb = new StringBundler(2);
+
+		String[] names = new String[] {getFirstName(), getLastName()};
 
 		for (String name : names) {
 			sb.append(StringUtil.toUpperCase(StringUtil.shorten(name, 1)));

--- a/portal-impl/src/com/liferay/portal/workflow/WorkflowControlPanelEntry.java
+++ b/portal-impl/src/com/liferay/portal/workflow/WorkflowControlPanelEntry.java
@@ -30,7 +30,7 @@ public class WorkflowControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
 
-		if (group.isLayoutSetPrototype() ||
+		if (group.isLayoutPrototype() || group.isLayoutSetPrototype() ||
 			!WorkflowEngineManagerUtil.isDeployed()) {
 
 			return true;


### PR DESCRIPTION
**CONTENT ON DEMAND**

Alan helped to make the change with two ways. This is the first one, which **always keeps the product-menu portlet on the page but makes the portlet itself to load actual content on demand**. With this way, we still have the portlet processing overhead when loading the page even if the panel is closed. It may provide benefit in other area though.

The second one is here:
https://github.com/juliocamarero/liferay-portal/pull/3873