### PR TITLE
LPS-64819 Stored XSS in Journal Article edit screen - Preview and View Source screens

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -1627,7 +1627,7 @@
 			if (!urlPreview) {
 				urlPreview = new Liferay.UrlPreview(
 					{
-						title: event.title,
+						title: Util.escapeHTML(event.title),
 						url: event.uri
 					}
 				);
@@ -1635,7 +1635,7 @@
 				instance._urlPreview = urlPreview;
 			}
 			else {
-				urlPreview.set('title', event.title);
+				urlPreview.set('title', Util.escapeHTML(event.title));
 				urlPreview.set('url', event.uri);
 			}
 

--- a/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/portlet/configuration/icon/ViewJournalSourcePortletConfigurationIcon.java
+++ b/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/portlet/configuration/icon/ViewJournalSourcePortletConfigurationIcon.java
@@ -201,7 +201,8 @@ public class ViewJournalSourcePortletConfigurationIcon
 		sb.append(portletDisplay.getId());
 		sb.append("', title: '");
 		sb.append(
-			HtmlUtil.escapeJS(article.getTitle(themeDisplay.getLocale())));
+			HtmlUtil.escapeJS(HtmlUtil.escape(article.getTitle
+				(themeDisplay.getLocale()))));
 		sb.append("'});");
 
 		return sb.toString();

--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/article_action.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/article_action.jsp
@@ -91,7 +91,7 @@ else {
 		</liferay-portlet:renderURL>
 
 		<%
-		String taglibOnClick = "Liferay.fire('previewArticle', {title: '" + HtmlUtil.escapeJS(HtmlUtil.escape(article.getTitle(locale))) + "', uri: '" + HtmlUtil.escapeJS(previewArticleContentURL.toString()) + "'});";
+		String taglibOnClick = "Liferay.fire('previewArticle', {title: '" + HtmlUtil.escapeJS(article.getTitle(locale)) + "', uri: '" + HtmlUtil.escapeJS(previewArticleContentURL.toString()) + "'});";
 		%>
 
 		<liferay-ui:icon

--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/preview.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/preview.jsp
@@ -39,7 +39,7 @@ JournalArticle article = ActionUtil.getArticle(renderRequest);
 		Liferay.fire(
 			'previewArticle',
 			{
-				title: '<%= HtmlUtil.escapeJS(HtmlUtil.escape(article.getTitle(locale))) %>',
+				title: '<%= HtmlUtil.escapeJS(article.getTitle(locale)) %>',
 				uri: '<%= HtmlUtil.escapeJS(previewArticleContentURL.toString()) %>'
 			}
 		);


### PR DESCRIPTION
Hi Julio,

https://issues.liferay.com/browse/LPS-64819

**first commit c6cdaaf**

Journal preview dialog requires escaped journal title, but on some places we forget to escape it.

So I changed `previewArticle` JS function to escape the article title by default and remove double escaping.

**2nd commit d7f69d5**
/cc @danielkocsis
We need to escape it here twice, first time for the JS function, second time to prevent Liferay.Util.Window to render it as HTML

Thanks.