### PR TITLE
LPS-64370 Update BREAKING_CHANGES

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/asset/FileEntryAssetValidator.java
+++ b/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/asset/FileEntryAssetValidator.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.asset;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portlet.asset.util.AssetEntryValidator;
+import com.liferay.portlet.asset.util.BaseAssetEntryValidator;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	immediate = true,
+	property = {
+		"model.class.name=com.liferay.document.library.kernel.model.DLFileEntry"
+	},
+	service = AssetEntryValidator.class
+)
+public class FileEntryAssetValidator extends BaseAssetEntryValidator {
+
+	@Override
+	public void validate(
+			long groupId, String className, long classTypePK,
+			long[] categoryIds, String[] entryNames)
+		throws PortalException {
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
+			classTypePK);
+
+		if ((dlFileEntry == null) ||
+			(dlFileEntry.getRepositoryId() != groupId)) {
+
+			return;
+		}
+
+		super.validate(
+			groupId, className, classTypePK, categoryIds, entryNames);
+	}
+
+	@Reference(unbind = "-")
+	protected void setDLFileEntryLocalService(
+		DLFileEntryLocalService dlFileEntryLocalService) {
+
+		_dlFileEntryLocalService = dlFileEntryLocalService;
+	}
+
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+}

--- a/portal-impl/src/META-INF/asset-spring.xml
+++ b/portal-impl/src/META-INF/asset-spring.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<beans
+	default-destroy-method="destroy"
+	default-init-method="afterPropertiesSet"
+	xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
+>
+	<bean id="com.liferay.portlet.asset.util.AssetEntryValidator" class="com.liferay.portlet.asset.util.DefaultAssetEntryValidator" />
+</beans>

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -98,8 +98,6 @@ public class PropsValues {
 
 	public static final boolean ASSET_ENTRY_BUFFERED_INCREMENT_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.BUFFERED_INCREMENT_ENABLED, new Filter("AssetEntry")));
 
-	public static final String ASSET_ENTRY_VALIDATOR = PropsUtil.get(PropsKeys.ASSET_ENTRY_VALIDATOR);
-
 	public static final int ASSET_FILTER_SEARCH_LIMIT = GetterUtil.getInteger(PropsUtil.get(PropsKeys.ASSET_FILTER_SEARCH_LIMIT));
 
 	public static final String ASSET_VOCABULARY_DEFAULT = PropsUtil.get(PropsKeys.ASSET_VOCABULARY_DEFAULT);

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
@@ -1721,7 +1721,7 @@ public class VerifyProperties extends VerifyProcess {
 	private static final String[] _OBSOLETE_PORTAL_KEYS = new String[] {
 		"aim.login", "aim.login", "amazon.access.key.id",
 		"amazon.associate.tag", "amazon.secret.access.key",
-		"asset.entry.increment.view.counter.enabled",
+		"asset.entry.increment.view.counter.enabled", "asset.entry.validator",
 		"asset.publisher.asset.entry.query.processors",
 		"asset.publisher.filter.unlistable.entries",
 		"asset.publisher.query.form.configuration",

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -25,6 +25,7 @@ import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -43,12 +44,10 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.social.SocialActivityManagerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.InstancePool;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.asset.service.base.AssetEntryLocalServiceBaseImpl;
 import com.liferay.portlet.asset.service.permission.AssetCategoryPermission;
 import com.liferay.portlet.asset.util.AssetEntryValidator;
@@ -906,10 +905,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 			return;
 		}
 
-		AssetEntryValidator validator = (AssetEntryValidator)InstancePool.get(
-			PropsValues.ASSET_ENTRY_VALIDATOR);
-
-		validator.validate(
+		assetEntryValidator.validate(
 			groupId, className, classTypePK, categoryIds, tagNames);
 	}
 
@@ -1052,5 +1048,8 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 		indexer.reindex(className, entry.getClassPK());
 	}
+
+	@BeanReference(type = AssetEntryValidator.class)
+	protected AssetEntryValidator assetEntryValidator;
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/util/DefaultAssetEntryValidator.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/DefaultAssetEntryValidator.java
@@ -14,8 +14,43 @@
 
 package com.liferay.portlet.asset.util;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.registry.collections.ServiceTrackerCollections;
+import com.liferay.registry.collections.ServiceTrackerMap;
+
 /**
  * @author Brian Wing Shun Chan
  */
 public class DefaultAssetEntryValidator extends BaseAssetEntryValidator {
+
+	public void afterPropertiesSet() {
+		_serviceTrackerMap = ServiceTrackerCollections.openSingleValueMap(
+			AssetEntryValidator.class, "model.class.name");
+	}
+
+	public void destroy() {
+		_serviceTrackerMap.close();
+	}
+
+	@Override
+	public void validate(
+			long groupId, String className, long classTypePK,
+			long[] categoryIds, String[] entryNames)
+		throws PortalException {
+
+		AssetEntryValidator assetEntryValidator = _serviceTrackerMap.getService(
+			className);
+
+		if (assetEntryValidator == null) {
+			super.validate(
+				groupId, className, classTypePK, categoryIds, entryNames);
+		}
+		else {
+			assetEntryValidator.validate(
+				groupId, className, classTypePK, categoryIds, entryNames);
+		}
+	}
+
+	private ServiceTrackerMap<String, AssetEntryValidator> _serviceTrackerMap;
+
 }

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8165,15 +8165,6 @@
     #
     asset.categories.selector.max.entries=50
 
-    # Input a class name that extends
-    # com.liferay.portlet.asset.util.BaseAssetEntryValidator. This class will be
-    # called to validate entries. The DefaultAssetEntryValidator class is just
-    # an empty class that doesn't actually do any validation. The
-    # MinimalAssetEntryValidator requires all entities to have at least one tag.
-    #
-    asset.entry.validator=com.liferay.portlet.asset.util.DefaultAssetEntryValidator
-    #asset.entry.validator=com.liferay.portlet.asset.util.MinimalAssetEntryValidator
-
     #
     # Set the limit for results used when performing asset searches that are
     # subsequently filtered by permissions.

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -802,6 +802,7 @@
         META-INF/messaging-core-spring.xml,\
         META-INF/messaging-misc-spring.xml,\
         \
+        META-INF/asset-spring.xml,\
         META-INF/cluster-spring.xml,\
         META-INF/comment-spring.xml,\
         META-INF/company-provider-spring.xml,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -93,8 +93,6 @@ public interface PropsKeys {
 
 	public static final String ASSET_CATEGORIES_SELECTOR_MAX_ENTRIES = "asset.categories.selector.max.entries";
 
-	public static final String ASSET_ENTRY_VALIDATOR = "asset.entry.validator";
-
 	public static final String ASSET_FILTER_SEARCH_LIMIT = "asset.filter.search.limit";
 
 	public static final String ASSET_RENDERER_ENABLED = "asset.renderer.enabled.";

--- a/readme/7.0/BREAKING_CHANGES.markdown
+++ b/readme/7.0/BREAKING_CHANGES.markdown
@@ -4023,3 +4023,34 @@ You should port your PHP portlet to a different technology.
 
 This change simplifies future maintenance of the portal. This support could be
 added back in the future as an independent module.
+
+---------------------------------------
+
+### Removed `asset.entry.validator` property
+- **Date:** 2016-Mar-17
+- **JIRA Ticket:** LPS-64370
+
+#### What changed?
+
+The property `asset.entry.validator` was removed from `portal.properties`.
+
+#### Who is affected?
+
+Any installation with a customized asset validator.
+
+#### How should I update my code?
+
+You should create a new OSGi component that implements
+`AssetEntryValidator`, and define for which models it will be
+applicable by using the `model.class.name` OSGi property.
+
+#### Why was this change made?
+
+The default asset entry validator ensured that all assets of a
+particular type honored required vocabulary restrictions . In general,
+this was incorrect, as there may be different models of the same type
+that require different validation (e.g. A D&M FileEntry vs an
+attachment); additionally, in the context of a modular application, it
+was very difficult to extend or modify this behaviour without
+introducing dependencies between the core and the modules that
+required custom validation logic.


### PR DESCRIPTION
Buenas @ealonso me ha mandado esto @adolfopa 

Yo lo veo todo bien, la única duda que me surge es qué queréis hacer con el `MinimalAssetEntryValidator` porque antes se podía aplicar ese haciendo el cambio en el portal-ext.properties pero yo creo que ahora mismo no tiene ningún sentido dejarlo en el core porque no es sencillo que nadie lo pueda aplicar.

Entonces, se me ocurren dos alternativas:
1. Considerar que `MinimalAssetEntryValidator` era un código de ejemplo y que ahora mismo lo podemos borrar.
2. Si pensamos que hay gente que lo puede estar utilizando y le queréis dar soporte, sacarlo a un módulo de osgi que esté dentro de asset y poner que no se despliegue por defecto. De esta manera, si alguien quiere mantener el comportamiento que tenía antes siempre pueden desplegar el módulo y listo.

Yo me inclino a pensar que no merece la pena hacer el #2 pero al final es vuestro código y es decisión vuestra :)
