### PR TITLE
LPS-63235 master

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/portlet/DDLFormAdminPortlet.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/portlet/DDLFormAdminPortlet.java
@@ -90,7 +90,6 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 		"com.liferay.portlet.header-portlet-css=/admin/css/main.css",
 		"com.liferay.portlet.icon=/admin/icons/form.png",
 		"com.liferay.portlet.instanceable=false",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/portlet/DDLFormPortlet.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/portlet/DDLFormPortlet.java
@@ -81,7 +81,6 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.friendly-url-mapping=form",
 		"com.liferay.portlet.header-portlet-css=/admin/css/main.css",
 		"com.liferay.portlet.instanceable=true",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/portlet/DDLDisplayPortlet.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/portlet/DDLDisplayPortlet.java
@@ -73,7 +73,6 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.header-portlet-javascript=/js/main.js",
 		"com.liferay.portlet.instanceable=true",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/portlet/DDLPortlet.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/portlet/DDLPortlet.java
@@ -73,7 +73,6 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.header-portlet-javascript=/js/main.js",
 		"com.liferay.portlet.icon=/icons/dynamic_data_lists.png",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/java/com/liferay/dynamic/data/mapping/data/provider/web/portlet/DDMDataProviderPortlet.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/java/com/liferay/dynamic/data/mapping/data/provider/web/portlet/DDMDataProviderPortlet.java
@@ -45,7 +45,6 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.display-category=category.hidden",
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.instanceable=false",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/foundation/hello-world/hello-world-web/src/main/java/com/liferay/hello/world/web/portlet/HelloWorldPortlet.java
+++ b/modules/apps/foundation/hello-world/hello-world-web/src/main/java/com/liferay/hello/world/web/portlet/HelloWorldPortlet.java
@@ -38,6 +38,7 @@ import org.osgi.service.component.annotations.Component;
 		"com.liferay.portlet.css-class-wrapper=portlet-hello-world",
 		"com.liferay.portlet.display-category=category.sample",
 		"com.liferay.portlet.icon=/icons/hello_world.png",
+		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/portlet/SearchPortlet.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/portlet/SearchPortlet.java
@@ -48,6 +48,7 @@ import org.osgi.service.component.annotations.Component;
 		"com.liferay.portlet.css-class-wrapper=portlet-search",
 		"com.liferay.portlet.display-category=category.tools",
 		"com.liferay.portlet.icon=/icons/search.png",
+		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/web-experience/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/portlet/AssetCategoriesNavigationPortlet.java
+++ b/modules/apps/web-experience/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/portlet/AssetCategoriesNavigationPortlet.java
@@ -30,7 +30,6 @@ import org.osgi.service.component.annotations.Component;
 		"com.liferay.portlet.display-category=category.cms",
 		"com.liferay.portlet.icon=/icons/asset_categories_navigation.png",
 		"com.liferay.portlet.instanceable=true",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/AssetPublisherPortlet.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/AssetPublisherPortlet.java
@@ -71,7 +71,6 @@ import org.osgi.service.component.annotations.Component;
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.icon=/icons/asset_publisher.png",
 		"com.liferay.portlet.instanceable=true",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/HighestRatedAssetsPortlet.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/HighestRatedAssetsPortlet.java
@@ -29,7 +29,6 @@ import org.osgi.service.component.annotations.Component;
 		"com.liferay.portlet.display-category=category.cms",
 		"com.liferay.portlet.icon=/icons/asset_publisher.png",
 		"com.liferay.portlet.instanceable=true",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/MostViewedAssetsPortlet.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/MostViewedAssetsPortlet.java
@@ -29,7 +29,6 @@ import org.osgi.service.component.annotations.Component;
 		"com.liferay.portlet.display-category=category.cms",
 		"com.liferay.portlet.icon=/icons/asset_publisher.png",
 		"com.liferay.portlet.instanceable=true",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/web-experience/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/portlet/AssetTagsCloudPortlet.java
+++ b/modules/apps/web-experience/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/portlet/AssetTagsCloudPortlet.java
@@ -30,7 +30,6 @@ import org.osgi.service.component.annotations.Component;
 		"com.liferay.portlet.display-category=category.cms",
 		"com.liferay.portlet.icon=/icons/asset_tags_cloud.png",
 		"com.liferay.portlet.instanceable=true",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.render-weight=50",

--- a/modules/apps/web-experience/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/portlet/AssetTagsNavigationPortlet.java
+++ b/modules/apps/web-experience/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/portlet/AssetTagsNavigationPortlet.java
@@ -30,7 +30,6 @@ import org.osgi.service.component.annotations.Component;
 		"com.liferay.portlet.display-category=category.cms",
 		"com.liferay.portlet.icon=/icons/asset_tags_navigation.png",
 		"com.liferay.portlet.instanceable=true",
-		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/portlet/ProductNavigationProductMenuPortlet.java
+++ b/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/portlet/ProductNavigationProductMenuPortlet.java
@@ -41,6 +41,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.display-category=category.hidden",
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.instanceable=false",
+		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.system=true",
 		"com.liferay.portlet.use-default-template=false",

--- a/modules/apps/web-experience/product-navigation/product-navigation-user-personal-bar-web/src/main/java/com/liferay/product/navigation/user/personal/bar/web/portlet/ProductNavigationUserPersonalBarPortlet.java
+++ b/modules/apps/web-experience/product-navigation/product-navigation-user-personal-bar-web/src/main/java/com/liferay/product/navigation/user/personal/bar/web/portlet/ProductNavigationUserPersonalBarPortlet.java
@@ -41,6 +41,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.css-class-wrapper=portlet-user-personal-bar",
 		"com.liferay.portlet.display-category=category.hidden",
+		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
@@ -455,13 +455,9 @@ public class CacheFilter extends BasePortalFilter {
 				bufferCacheServletResponse.getHeader(
 					HttpHeaders.CACHE_CONTROL));
 
-			if (((bufferCacheServletResponse.getStatus() ==
-					HttpServletResponse.SC_OK) ||
-				 (bufferCacheServletResponse.getStatus() ==
-					 HttpServletResponse.SC_NOT_MODIFIED)) &&
+			if (isCacheableResponse(bufferCacheServletResponse) &&
 				!cacheControl.contains(HttpHeaders.PRAGMA_NO_CACHE_VALUE) &&
-				isCacheableRequest(request) &&
-				isCacheableResponse(bufferCacheServletResponse)) {
+				isCacheableRequest(request)) {
 
 				CacheUtil.putCacheResponseData(
 					companyId, key, cacheResponseData);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
@@ -336,8 +336,10 @@ public class CacheFilter extends BasePortalFilter {
 	protected boolean isCacheableResponse(
 		BufferCacheServletResponse bufferCacheServletResponse) {
 
-		if ((bufferCacheServletResponse.getStatus() ==
-				HttpServletResponse.SC_OK) &&
+		if (((bufferCacheServletResponse.getStatus() ==
+				HttpServletResponse.SC_OK) ||
+			 (bufferCacheServletResponse.getStatus() ==
+				 HttpServletResponse.SC_NOT_MODIFIED)) &&
 			(bufferCacheServletResponse.getBufferSize() <
 				PropsValues.CACHE_CONTENT_THRESHOLD_SIZE)) {
 
@@ -453,8 +455,10 @@ public class CacheFilter extends BasePortalFilter {
 				bufferCacheServletResponse.getHeader(
 					HttpHeaders.CACHE_CONTROL));
 
-			if ((bufferCacheServletResponse.getStatus() ==
-					HttpServletResponse.SC_OK) &&
+			if (((bufferCacheServletResponse.getStatus() ==
+					HttpServletResponse.SC_OK) ||
+				 (bufferCacheServletResponse.getStatus() ==
+					 HttpServletResponse.SC_NOT_MODIFIED)) &&
 				!cacheControl.contains(HttpHeaders.PRAGMA_NO_CACHE_VALUE) &&
 				isCacheableRequest(request) &&
 				isCacheableResponse(bufferCacheServletResponse)) {


### PR DESCRIPTION
Hi @juliocamarero. It turns out after https://issues.liferay.com/browse/LPS-57330 (where embedded portlets are checked for cacheability too) all Guest pages were NOT cached, as some of the embedded portlets did not have this option enabled.

Please, can you check that Product navigation user personal bar and product menu web can be enabled without any problem of showing stale data to users? My checks had been successful until now.

@eduardolundgren @marcellustavares I've removed layout cacheability for the DDL/DDM portlets as it wasn't working actually due to this bug, and would show stale data after this fix.

After you finish the work, can you send to @shuyangzhou so he can review the second and third commit?

/cc @adolfopa 

Thanks!