### PR TITLE
[TECHNICAL-SUPPORT] LPS-63772 Create portletURL with 0 as classTypeId only if it is not p…resent in classTypes

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -407,19 +407,14 @@ public class AssetUtil {
 					themeDisplay.getScopeGroupId()),
 				themeDisplay.getLocale());
 
-			if ((classTypeIds.length == 0) || classTypes.isEmpty()) {
-				PortletURL addPortletURL = getAddPortletURL(
-					liferayPortletRequest, liferayPortletResponse, groupId,
-					className, 0, allAssetCategoryIds, allAssetTagNames,
-					redirect);
-
-				if (addPortletURL != null) {
-					addPortletURLs.put(className, addPortletURL);
-				}
-			}
+			boolean addDefaultPortletURL = true;
 
 			for (ClassType classType : classTypes) {
 				long classTypeId = classType.getClassTypeId();
+
+				if (classTypeId == 0) {
+					addDefaultPortletURL = false;
+				}
 
 				if (ArrayUtil.contains(classTypeIds, classTypeId) ||
 					(classTypeIds.length == 0)) {
@@ -436,6 +431,19 @@ public class AssetUtil {
 
 						addPortletURLs.put(mesage, addPortletURL);
 					}
+				}
+			}
+
+			if (((classTypeIds.length == 0) || classTypes.isEmpty()) &&
+				addDefaultPortletURL) {
+
+				PortletURL addPortletURL = getAddPortletURL(
+					liferayPortletRequest, liferayPortletResponse, groupId,
+					className, 0, allAssetCategoryIds, allAssetTagNames,
+					redirect);
+
+				if (addPortletURL != null) {
+					addPortletURLs.put(className, addPortletURL);
 				}
 			}
 		}


### PR DESCRIPTION
Hi Julio,

sorry, it will be a bit longer than usual:

**1.**
Since [LPS-46103](https://issues.liferay.com/browse/LPS-46103) the classTypes list includes the Basic Document as well, so there is no need to create the default portletURL (currently the Basic Document is listed twice in the Asset Publisher's add dropdown).

This problem doesn't affect Journal and DDLRecords, as in **JournalArticle/DDLRecordAssetRendererFactory** classes the **hasAddPermission** methods check whether the classTypeId is 0.
However, we can't use this logic for DLFileEntries, as the default  dlFileEntryType for Basic Document is generated with 0 as fileEntryTypeId.


**2.**
I found this regression while I was checking the code related to the mentioned LPS-46103. After LPS-46103 it is possible to configure Asset Publisher's portlet to filter by Basic Document.

**Do you see any problems with backporting LPS-46103 to 6.2.x?**
I'm asking because [LPS-29196](https://issues.liferay.com/browse/LPS-29196) (which was solved in [LPS-45107](https://issues.liferay.com/browse/LPS-45107)) for selecting Basic Document in Asset Publisher's filter was opened as a feature request. 
However, it focuses on Web Contents (creating the default Web Content structure as a DDMStructure), the dlFileEntryType for Basic Document exists in 6.2 as well and I can't see any problems using it.

Thanks,
Tamás