### PR TITLE
LPS-69082 Control Menu Portlet Back Link should use Lexicon SVG icon

### DIFF
--- a/modules/apps/web-experience/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_back_link.jsp
+++ b/modules/apps/web-experience/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_back_link.jsp
@@ -20,6 +20,8 @@
 String portletBackURL = (String)request.getAttribute(ProductNavigationControlMenuWebKeys.PORTLET_BACK_URL);
 %>
 
-<div class="toolbar-group-content">
-	<a class="control-menu-icon" href="<%= HtmlUtil.escapeHREF(portletBackURL) %>"><span class="icon-angle-left icon-monospaced"></span></a>
-</div>
+<li class="control-menu-nav-item">
+	<a class="control-menu-icon" href="<%= HtmlUtil.escapeHREF(portletBackURL) %>">
+		<aui:icon cssClass="icon-monospaced" image="angle-left" markupView="lexicon" />
+	</a>
+</li>

--- a/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -280,7 +280,7 @@
 		height: 16px;
 		left: 0;
 		position: absolute;
-		top: 1px;
+		top: 0;
 
 		@include transition(all 0.6s $ease-out-quart);
 		@include transition-delay(0.2s);
@@ -293,6 +293,7 @@
 		height: 18px;
 		position: absolute;
 		right: 0;
+		top: -1px;
 
 		@include transition(all 0.3s $ease-out-quart);
 		@include transition-delay(0.2s);
@@ -306,11 +307,11 @@ body.open .toast-animation {
 		border-left-width: 6px;
 		height: 18px;
 		left: 4px;
-		top: 0;
+		top: -1px;
 	}
 
 	.cn {
-		border-left-width: 5px;
+		border-left-width: 9px;
 		width: 19px;
 	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
@@ -25,7 +25,7 @@
 </tr>
 <tr>
 	<td>ANGLE_LEFT_BACK</td>
-	<td>//div[contains(@class,'taglib-header')]//span[contains(.,'Back')]/a | //div[contains(@class,'toolbar-group-content')]//span[contains(@class,'icon-angle-left')]</td>
+	<td>//div[contains(@class,'taglib-header')]//span[contains(.,'Back')]/a | //*[name()='svg'][contains(@class,'icon-angle-left')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -35,7 +35,7 @@
 </tr>
 <tr>
 	<td>BACK</td>
-	<td>//a[contains(@class,'icon-circle-arrow-left') and contains(@class,'previous-level')] | //span[contains(@class,'icon-angle-left')]</td>
+	<td>//a[contains(@class,'icon-circle-arrow-left') and contains(@class,'previous-level')] | //*[name()='svg'][contains(@class,'icon-angle-left')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
@juliocamerero, sending this over from @pat270. He updated the back icons to use svg elements, and I've updated the poshi xpath locators for it as well.