### PR TITLE
LPS-65921 by default, control panel urls should be pointed to the site, not to the scope. If we need to generate a controlPanelURL to the scope, then the group should be passed to the method

### DIFF
--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/edit_layout_control_menu_entry_icon.jsp
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/edit_layout_control_menu_entry_icon.jsp
@@ -35,7 +35,7 @@
 <%
 String portletId = LayoutAdminPortletKeys.GROUP_PAGES;
 
-Group group = themeDisplay.getScopeGroup();
+Group group = themeDisplay.getSiteGroup();
 
 if (group.isLayoutPrototype()) {
 	portletId = LayoutAdminPortletKeys.LAYOUT_PROTOTYPE_PAGE;

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/information_messages.jsp
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/information_messages.jsp
@@ -104,7 +104,7 @@ data.put("qa-id", "info");
 				<span class="message-info">
 
 					<%
-					Group group = themeDisplay.getScopeGroup();
+					Group group = themeDisplay.getSiteGroup();
 					%>
 
 					<c:choose>

--- a/modules/apps/web-experience/site/site-api/src/main/java/com/liferay/site/internal/application/list/LatentGroupProvider.java
+++ b/modules/apps/web-experience/site/site-api/src/main/java/com/liferay/site/internal/application/list/LatentGroupProvider.java
@@ -39,7 +39,7 @@ public class LatentGroupProvider implements GroupProvider {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		Group group = themeDisplay.getScopeGroup();
+		Group group = themeDisplay.getSiteGroup();
 
 		if (!group.isControlPanel()) {
 			return group;

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -646,12 +646,7 @@ public class ServicePreAction extends Action {
 		long siteGroupId = 0;
 
 		if (layout != null) {
-			if (layout.isTypeControlPanel()) {
-				siteGroupId = PortalUtil.getSiteGroupId(scopeGroupId);
-			}
-			else {
-				siteGroupId = PortalUtil.getSiteGroupId(layout.getGroupId());
-			}
+			siteGroupId = PortalUtil.getSiteGroupId(layout.getGroupId());
 		}
 
 		// Theme and color scheme

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1703,7 +1703,7 @@ public class PortalImpl implements Portal {
 				WebKeys.THEME_DISPLAY);
 
 			group = getControlPanelDisplayGroup(
-				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
+				themeDisplay.getCompanyId(), themeDisplay.getSiteGroupId(),
 				themeDisplay.getDoAsGroupId(), portletId);
 		}
 
@@ -1733,7 +1733,7 @@ public class PortalImpl implements Portal {
 					WebKeys.THEME_DISPLAY);
 
 			group = getControlPanelDisplayGroup(
-				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
+				themeDisplay.getCompanyId(), themeDisplay.getSiteGroupId(),
 				themeDisplay.getDoAsGroupId(), portletId);
 		}
 

--- a/portal-impl/src/com/liferay/portlet/PortletContainerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletContainerImpl.java
@@ -300,14 +300,7 @@ public class PortletContainerImpl implements PortletContainer {
 
 		themeDisplay.setScopeGroupId(scopeGroupId);
 
-		long siteGroupId = 0;
-
-		if (layout.isTypeControlPanel()) {
-			siteGroupId = PortalUtil.getSiteGroupId(scopeGroupId);
-		}
-		else {
-			siteGroupId = PortalUtil.getSiteGroupId(layout.getGroupId());
-		}
+		long siteGroupId = PortalUtil.getSiteGroupId(layout.getGroupId());
 
 		themeDisplay.setSiteGroupId(siteGroupId);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/BaseControlPanelEntry.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/BaseControlPanelEntry.java
@@ -119,7 +119,8 @@ public abstract class BaseControlPanelEntry implements ControlPanelEntry {
 		}
 
 		if (category.equals(PortletCategoryKeys.SITE_ADMINISTRATION_CONTENT) &&
-			group.isLayout() && !portlet.isScopeable()) {
+			((group.isLayout() && !portlet.isScopeable()) ||
+			 	group.isInheritContent())) {
 
 			return true;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/RequestBackedPortletURLFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/RequestBackedPortletURLFactoryUtil.java
@@ -136,7 +136,7 @@ public class RequestBackedPortletURLFactoryUtil {
 				WebKeys.THEME_DISPLAY);
 
 			if (group == null) {
-				group = themeDisplay.getScopeGroup();
+				group = themeDisplay.getSiteGroup();
 			}
 
 			LiferayPortletURL liferayPortletURL = PortletURLFactoryUtil.create(


### PR DESCRIPTION
Everything is fine except for the last commit. With it the layout scope stops working. Clicking the items in the Content section change the scope back to the site scope
