### PR TITLE
[TECHNICAL-SUPPORT] LPS-68731

### DIFF
--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 7748c72b42ea7ce466aa8e2b70536dfda7e85688
+	commit = ce1596c83c9dddc2b570499ccba9f55c1c8708ed
 	mode = push
-	parent = 91a5ea4407db7d96d3cb619f3de5927e353607f3
+	parent = ed7d8b6d802d9e505eab5fca540c4a9a40ea9b6a
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/bookmarks/.gitrepo
+++ b/modules/apps/collaboration/bookmarks/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 94e7f079658dcff1c1820ff73efd0f8477369114
+	commit = 6cd61f0d89778236108bcb249cf0b66aafbd658c
 	mode = push
-	parent = db4bdfbb5cba8ee94a7d6cdb8bc7b14b2fb5a1d8
+	parent = 2ab3c265701ac536fb1d0f52ee9a6aa0f2d91c25
 	remote = git@github.com:liferay/com-liferay-bookmarks.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 13aed6c6f0b821580b969a255aa3124c55daa972
+	commit = 2986d37119627d8cf36686c66ccbbc8f5beefe95
 	mode = push
-	parent = a7aca5e0125b1faa69552c0fcc4ff7b6e0bdd19d
+	parent = 967fe7a6fd7a017016c33daba0fa389d6a5765e7
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/flags/.gitrepo
+++ b/modules/apps/collaboration/flags/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 67e4b5b4e27690047b712ad12a45ee7a51fab7e8
+	commit = 1a10be331f84002acf186080f04f91a7c83e76df
 	mode = push
-	parent = f70f56e0612403a8e5605cfa63b3cc2cba6d2b12
+	parent = ad0c0a2a9ee1a48d2a6fc8d551ef8cf8fc30108d
 	remote = git@github.com:liferay/com-liferay-flags.git

--- a/modules/apps/collaboration/invitation/.gitrepo
+++ b/modules/apps/collaboration/invitation/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 6972cb1a7d0852199ee8f71dc1dc5f4e4e67b769
+	commit = 1b7fdba51e435599f03064031b61930075cd4a68
 	mode = push
-	parent = 1e9a1f2f819bff290f438482fe1776f30324bc3c
+	parent = 3beab59d572d6c5662ab8fc36a489dbbff8cc2af
 	remote = git@github.com:liferay/com-liferay-invitation.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3c5365d92ad06612c4a7d5d7ba299b181c09ec30
+	commit = 4c065f141b8be2627576cfad7f309834257185b6
 	mode = push
-	parent = 161526ee9773f726e0deed5f1866a6a6521c57f3
+	parent = 37cdda8b22814336d2ca23a01429bb8ae377abf1
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/microblogs/.gitrepo
+++ b/modules/apps/collaboration/microblogs/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 62fc267be668071ad22bcd4963ddba0e8cb019c7
+	commit = dedb633790bb073405ddf93599f5274347548fbc
 	mode = push
-	parent = cb9acedbdafe945c5ba54f46a5ef7e2b8e86319c
+	parent = f474f1e7a87a69e380b0df781e840bbb1a3a29c5
 	remote = git@github.com:liferay/com-liferay-microblogs.git

--- a/modules/apps/collaboration/notifications/.gitrepo
+++ b/modules/apps/collaboration/notifications/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 7a3699e8aea5012f4f4d973ceb68f5fc8e114b91
+	commit = 7fac4f96221695d3205b376918b327539e81a395
 	mode = push
-	parent = 49c357a9329fc4424295bfd968590dc68beabaa9
+	parent = 3d42a812e494f0856d58412b374bf9963aea8f7b
 	remote = git@github.com:liferay/com-liferay-notifications.git

--- a/modules/apps/collaboration/social/.gitrepo
+++ b/modules/apps/collaboration/social/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = f396d43493e7c9d4ad9be4d5050a8005ffc1d723
+	commit = f319ac94fadf234b486b73951957f3fb4356dfbc
 	mode = push
-	parent = 249d79c670439290ffbab54c7e74ff708a6e5697
+	parent = 3452f76eb9c50418e287ce4ba21840656d940496
 	remote = git@github.com:liferay/com-liferay-social.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = bc3606cc77e356bee3c9049b8640896bb0e734f3
+	commit = 7f745bbaeb83a1cb365271c49b1ced686eea05f6
 	mode = push
-	parent = 93afdf6838c831488a10d3b76eb039f8470ef26c
+	parent = ee739a3ef7a639946a41ff0c7bdc0df94e46d672
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 7253e56f543c21cc2a82dc0593eeb3a067925c26
+	commit = 1f8c0f852bdccecf7f6290625c0de6d05ffa95ec
 	mode = push
-	parent = fe0690fb719f86dc776d932e0988de59b329c9e7
+	parent = de3070c4f796623a5c3487536e1b71b62b4b59c2
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = ecebb51a03e37091c03d26d84eeded7afc2dde6c
+	commit = 49ccc2a73bf021999081576488e76f3bbce7cebf
 	mode = push
-	parent = 4c863832887f67ae47ac3c4a1b3e3d98d97aeec9
+	parent = 1a13c8d8a8bf9599d2f2bef5a613a6141e026088
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 9dcece553a4f6312824787e6e44ddad2dcf7e2ce
+	commit = 3dc384607571feb3b6453e2eb69b7c6135212856
 	mode = push
-	parent = fc5b91a2c9f5e0d6954612a3d15349d58a783211
+	parent = 82ea6c179faccddd753df287f1618a89fa5fd035
 	remote = git@github.com:liferay/com-liferay-dynamic-data-mapping.git

--- a/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
+++ b/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0a71db0b74b4c9d25da491c6779b3ea437d06186
+	commit = e4443a3ba60daed22c3ab0627c999024535a6765
 	mode = push
-	parent = 2571fcb548468ad540dbc43822ac962049f26fd4
+	parent = 95f94fb8553dc1ed979d39debc63634349b0b4e3
 	remote = git@github.com:liferay/com-liferay-portal-workflow.git

--- a/modules/apps/foundation/configuration-admin/.gitrepo
+++ b/modules/apps/foundation/configuration-admin/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 32f7bab684c3b7ccadfe70d31816de466115bc28
+	commit = 99ff1f7e34f5e413cf7510214d959c7e3c795aae
 	mode = push
-	parent = e2e38da47e12241c76ad394fbdf1dcb63b0e1ab8
+	parent = 795372285a659e1ab7213c2f50c2201922ea67e2
 	remote = git@github.com:liferay/com-liferay-configuration-admin.git

--- a/modules/apps/foundation/contacts/.gitrepo
+++ b/modules/apps/foundation/contacts/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 1ba9320949bd98795cc1e4a9ff1a9050c75d24fb
+	commit = bc7918d2ef2c73c2e9554471288314cb3eec2c37
 	mode = push
-	parent = abe362e21df77bfbf2c5ebd92e35295f3bd0fe7e
+	parent = 904d2ce8f63b42ef4437140f89dd84cf4ab823b8
 	remote = git@github.com:liferay/com-liferay-contacts.git

--- a/modules/apps/foundation/frontend-css/.gitrepo
+++ b/modules/apps/foundation/frontend-css/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3d164da85439c31ba04369b11c6733e9a421e542
+	commit = fd03735873a56c5515d591d9040656dcfa30a4db
 	mode = push
-	parent = 7c14f1dd3d99fe04cc304eb5b84373f1555fc1eb
+	parent = b102519cab2499d0754a0662169db718915126d5
 	remote = git@github.com:liferay/com-liferay-frontend-css.git

--- a/modules/apps/foundation/frontend-editor/.gitrepo
+++ b/modules/apps/foundation/frontend-editor/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 5306931c2a771fe126a47606b1a0c86ecb2e679f
+	commit = 12e7e2504160b1cda5e3d262f0a5f4373f2231cd
 	mode = push
-	parent = 4c98a856cd12660015ec7ee1ceb6410423ec7bb9
+	parent = 57850dd85d62974a2f6d3ce072e794151150b3a8
 	remote = git@github.com:liferay/com-liferay-frontend-editor.git

--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a515f9d8b6f3cfb6bc0b7ef1445530d1aa746a15
+	commit = 25f8a50921bd666b467e2a11aae6c0f0c29d051d
 	mode = push
-	parent = 561428324b13a66eb7b5d31cf2cdf2691c421f9f
+	parent = 5fb5dc04d145d188b890d9756cfc2419cb2b4010
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/foundation/frontend-taglib/.gitrepo
+++ b/modules/apps/foundation/frontend-taglib/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 43e2eec176b9957eab2d3b109798a73b1a172e6d
+	commit = 9225fc0e28b7d1c4f78352bc1164ce1000174ef4
 	mode = push
-	parent = 3839043942709feb75f5e725404dd40587846bd4
+	parent = 09b07b1046d60b7cbdbb8a8fcd7ffd48be998c24
 	remote = git@github.com:liferay/com-liferay-frontend-taglib.git

--- a/modules/apps/foundation/frontend-theme/.gitrepo
+++ b/modules/apps/foundation/frontend-theme/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a724732c3a73ec55c4ef96d6311dc6a201baef51
+	commit = e405d0b61c2431f48bb2d3c256ac736b61f39921
 	mode = push
-	parent = 0704c4b6ffb10a6381259337b62c99968e3b3ff6
+	parent = 239091b4dac53c930e3cd8b24665fd5d83335107
 	remote = git@github.com:liferay/com-liferay-frontend-theme.git

--- a/modules/apps/foundation/license-manager/.gitrepo
+++ b/modules/apps/foundation/license-manager/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = fda6a2e64dc946be004fdc37f263af6d88413ab0
+	commit = 08741212ff3df4a7cbbea440e978a8b6f761a0e5
 	mode = push
-	parent = 7488d6b7744363a9f210cc34b24ed101e6adb471
+	parent = fd0d5aaba127fbb9fedc5b71c10bc92c88b8b2da
 	remote = git@github.com:liferay/com-liferay-license-manager.git

--- a/modules/apps/foundation/petra/.gitrepo
+++ b/modules/apps/foundation/petra/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 527ae0640d2186e4b454087ed9b0c6d2f438aab9
+	commit = 30d458f2780706a9d8859e336b24db6652a3150a
 	mode = push
-	parent = f923d0b0880dc9234d8cff8dbff40e925c807f12
+	parent = 663f016100d789dab30b31b08141172f689b528e
 	remote = git@github.com:liferay/com-liferay-petra.git

--- a/modules/apps/foundation/portal-cache/.gitrepo
+++ b/modules/apps/foundation/portal-cache/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a52b440b0505b602aa914de146452f75b56d07a4
+	commit = faf020d1dc36ef250a247efcabd30dabd37e622a
 	mode = push
-	parent = 79527424777b2f0a6d77e0c5a8be5ad0067fc92d
+	parent = a4f7554b0fdce77fc0e8bd91bc51e3c6809f96ac
 	remote = git@github.com:liferay/com-liferay-portal-cache.git

--- a/modules/apps/foundation/portal-configuration/.gitrepo
+++ b/modules/apps/foundation/portal-configuration/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 2e498b579e84ba22b79dac2cf0f260c6e47f34e2
+	commit = 64ae86f60bee413d549177bb9647b21c362aeda0
 	mode = push
-	parent = 0c83955c51a69e33715c96436c1dfb32487cb654
+	parent = 284c20e28c09e4d756a39aba6c1d027e5e9054df
 	remote = git@github.com:liferay/com-liferay-portal-configuration.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 460f0de95de5a1291e90d8c743658205a14d3ff4
+	commit = 6eb2baa426729515e79b007f2eb0af0c6e72ed48
 	mode = push
-	parent = 94f272561f1796b4e2c3b3f54197a1dffd66e2ac
+	parent = ab42643cda36bcdfe3b820e2ba96727a058ffc19
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-security-sso/.gitrepo
+++ b/modules/apps/foundation/portal-security-sso/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = ba786ca7f2a5331deead0ec1718d8e575e56d1b2
+	commit = f9099c750befc7f6f0165a240f6ec02433374bb2
 	mode = push
-	parent = 60ffc85d248414601ec854b68ab62e6599280126
+	parent = 502d8616a17e1ee14428da3b5f589869a4673cf8
 	remote = git@github.com:liferay/com-liferay-portal-security-sso.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 21b2781be46256bb8b939b2400df52c9aeee68a0
+	commit = 2b7af6f1248a1fd2a8fd1d52ab527387dc1c808c
 	mode = push
-	parent = 311372d990fea8d5a5d13a11acd963b020e03931
+	parent = 51d3142ceb9b00948d7d9e719704f0684f91a5ea
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/foundation/portal-settings/.gitrepo
+++ b/modules/apps/foundation/portal-settings/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = c985b5fa1dc1bc5793420f315f036b69d63a6366
+	commit = f18092da4d87c57f72ab4dc075bad95116f74f22
 	mode = push
-	parent = d4ead1e712d2c362c281c8de70b6fb5201b66ec0
+	parent = 520beac90a43c7fadac9d49f89f38cd2926793ee
 	remote = git@github.com:liferay/com-liferay-portal-settings.git

--- a/modules/apps/foundation/portal-store/.gitrepo
+++ b/modules/apps/foundation/portal-store/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 9b1dcb577cdda3818b9b3f19f67491b112fc5efe
+	commit = 1acd47a97a72cb2f0ade5dcd07e438187fddd0dd
 	mode = push
-	parent = eb9225742ea9bd847e46ec8eee90ec0e8961f696
+	parent = bb500505724708bca1ae00f8a178053bdaee7f65
 	remote = git@github.com:liferay/com-liferay-portal-store.git

--- a/modules/apps/foundation/portal-template/.gitrepo
+++ b/modules/apps/foundation/portal-template/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = f0480b27dde64dbcf6a520738712ed970cfac1ee
+	commit = 3331ddf141cd4ece65f31ebf6c9485cc7ff542e4
 	mode = push
-	parent = 9cad2893e882350868e55396cde71a9a4bd30ffd
+	parent = 809e8baedcbee41d0ecc98b063c695a190ec354d
 	remote = git@github.com:liferay/com-liferay-portal-template.git

--- a/modules/apps/foundation/portal/.gitrepo
+++ b/modules/apps/foundation/portal/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a7214110a72a02c08d078e58f73d74f3299ec038
+	commit = da4eedafd63a4fe47441d8919c01ab8b5d99b159
 	mode = push
-	parent = 988e978f53370241efa7b7d7582566fb89b354f8
+	parent = 2c87ff284107c138907314f5a37b6ad1aca1bbcc
 	remote = git@github.com:liferay/com-liferay-portal.git

--- a/modules/apps/foundation/roles/.gitrepo
+++ b/modules/apps/foundation/roles/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 225822a45896ee8b7658317561b4233941a94964
+	commit = acbcd7ae314ad6928ef9a87dbae7eaf3c4fbaaf7
 	mode = push
-	parent = a269aaa24abca149a9281cdf010b8efcaef3813b
+	parent = 035deba55f0e5d2bfbebd13a5fdfbbb1cb48653c
 	remote = git@github.com:liferay/com-liferay-roles.git

--- a/modules/apps/foundation/server/.gitrepo
+++ b/modules/apps/foundation/server/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 064f75364f5edf3706a166af699301416c223e4d
+	commit = e64b6ba013b036816523ec970597c008f05cd2db
 	mode = push
-	parent = 288630cb4e35579c260d04d5ff7636d73d008f20
+	parent = ac5316402a127884beb43a98e7e4c3263e7c36ac
 	remote = git@github.com:liferay/com-liferay-server.git

--- a/modules/apps/screens/.gitrepo
+++ b/modules/apps/screens/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3cd63683adc0c3dba3061056ac0f5baf9d051ac0
+	commit = 208946eb98f307f5ece5577d9d213bcbc979ef06
 	mode = push
-	parent = dd20e09877f9945018b0f679f1fba81bd42f7cf6
+	parent = 9ec5cd0c260589383490e4031fafe39b1141848f
 	remote = git@github.com:liferay/com-liferay-screens.git

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a86d4ac3907c5ea87fd102df7baa8af284d4c12f
+	commit = 344155efa9fbe728627f3bfabc4083e7c9ff470a
 	mode = push
-	parent = e907033a10eb227d3fdcddfb81bf878bdd6357a1
+	parent = 5930936536371b49ce6ad8ae1e398f0c36cc7517
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 8d130504d294c81b76c7bd9adc13a1f2efeeb504
+	commit = cc1897c1f7625b6ca444e278cab985be4bb637db
 	mode = push
-	parent = 7a5a2a89b525e8acde5e1ab1f03d7066f1832fdc
+	parent = cd37b797d9c15397062b2f5285dd601463ad9bd1
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 4288d85b0851bbcbd9130c5b5e1a3b191bee8256
+	commit = 0afffc965f4f189572c7dc00dd26fc08705920c5
 	mode = push
-	parent = e51c5227e824a938c68b151398f6c662f4aab930
+	parent = ca72aa7ff430464df3f2c827a6d3d75a7431ef67
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 1a76c2ea39caebdea3a49c83434ecc4169720a2e
+	commit = cbfffe3a00940f5d4f0469b2085cf48f5017455c
 	mode = push
-	parent = 7cc6be2e72821f308994f5548ba2241d5c306f85
+	parent = d0266d210706a78405fd1c78052fcfdeb5e13ef5
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/layout/.gitrepo
+++ b/modules/apps/web-experience/layout/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 9926eae308ac0bb9dc3a8c567b1e8dc0542767e9
+	commit = 348bb87b7a8d0744703295dbe3081ef5931828a7
 	mode = push
-	parent = bd9c1029dc42029e327752b873fea4dfb158f68d
+	parent = ffa94ca22df77b9f1ec38501adeca49c7c009fce
 	remote = git@github.com:liferay/com-liferay-layout.git

--- a/modules/apps/web-experience/portlet-configuration/.gitrepo
+++ b/modules/apps/web-experience/portlet-configuration/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 59cdaf63eaa69978c9f5b8d1262cff976cd25185
+	commit = 53ec0c9586f242f246bcf361bc39c670ff68c7b3
 	mode = push
-	parent = 2e91604766996474c75453ed0ce5147fd7839862
+	parent = 6b7a0cdcbc9f11cacae0f3f59c728b652481090a
 	remote = git@github.com:liferay/com-liferay-portlet-configuration.git

--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -111,6 +111,9 @@ definePermissionsURL.setParameter("backURL", currentURL);
 definePermissionsURL.setPortletMode(PortletMode.VIEW);
 definePermissionsURL.setRefererPlid(plid);
 definePermissionsURL.setWindowState(LiferayWindowState.POP_UP);
+
+int cur = ParamUtil.getInteger(request, SearchContainer.DEFAULT_CUR_PARAM);
+int delta = ParamUtil.getInteger(request, SearchContainer.DEFAULT_DELTA_PARAM);
 %>
 
 <div class="edit-permissions portlet-configuration-edit-permissions">
@@ -125,6 +128,8 @@ definePermissionsURL.setWindowState(LiferayWindowState.POP_UP);
 		<portlet:param name="resourceGroupId" value="<%= String.valueOf(resourceGroupId) %>" />
 		<portlet:param name="resourcePrimKey" value="<%= resourcePrimKey %>" />
 		<portlet:param name="roleTypes" value="<%= roleTypesParam %>" />
+		<portlet:param name="cur" value="<%= String.valueOf(cur) %>" />
+		<portlet:param name="delta" value="<%= String.valueOf(delta) %>" />
 	</portlet:actionURL>
 
 	<aui:form action="<%= updateRolePermissionsURL.toString() %>" cssClass="form" method="post" name="fm">
@@ -263,10 +268,11 @@ definePermissionsURL.setWindowState(LiferayWindowState.POP_UP);
 				%>
 
 				<liferay-ui:search-container
+					iteratorURL="<%= currentURLObj %>"
 					total="<%= roles.size() %>"
 				>
 					<liferay-ui:search-container-results
-						results="<%= roles %>"
+						results="<%= roles.subList(searchContainer.getStart(), searchContainer.getResultEnd()) %>"
 					/>
 
 					<liferay-ui:search-container-row
@@ -370,7 +376,7 @@ definePermissionsURL.setWindowState(LiferayWindowState.POP_UP);
 
 					</liferay-ui:search-container-row>
 
-					<liferay-ui:search-iterator markupView="lexicon" paginate="<%= false %>" searchContainer="<%= searchContainer %>" />
+					<liferay-ui:search-iterator markupView="lexicon" searchContainer="<%= searchContainer %>" />
 				</liferay-ui:search-container>
 			</div>
 		</div>

--- a/modules/apps/web-experience/product-navigation/.gitrepo
+++ b/modules/apps/web-experience/product-navigation/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 91927b2c566ae3ccfd9b7062cfc70ecf2af9beaf
+	commit = e04d1370c31067981324aecb6f88c611389b67fc
 	mode = push
-	parent = 2a64884c5be31ba6581da2aa3fb203b05a116433
+	parent = ed1b980beb30fbd6bd5560a56bb1406818777b82
 	remote = git@github.com:liferay/com-liferay-product-navigation.git

--- a/modules/apps/web-experience/site/.gitrepo
+++ b/modules/apps/web-experience/site/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0ce469b8508b524caf3874909188a85c3107414d
+	commit = b6bb9d4377dbe86dfd5c351a8beb35468b80bd12
 	mode = push
-	parent = 392770957245a22d63986c4a6764b66ccfe71ef8
+	parent = ed8cf5d60a27aa0319f2a8d8dbbb4d969a2091e3
 	remote = git@github.com:liferay/com-liferay-site.git

--- a/modules/apps/web-experience/staging/.gitrepo
+++ b/modules/apps/web-experience/staging/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3efffbaf0302e89cec4c2eea2d67f8d4bf207db0
+	commit = cb75c3a0ebfcda095761892e278fe44d800dddf3
 	mode = push
-	parent = da67a0b3bfe32cb704ce3f0b2b07e4711da82d22
+	parent = 1b5d9e1580d1289fa8ff482294b4b7c1bad0cf0a
 	remote = git@github.com:liferay/com-liferay-staging.git


### PR DESCRIPTION
Hey @juliocamarero,

There is a performance and usability with the permission configuration window. Currently, it fetches all possible roles and displays them all at once. Depending on how many roles exist, browser can choke on displaying all of them and it also takes a long time to display and update the roles' permissions.

This fix is to simply add pagination to that window to allow users to view the roles more easier and reduce the load on the browser. Please let me know what you think, if you believe the fix should be taken in a different direction, or if someone else should review the pull.

Thanks!