### PR TITLE
[TECH SUPPORT] LPS-63765 Guest user falls back to previous visited site's language when trying to visit a non-available language

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -100,7 +100,7 @@ public class I18nServlet extends HttpServlet {
 				request.setAttribute(WebKeys.I18N_PATH, i18nData.getI18nPath());
 
 				Locale locale = LocaleUtil.fromLanguageId(
-					i18nData.getLanguageId(), true, false);
+					i18nData.getLanguageId(), false, false);
 
 				HttpSession session = request.getSession();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -93,17 +93,11 @@ public class CookieKeys {
 		cookie.setValue(encodedValue);
 		cookie.setVersion(0);
 
+		response.addCookie(cookie);
+
 		Map<String, Cookie> cookieMap = _getCookieMap(request);
 
-		if (cookieMap.isEmpty()) {
-			cookieMap = new HashMap<>();
-		}
-
 		cookieMap.put(StringUtil.toUpperCase(name), cookie);
-
-		request.setAttribute(CookieKeys.class.getName(), cookieMap);
-
-		response.addCookie(cookie);
 	}
 
 	public static void addSupportCookie(
@@ -282,7 +276,7 @@ public class CookieKeys {
 		Cookie[] cookies = request.getCookies();
 
 		if (cookies == null) {
-			cookieMap = Collections.emptyMap();
+			cookieMap = new HashMap<>();
 		}
 		else {
 			cookieMap = new HashMap<>(cookies.length * 4 / 3);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -93,6 +93,16 @@ public class CookieKeys {
 		cookie.setValue(encodedValue);
 		cookie.setVersion(0);
 
+		Map<String, Cookie> cookieMap = _getCookieMap(request);
+
+		if (cookieMap.isEmpty()) {
+			cookieMap = new HashMap<>();
+		}
+
+		cookieMap.put(StringUtil.toUpperCase(name), cookie);
+
+		request.setAttribute(CookieKeys.class.getName(), cookieMap);
+
 		response.addCookie(cookie);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -98,6 +98,8 @@ public class CookieKeys {
 		Map<String, Cookie> cookieMap = _getCookieMap(request);
 
 		cookieMap.put(StringUtil.toUpperCase(name), cookie);
+
+		request.setAttribute(CookieKeys.class.getName(), cookieMap);
 	}
 
 	public static void addSupportCookie(

--- a/portal-web/docroot/html/common/themes/top_messages.jsp
+++ b/portal-web/docroot/html/common/themes/top_messages.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/html/common/themes/init.jsp" %>
 
 <%
-if ((PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 3) && !user.isDefaultUser() && (user.getLocale() != locale)) {
+if (!user.isDefaultUser() && (user.getLocale() != locale)) {
 	PortalUtil.addUserLocaleOptionsMessage(request);
 }
 %>


### PR DESCRIPTION
Hi @juliocamarero 

I added 2 things:

1. I think we still need to put the cookieMap back in the request to make it reachable for other servlets/filters in the same chain. If you removed this intentionally though, feel free to remove it again.

2. If after the reproduction steps we log in with a user that has a different display language as the site's default German, and visit the URL with the non-existing locale again, due to the redirect cache of the browser we can be redirected to the German locale again, without the option to switch back to the user's preferred language. This is because we only offer this option if locale.prepend.friendly.url.style=3 is set. I didn't find any explanations about why this restriction is necessary, I believe the option should be displayed when needed, regardless of the value of this property.

The integration test is still a work in progress.

Regards,
G